### PR TITLE
CMS preload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/nbudin/cadmus_files
-  revision: 990df4054c50e0f07339595a72b0fa79f82de650
+  revision: dcb282317beefde6a23aa218371a48d9164e5bec
   branch: cadmus_0_6
   specs:
     cadmus_files (0.2.0)
@@ -27,7 +27,7 @@ GIT
 
 GIT
   remote: https://github.com/nbudin/cadmus_navbar
-  revision: 93abd8ffa3821a95bec884c549300f0e4b61644d
+  revision: 266d7feda1972fb6a1bce1fca838e2d11a56aab6
   specs:
     cadmus_navbar (0.1.0)
       acts_as_list
@@ -94,7 +94,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    acts_as_list (0.9.10)
+    acts_as_list (0.9.11)
       activerecord (>= 3.0)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GIT
 
 GIT
   remote: https://github.com/nbudin/cadmus_navbar
-  revision: 266d7feda1972fb6a1bce1fca838e2d11a56aab6
+  revision: 1c8a8e66d90fd95bdfb0a367b57fbd3fc09ac1cc
   specs:
     cadmus_navbar (0.1.0)
       acts_as_list

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,6 +92,8 @@ class ApplicationController < ActionController::Base
   def liquid_registers
     liquid_assigns.merge(
       'controller' => self,
+      :cached_partials => @cached_partials,
+      :cached_files => @cached_files,
       :file_system => Cadmus::PartialFileSystem.new(convention)
     )
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -33,6 +33,8 @@ class PagesController < ApplicationController
   # Intercode's layout uses the @page_title instance variable for the <title> tag.
   before_action :set_page_title, only: :show
 
+  before_action :preload_cms_content, only: [:show, :root]
+
   # The actual root action implementation is exceedingly simple: since we've already loaded
   # @page in a before filter, we can just run the show action.  Sweet!
   def root
@@ -79,5 +81,13 @@ class PagesController < ApplicationController
 
   def page_params
     params.require(:page).permit(:name, :slug, :content, :admin_notes)
+  end
+
+  def preload_cms_content
+    @cached_partials ||= {}
+    @cached_partials.update(@page.cms_partials.index_by(&:name).transform_values(&:liquid_template))
+
+    @cached_files ||= {}
+    @cached_files.update(@page.cms_files.index_by(&:filename))
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,12 +15,12 @@ module ApplicationHelper
   def navigation_bar(navbar_classes = nil)
     navbar_classes ||= 'navbar-dark bg-intercode-blue'
 
