### PR TITLE
Cookie fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ This is the classic Rails development setup, and should work for Mac and Linux u
 8. Edit your hosts file (typically found in `/etc/hosts` on Mac and Linux systems) and add the following line: `127.0.0.1 intercode`
 9. From the Intercode source folder:
   1. Copy the basic developer database configuration: `cp config/database.yml.dev config/database.yml`
-  2. Install all the dependencies of Intercode: 
+  2. Install all the dependencies of Intercode:
     1. Install MySQL and PostgreSQL. With Homebrew: `brew install mysql postgres `
     2. `bundle install`
   3. Set up your local database: `bin/rake db:create db:migrate`
   4. Start up the Intercode server: `bin/rails server`
-10. You should now be able to go to http://intercode:3000 and see the app running!
+10. You should now be able to go to http://intercode.dev:3000 and see the app running!
 
-**IMPORTANT NOTE:** Intercode 2 in development mode uses `intercode` as its cookie domain.  If you use `localhost` to visit the site, that will mysteriously fail.  I'm going to try to make the site detect the wrong domain and redirect you, but for now, please just use the `intercode` domain name.
+**IMPORTANT NOTE:** Intercode 2 in development mode uses `intercode.dev` as its cookie domain.  If you use `localhost` to visit the site, that will mysteriously fail.  I'm going to try to make the site detect the wrong domain and redirect you, but for now, please just use the `intercode.dev` domain name.
 
 # Contacting us
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  config.action_mailer.default_url_options = { :host => 'intercode:3000' }
+  config.action_mailer.default_url_options = { :host => 'intercode.dev:3000' }
 
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -11,7 +11,7 @@ if default_host
   # www.interconlarp.org becomes interconlarp.org
   second_level_domain = just_hostname.split(".").reverse.take(2).reverse.join(".")
 
-  cookie_options[:domain] = second_level_domain
+  cookie_options[:domain] = ".#{second_level_domain}"
 end
 
 Rails.application.config.session_store :active_record_store, cookie_options


### PR DESCRIPTION
Turns out newer browsers don't like cookies with a top-level domain, so we gotta switch the default dev domain to make con subdomains work.