### PR TITLE
Track submission time for proposals separately

### DIFF
--- a/app/controllers/admin_event_proposals_controller.rb
+++ b/app/controllers/admin_event_proposals_controller.rb
@@ -10,11 +10,12 @@ class AdminEventProposalsController < ApplicationController
 
   def index
     scope = @admin_event_proposals.where.not(status: 'draft').includes(:owner)
+    now = Time.now
     @admin_event_proposals = scope.sort_by do |event_proposal|
       [
         %w[proposed reviewing].include?(event_proposal.status) ? 0 : 1,
         event_proposal.status,
-        event_proposal.created_at
+        now - (event_proposal.submitted_at || 0)
       ]
     end
   end

--- a/app/graphql/mutations/submit_event_proposal.rb
+++ b/app/graphql/mutations/submit_event_proposal.rb
@@ -8,7 +8,7 @@ Mutations::SubmitEventProposal = GraphQL::Relay::Mutation.define do
     event_proposal = ctx[:convention].event_proposals.find(args[:id])
 
     if event_proposal.status == 'draft'
-      event_proposal.update!(status: 'proposed')
+      event_proposal.update!(status: 'proposed', submitted_at: Time.now)
       EventProposalsMailer.new_proposal(event_proposal).deliver_later
     end
 

--- a/app/views/admin_event_proposals/index.html.haml
+++ b/app/views/admin_event_proposals/index.html.haml
@@ -33,6 +33,6 @@
           %td
             %span{class: "badge #{event_proposal_badge_class(event_proposal)}"}= event_proposal.status
           %td.text-nowrap
-            %small= event_proposal.created_at.strftime('%Y-%m-%d %H:%M')
+            %small= event_proposal.submitted_at.strftime('%Y-%m-%d %H:%M')
           %td.text-nowrap
             %small= event_proposal.updated_at.strftime('%Y-%m-%d %H:%M')

--- a/db/migrate/20180304162934_add_submitted_at_to_event_proposals.rb
+++ b/db/migrate/20180304162934_add_submitted_at_to_event_proposals.rb
@@ -1,0 +1,9 @@
+class AddSubmittedAtToEventProposals < ActiveRecord::Migration[5.1]
+  def change
+    add_column :event_proposals, :submitted_at, :datetime
+
+    reversible do |dir|
+      dir.up { EventProposal.where.not(status: 'draft').update_all('submitted_at = created_at') }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180216202555) do
+ActiveRecord::Schema.define(version: 20180304162934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20180216202555) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "timeblock_preferences"
+    t.datetime "submitted_at"
     t.index ["convention_id"], name: "index_event_proposals_on_convention_id"
     t.index ["event_id"], name: "index_event_proposals_on_event_id"
     t.index ["owner_id"], name: "index_event_proposals_on_owner_id"


### PR DESCRIPTION
Closes #647.

Since we weren't tracking submission time before this, any proposals submitted before this deploys will be "submitted at" the time the user started drafting them.  Not ideal, but probably the least bad option (and, conveniently, won't change their "submission time" on the admin screen).