-    root_item_scope = (convention&.cms_navigation_items&.root || CmsNavigationItem.none)
+    item_scope = (convention&.cms_navigation_items || CmsNavigationItem.global)
 
     renderer = CadmusNavbar::Renderers::Bootstrap4.new(
       request: request,
       url_for_page: ->(page) { page_url(page) },
-      root_items: root_item_scope.includes(:page, navigation_links: :page)
+      items_by_section_id: item_scope.includes(:page).group_by(&:navigation_section_id)
     )
 
     render partial: 'layouts/navigation_bar', locals: {

--- a/app/models/concerns/cms_references.rb
+++ b/app/models/concerns/cms_references.rb
@@ -9,7 +9,10 @@ module Concerns::CmsReferences
     liquid_block.nodelist.each do |node|
       yield node
 
-      each_node_in_liquid_block(node, &block) if node.is_a?(Liquid::Block)
+      case node
+      when Liquid::Block, Liquid::BlockBody
+        each_node_in_liquid_block(node, &block)
+      end
     end
   end
 

--- a/app/models/concerns/cms_references.rb
+++ b/app/models/concerns/cms_references.rb
@@ -52,8 +52,8 @@ module Concerns::CmsReferences
   end
 
   def referenced_files_recursive
-    CmsFile.where(name: (
-      referenced_file_names + referenced_partials_recursive.map(&:referenced_file_names)
+    CmsFile.where(file: (
+      referenced_file_names + referenced_partials_recursive.flat_map(&:referenced_file_names)
     ))
   end
 end

--- a/app/models/concerns/cms_references.rb
+++ b/app/models/concerns/cms_references.rb
@@ -29,9 +29,10 @@ module Concerns::CmsReferences
 
   def referenced_partials_direct(blacklist = [])
     names = referenced_partial_names - blacklist
+    return [] if names.none?
 
-    if parent
-      parent.cms_partials.where(name: names)
+    if parent_id && parent_type
+      CmsPartial.where(parent_id: parent_id, parent_type: parent_type, name: names)
     else
       CmsPartial.global.where(name: names)
     end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -4,6 +4,10 @@ class Page < ApplicationRecord
 
   cadmus_page
   belongs_to :cms_layout, optional: true
+  has_and_belongs_to_many :cms_files
+  has_and_belongs_to_many :cms_partials
+
+  before_commit :set_references, on: [:create, :update]
 
   def effective_cms_layout
     cms_layout || parent&.default_layout
@@ -15,5 +19,16 @@ class Page < ApplicationRecord
 
   def referenced_partials_recursive(blacklist = [])
     (super + effective_cms_layout.referenced_partials_recursive(blacklist)).uniq
+  end
+
+  def referenced_files_recursive
+    (super + effective_cms_layout.referenced_files_recursive).uniq
+  end
+
+  private
+
+  def set_references
+    self.cms_file_ids = referenced_files_recursive.map(&:id)
+    self.cms_partial_ids = referenced_partials_recursive.map(&:id)
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -18,11 +18,11 @@ class Page < ApplicationRecord
   end
 
   def referenced_partials_recursive(blacklist = [])
-    (super + effective_cms_layout.referenced_partials_recursive(blacklist)).uniq
+    (super + (effective_cms_layout&.referenced_partials_recursive(blacklist) || [])).uniq
   end
 
   def referenced_files_recursive
-    (super + effective_cms_layout.referenced_files_recursive).uniq
+    (super + (effective_cms_layout&.referenced_files_recursive || [])).uniq
   end
 
   private

--- a/db/migrate/20180403214703_create_cms_reference_join_tables.rb
+++ b/db/migrate/20180403214703_create_cms_reference_join_tables.rb
@@ -1,0 +1,12 @@
+class CreateCmsReferenceJoinTables < ActiveRecord::Migration[5.1]
+  def change
+    create_join_table :cms_files, :pages
+    create_join_table :cms_partials, :pages
+
+    Page.find_each do |page|
+      say "Calculating references for #{page.parent ? page.parent.name : 'global'} page #{page.slug}"
+      page.send(:set_references)
+      page.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180312150839) do
+ActiveRecord::Schema.define(version: 20180403214703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,11 @@ ActiveRecord::Schema.define(version: 20180312150839) do
     t.index ["parent_id", "file"], name: "index_cms_files_on_parent_id_and_file", unique: true
     t.index ["parent_id"], name: "index_cms_files_on_parent_id"
     t.index ["uploader_id"], name: "index_cms_files_on_uploader_id"
+  end
+
+  create_table "cms_files_pages", id: false, force: :cascade do |t|
+    t.bigint "cms_file_id", null: false
+    t.bigint "page_id", null: false
   end
 
   create_table "cms_layouts", force: :cascade do |t|
@@ -63,6 +68,11 @@ ActiveRecord::Schema.define(version: 20180312150839) do
     t.text "admin_notes"
     t.index ["parent_id", "parent_type", "name"], name: "index_cms_partials_on_parent_id_and_parent_type_and_name", unique: true
     t.index ["parent_id", "parent_type"], name: "index_cms_partials_on_parent_id_and_parent_type"
+  end
+
+  create_table "cms_partials_pages", id: false, force: :cascade do |t|
+    t.bigint "cms_partial_id", null: false
+    t.bigint "page_id", null: false
   end
 
   create_table "conventions", id: :serial, force: :cascade do |t|
@@ -477,12 +487,15 @@ ActiveRecord::Schema.define(version: 20180312150839) do
   add_foreign_key "runs", "events"
   add_foreign_key "runs", "users", column: "updated_by_id"
   add_foreign_key "signups", "runs"
+  add_foreign_key "signups", "user_con_profiles"
   add_foreign_key "signups", "users", column: "updated_by_id"
   add_foreign_key "staff_positions", "conventions"
   add_foreign_key "team_members", "events"
+  add_foreign_key "team_members", "user_con_profiles"
   add_foreign_key "ticket_types", "conventions"
   add_foreign_key "tickets", "events", column: "provided_by_event_id"
   add_foreign_key "tickets", "ticket_types"
+  add_foreign_key "tickets", "user_con_profiles"
   add_foreign_key "user_con_profiles", "conventions"
   add_foreign_key "user_con_profiles", "users"
 end


### PR DESCRIPTION
Improves performance in two of our worst-performing, and most public, actions (PagesController#root and PagesController#show), and also slightly improves performance across the board for any page that renders a navigation bar.  Specifically:

* Pre-process Liquid templates when saving a page to determine all the partials and files that page will pull in
* Save the results of that pre-processing in join tables
* Use that when rendering a page to load all the referenced objects in one shot as opposed to letting Liquid load them one-by-one on demand
* Do a single query for navigation bar items rather than two tiers of query (root and sub-items)