### PR TITLE
Movable signups in registration policy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,10 @@ Layout/AlignParameters:
   Enabled: true
   EnforcedStyle: with_fixed_indentation
 
+Layout/BlockAlignment:
+  Description: 'Align block ends correctly.'
+  Enabled: true
+
 Layout/BlockEndNewline:
   Description: 'Put end statement of multiline block on its own line.'
   Enabled: true
@@ -48,6 +52,17 @@ Layout/ClosingParenthesisIndentation:
 
 Layout/CommentIndentation:
   Description: 'Indentation of comments.'
+  Enabled: true
+
+Layout/ConditionPosition:
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
+  Enabled: true
+
+Layout/DefEndAlignment:
+  Description: 'Align ends corresponding to defs correctly.'
   Enabled: true
 
 Layout/DotPosition:
@@ -87,6 +102,11 @@ Layout/EmptyLinesAroundModuleBody:
 Layout/EmptyLinesAroundMethodBody:
   Description: "Keeps track of empty lines around method bodies."
   Enabled: true
+
+Lint/EndAlignment:
+  Description: 'Align ends correctly.'
+  Enabled: true
+  EnforcedStyleAlignWith: variable
 
 Layout/EndOfLine:
   Description: 'Use Unix-style line endings.'
@@ -286,27 +306,12 @@ Lint/AssignmentInCondition:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
   Enabled: true
 
-Lint/BlockAlignment:
-  Description: 'Align block ends correctly.'
-  Enabled: true
-
 Lint/CircularArgumentReference:
   Description: "Don't refer to the keyword argument in the default value."
   Enabled: true
 
-Lint/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#same-line-condition'
-  Enabled: true
-
 Lint/Debugger:
   Description: 'Check for debugger calls.'
-  Enabled: true
-
-Lint/DefEndAlignment:
-  Description: 'Align ends corresponding to defs correctly.'
   Enabled: true
 
 Lint/DeprecatedClassMethods:
@@ -332,11 +337,6 @@ Lint/EmptyEnsure:
 Lint/EmptyInterpolation:
   Description: 'Checks for empty string interpolation.'
   Enabled: true
-
-Lint/EndAlignment:
-  Description: 'Align ends correctly.'
-  Enabled: true
-  EnforcedStyleAlignWith: variable
 
 Lint/EndInMethod:
   Description: 'END blocks should not be placed inside method definitions.'
@@ -1105,8 +1105,13 @@ Style/TrailingCommaInArguments:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
   Enabled: true
 
-Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in literals.'
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  Description: 'Checks for trailing comma in hash literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: true
 

--- a/app/graphql/better_rescue_middleware.rb
+++ b/app/graphql/better_rescue_middleware.rb
@@ -22,7 +22,7 @@ class BetterRescueMiddleware
     yield
   rescue StandardError => err
     Rails.logger.error "#{err.class.name} processing GraphQL query: #{err.message}"
-    Rails.logger.error Rails.backtrace_cleaner.clean(err.backtrace).join("\n")
+    Rails.logger.error Rails.backtrace_cleaner.clean(err.backtrace).reverse.join("\n")
     Rollbar.error(err)
     attempt_rescue(err)
   end

--- a/app/graphql/mutations/update_signup_bucket.rb
+++ b/app/graphql/mutations/update_signup_bucket.rb
@@ -7,7 +7,7 @@ Mutations::UpdateSignupBucket = GraphQL::Relay::Mutation.define do
 
   resolve ->(_obj, args, ctx) do
     signup = ctx[:convention].signups.find(args[:id])
-    raise "The selected bucket is full." if signup.run.bucket_full?(args[:bucket_key]) && signup.counted?
+    raise 'The selected bucket is full.' if signup.run.bucket_full?(args[:bucket_key]) && signup.counted?
 
     original_bucket_key = signup.bucket_key
     signup.update!(bucket_key: args[:bucket_key])

--- a/app/graphql/types/run_type.rb
+++ b/app/graphql/types/run_type.rb
@@ -15,7 +15,7 @@ Types::RunType = GraphQL::ObjectType.define do
   end
 
   field :confirmed_signup_count, types.Int do
-    resolve ->(obj, _args, ctx) {
+    resolve ->(obj, _args, _ctx) {
       SignupCountLoader.for.load(obj).then do |presenter|
         presenter.counted_signups_by_state('confirmed').size
       end
@@ -23,13 +23,13 @@ Types::RunType = GraphQL::ObjectType.define do
   end
 
   field :confirmed_limited_signup_count, types.Int do
-    resolve ->(obj, _args, ctx) {
+    resolve ->(obj, _args, _ctx) {
       SignupCountLoader.for.load(obj).then(&:confirmed_limited_count)
     }
   end
 
   field :waitlisted_signup_count, types.Int do
-    resolve ->(obj, _args, ctx) {
+    resolve ->(obj, _args, _ctx) {
       SignupCountLoader.for.load(obj).then do |presenter|
         presenter.counted_signups_by_state('waitlisted').size
       end
@@ -37,7 +37,7 @@ Types::RunType = GraphQL::ObjectType.define do
   end
 
   field :not_counted_signup_count, types.Int do
-    resolve ->(obj, _args, ctx) {
+    resolve ->(obj, _args, _ctx) {
       SignupCountLoader.for.load(obj).then do |presenter|
         (
           presenter.not_counted_signups_by_state('confirmed').size +

--- a/app/models/event_proposal/timeblock_preference.rb
+++ b/app/models/event_proposal/timeblock_preference.rb
@@ -35,7 +35,7 @@ class EventProposal::TimeblockPreference
     return self == EventProposal::TimeblockPreference.new(other) if other.is_a?(Hash)
     return self == other.to_unsafe_h if other.is_a?(ActionController::Parameters)
     return false unless other.is_a?(EventProposal::TimeblockPreference)
-    
+
     attributes == other.attributes
   end
 

--- a/app/services/event_change_registration_policy_service.rb
+++ b/app/services/event_change_registration_policy_service.rb
@@ -5,7 +5,8 @@ class EventChangeRegistrationPolicyService < ApplicationService
   self.result_class = Result
 
   class SignupSimulator
-    attr_reader :registration_policy, :move_results_by_signup_id, :immovable_signups, :new_signups_by_signup_id
+    attr_reader :registration_policy, :move_results_by_signup_id, :immovable_signups,
+      :new_signups_by_signup_id
     attr_accessor :logger
 
     def initialize(registration_policy)
@@ -47,25 +48,32 @@ class EventChangeRegistrationPolicyService < ApplicationService
           log_immovable_signup(signup)
         end
       else
-        build_move_result(signup, destination_bucket) unless destination_bucket.key == signup.bucket_key
-        if destination_bucket && destination_bucket.full?(new_signups_by_signup_id.values)
-          move_signup(bucket_finder.no_preference_bucket_finder, destination_bucket)
-        end
-
-        new_signup = signup.dup
-        new_signup.assign_attributes(
-          bucket_key: destination_bucket.key,
-          state: 'confirmed',
-          counted: destination_bucket.counted?
-        )
-        new_signups_by_signup_id[signup.id] = new_signup
-        log_signup_placement(signup, destination_bucket)
+        place_signup signup, bucket_finder, destination_bucket
       end
 
       log_bucket_counts
     end
 
     private
+
+    def place_signup(signup, bucket_finder, destination_bucket)
+      unless destination_bucket.key == signup.bucket_key
+        build_move_result(signup, destination_bucket)
+      end
+
+      if destination_bucket && destination_bucket.full?(new_signups_by_signup_id.values)
+        move_signup(bucket_finder.no_preference_bucket_finder, destination_bucket)
+      end
+
+      new_signup = signup.dup
+      new_signup.assign_attributes(
+        bucket_key: destination_bucket.key,
+        state: 'confirmed',
+        counted: destination_bucket.counted?
+      )
+      new_signups_by_signup_id[signup.id] = new_signup
+      log_signup_placement(signup, destination_bucket)
+    end
 
     def build_move_result(signup, destination_bucket)
       move_results_by_signup_id[signup.id] = SignupMoveResult.new(
@@ -84,7 +92,8 @@ class EventChangeRegistrationPolicyService < ApplicationService
         .first
 
       build_move_result(movable_signup, destination_bucket)
-      puts "Moving signup for #{movable_signup.user_con_profile.name_without_nickname} to #{destination_bucket.key}"
+      log "Moving signup for #{movable_signup.user_con_profile.name_without_nickname} to \
+#{destination_bucket.key}"
 
       movable_signup.bucket_key = destination_bucket.key
       movable_signup
@@ -96,16 +105,19 @@ class EventChangeRegistrationPolicyService < ApplicationService
 
     def log_immovable_signup(signup)
       return unless logger
-      log "Signup for #{signup.user_con_profile.name_without_nickname} (#{signup.requested_bucket_key}) is immovable"
+      log "Signup for #{signup.user_con_profile.name_without_nickname} \
+(#{signup.requested_bucket_key}) is immovable"
     end
 
     def log_signup_placement(signup, destination_bucket)
       return unless logger
 
       if destination_bucket.key == signup.bucket_key
-        log "Signup for #{signup.user_con_profile.name_without_nickname} remains in #{destination_bucket.key}"
+        log "Signup for #{signup.user_con_profile.name_without_nickname} remains in \
+#{destination_bucket.key}"
       else
-        log "Signup for #{signup.user_con_profile.name_without_nickname} placed in #{destination_bucket.key} (was #{signup.bucket_key})"
+        log "Signup for #{signup.user_con_profile.name_without_nickname} placed in \
+#{destination_bucket.key} (was #{signup.bucket_key})"
       end
     end
 
@@ -113,43 +125,30 @@ class EventChangeRegistrationPolicyService < ApplicationService
       return unless logger
 
       bucket_counts = registration_policy.buckets.map do |bucket|
-        "#{bucket.key}: #{new_signups_by_signup_id.values.select { |signup| signup.bucket_key == bucket.key && signup.counted? }.size}/#{bucket.total_slots}"
+        signup_count = new_signups_by_signup_id.values.select do |signup|
+          signup.bucket_key == bucket.key && signup.counted?
+        end.size
+        "#{bucket.key}: #{signup_count}/#{bucket.total_slots}"
       end
       log "Counts: [#{bucket_counts.join(' | ')}]"
       log
     end
   end
 
-  attr_reader :event, :new_registration_policy, :whodunit
+  attr_reader :event, :new_registration_policy, :whodunit, :move_results
 
   def initialize(event, new_registration_policy, whodunit)
     @event = event
     @new_registration_policy = new_registration_policy
     @whodunit = whodunit
+    @move_results = []
   end
 
   private
 
   def inner_call
-    new_signups_by_signup_id = {}
-    move_results = []
-
     lock_all_runs do
-      immovable_signups = []
-
-      all_signups = Signup.where.not(state: 'withdrawn')
-        .joins(:run).includes(:user_con_profile).where(runs: { event_id: event.id }).to_a
-
-      signups_by_run_id = all_signups.group_by(&:run_id)
-        .transform_values { |signups| signups.sort_by(&:created_at) }
-
-      event.runs.each do |run|
-        simulator = SignupSimulator.new(new_registration_policy)
-        simulator.simulate_signups(signups_by_run_id[run.id] || [])
-
-        new_signups_by_signup_id.update(simulator.new_signups_by_signup_id)
-        immovable_signups.concat(simulator.immovable_signups)
-      end
+      immovable_signups, new_signups_by_signup_id = simulate_signups
 
       if immovable_signups.any?
         immovable_signups.each do |signup|
@@ -161,40 +160,77 @@ class EventChangeRegistrationPolicyService < ApplicationService
 
         return failure(errors)
       else
-        signups_by_id = all_signups.index_by(&:id)
-        new_signups_by_signup_id.each do |signup_id, new_signup|
-          signup = signups_by_id[signup_id]
-          next if new_signup.state == signup.state && new_signup.bucket_key == signup.bucket_key && new_signup.counted == signup.counted
-
-          if new_signup.state != signup.state || new_signup.bucket_key != signup.bucket_key
-            move_result = SignupMoveResult.new(
-              signup.id,
-              new_signup.state,
-              new_signup.bucket_key,
-              signup.state,
-              signup.bucket_key
-            )
-            move_results << move_result
-          end
-
-          # Do a direct SQL update, bypassing validations, since we haven't updated
-          # the registration policy yet
-          signup.update_columns(
-            state: new_signup.state,
-            bucket_key: new_signup.bucket_key,
-            counted: new_signup.counted
-          )
-
-          notify_moved_signup(move_result) if move_result&.should_notify?
-        end
+        apply_all_changes new_signups_by_signup_id
       end
 
-      @event.allow_registration_policy_change = true
-      @event.update!(registration_policy: new_registration_policy)
+      event.allow_registration_policy_change = true
+      event.update!(registration_policy: new_registration_policy)
     end
 
-    notify_team_members(move_results)
+    notify_move_results
     success(move_results: move_results)
+  end
+
+  def simulate_signups
+    immovable_signups = []
+    new_signups_by_signup_id = {}
+
+    event.runs.each do |run|
+      simulator = SignupSimulator.new(new_registration_policy)
+      simulator.simulate_signups(signups_by_run_id[run.id] || [])
+
+      new_signups_by_signup_id.update(simulator.new_signups_by_signup_id)
+      immovable_signups.concat(simulator.immovable_signups)
+    end
+
+    [immovable_signups, new_signups_by_signup_id]
+  end
+
+  def apply_all_changes(new_signups_by_signup_id)
+    signups_by_id = all_signups.index_by(&:id)
+    new_signups_by_signup_id.each do |signup_id, new_signup|
+      signup = signups_by_id[signup_id]
+      check_for_move signup, new_signup
+      apply_changes_for_signup signup, new_signup
+    end
+  end
+
+  def apply_changes_for_signup(signup, new_signup)
+    identical = (
+      new_signup.state == signup.state &&
+      new_signup.bucket_key == signup.bucket_key &&
+      new_signup.counted == signup.counted
+    )
+    return if identical
+
+    # Do a direct SQL update, bypassing validations, since we haven't updated
+    # the registration policy yet
+    signup.update_columns(
+      state: new_signup.state,
+      bucket_key: new_signup.bucket_key,
+      counted: new_signup.counted
+    )
+  end
+
+  def check_for_move(signup, new_signup)
+    return unless new_signup.state != signup.state || new_signup.bucket_key != signup.bucket_key
+
+    move_result = SignupMoveResult.new(
+      signup.id,
+      new_signup.state,
+      new_signup.bucket_key,
+      signup.state,
+      signup.bucket_key
+    )
+    move_results << move_result
+  end
+
+  def notify_move_results
+    move_results.each do |move_result|
+      notify_moved_signup(move_result) if move_result.should_notify?
+    end
+    
+    notify_team_members(move_results)
   end
 
   def notify_moved_signup(result)
@@ -212,6 +248,16 @@ class EventChangeRegistrationPolicyService < ApplicationService
         whodunit
       ).deliver_later
     end
+  end
+
+  def all_signups
+    @all_signups ||= Signup.where.not(state: 'withdrawn')
+      .joins(:run).includes(:user_con_profile).where(runs: { event_id: event.id }).to_a
+  end
+
+  def signups_by_run_id
+    @signups_by_run_id ||= all_signups.group_by(&:run_id)
+      .transform_values { |signups| signups.sort_by(&:created_at) }
   end
 
   def lock_all_runs(&block)

--- a/app/services/event_change_registration_policy_service.rb
+++ b/app/services/event_change_registration_policy_service.rb
@@ -187,7 +187,7 @@ class EventChangeRegistrationPolicyService < ApplicationService
             counted: new_signup.counted
           )
 
-          notify_moved_signup(move_result) if move_result.should_notify?
+          notify_moved_signup(move_result) if move_result&.should_notify?
         end
       end
 

--- a/app/services/event_change_registration_policy_service.rb
+++ b/app/services/event_change_registration_policy_service.rb
@@ -40,7 +40,6 @@ class EventChangeRegistrationPolicyService < ApplicationService
       ).find_bucket
 
       if !destination_bucket
-        binding.pry if signup.confirmed?
         if signup.confirmed?
           immovable_signups << signup
           puts "Signup for #{signup.user_con_profile.name_without_nickname} (#{signup.requested_bucket_key}) is immovable"

--- a/app/services/event_change_registration_policy_service.rb
+++ b/app/services/event_change_registration_policy_service.rb
@@ -4,6 +4,103 @@ class EventChangeRegistrationPolicyService < ApplicationService
   end
   self.result_class = Result
 
+  class SignupSimulator
+    attr_reader :registration_policy, :move_results_by_signup_id, :immovable_signups, :new_signups_by_signup_id
+
+    def initialize(registration_policy)
+      @registration_policy = registration_policy
+      @move_results_by_signup_id = {}
+      @immovable_signups = []
+      @new_signups_by_signup_id = {}
+    end
+
+    def success?
+      immovable_signups.empty?
+    end
+
+    def move_results
+      move_results_by_signup_id.values
+    end
+
+    def simulate_signups(signups)
+      signups.each { |signup| simulate_signup signup }
+    end
+
+    def simulate_signup(signup)
+      if signup.confirmed? && !signup.bucket_key
+        new_signups_by_signup_id[signup.id] = signup
+        return
+      end
+
+      destination_bucket = SignupBucketFinder.new(
+        registration_policy,
+        signup.requested_bucket_key,
+        new_signups_by_signup_id.values,
+        allow_movement: true
+      ).find_bucket
+
+      if !destination_bucket
+        binding.pry if signup.confirmed?
+        if signup.confirmed?
+          immovable_signups << signup
+          puts "Signup for #{signup.user_con_profile.name_without_nickname} (#{signup.requested_bucket_key}) is immovable"
+        end
+      else
+        build_move_result(signup, destination_bucket) unless destination_bucket.key == signup.bucket_key
+        move_signup(destination_bucket) if destination_bucket && destination_bucket.full?(new_signups_by_signup_id.values)
+
+        new_signup = signup.dup
+        new_signup.assign_attributes(
+          bucket_key: destination_bucket.key,
+          state: 'confirmed',
+          counted: destination_bucket.counted?
+        )
+        new_signups_by_signup_id[signup.id] = new_signup
+        if destination_bucket.key == signup.bucket_key
+          puts "Signup for #{signup.user_con_profile.name_without_nickname} remains in #{destination_bucket.key}"
+        else
+          puts "Signup for #{signup.user_con_profile.name_without_nickname} placed in #{destination_bucket.key} (was #{signup.bucket_key})"
+        end
+      end
+
+      bucket_counts = registration_policy.buckets.map do |bucket|
+        "#{bucket.key}: #{new_signups_by_signup_id.values.select { |signup| signup.bucket_key == bucket.key && signup.counted? }.size}/#{bucket.total_slots}"
+      end
+      puts "Counts: [#{bucket_counts.join(' | ')}]"
+      puts
+    end
+
+    private
+
+    def build_move_result(signup, destination_bucket)
+      move_results_by_signup_id[signup.id] = SignupMoveResult.new(
+        signup.id,
+        'confirmed',
+        destination_bucket.key,
+        signup.state,
+        signup.bucket_key
+      )
+    end
+
+    def move_signup(from_bucket)
+      bucket_finder = SignupBucketFinder.new(
+        registration_policy,
+        nil,
+        new_signups_by_signup_id.values,
+        allow_movement: true
+      )
+
+      movable_signup = bucket_finder.movable_signups_for_bucket(from_bucket).first
+      destination_bucket = bucket_finder.prioritized_buckets_with_capacity_except(from_bucket).first
+
+      build_move_result(movable_signup, destination_bucket)
+      puts "Moving signup for #{movable_signup.user_con_profile.name_without_nickname} to #{destination_bucket.key}"
+
+      movable_signup.bucket_key = destination_bucket.key
+      movable_signup
+    end
+  end
+
   attr_reader :event, :new_registration_policy, :whodunit
 
   def initialize(event, new_registration_policy, whodunit)
@@ -15,25 +112,24 @@ class EventChangeRegistrationPolicyService < ApplicationService
   private
 
   def inner_call
+    new_signups_by_signup_id = {}
     move_results = []
 
     lock_all_runs do
       immovable_signups = []
 
       all_signups = Signup.where.not(state: 'withdrawn')
-        .joins(:run).where(runs: { event_id: event.id }).to_a
+        .joins(:run).includes(:user_con_profile).where(runs: { event_id: event.id }).to_a
 
       signups_by_run_id = all_signups.group_by(&:run_id)
         .transform_values { |signups| signups.sort_by(&:created_at) }
 
       event.runs.each do |run|
-        run_signups = signups_by_run_id[run.id] || []
-        run_move_results, run_immovable_signups = apply_registration_policy_for_run_signups(
-          run_signups
-        )
+        simulator = SignupSimulator.new(new_registration_policy)
+        simulator.simulate_signups(signups_by_run_id[run.id] || [])
 
-        move_results.concat(run_move_results)
-        immovable_signups.concat(run_immovable_signups)
+        new_signups_by_signup_id.merge(simulator.new_signups_by_signup_id)
+        immovable_signups.concat(simulator.immovable_signups)
       end
 
       if immovable_signups.any?
@@ -46,10 +142,24 @@ class EventChangeRegistrationPolicyService < ApplicationService
 
         return failure(errors)
       else
-        move_results.each do |move_result|
-          Signup.where(id: move_result.signup_id).update_all(
-            bucket_key: move_result.bucket_key,
-            state: move_result.state
+        signups_by_id = all_signups.index_by(&:id)
+        new_signups_by_signup_id.each do |new_signup, signup_id|
+          signup = signups_by_id[signup_id]
+          next if new_signup.state == signup.state && new_signup.bucket_key == signup.bucket_key && new_signup.counted == signup.counted
+
+          move_result = SignupMoveResult.new(
+            signup.id,
+            new_signup.state,
+            new_signup.bucket_key,
+            signup.state,
+            signup.bucket_key
+          )
+          move_results << move_results
+
+          signup.update!(
+            state: new_signup.state,
+            bucket_key: new_signup.bucket_key,
+            counted: new_signup.counted
           )
 
           notify_moved_signup(move_result) if move_result.should_notify?
@@ -62,52 +172,6 @@ class EventChangeRegistrationPolicyService < ApplicationService
 
     notify_team_members(move_results)
     success(move_results: move_results)
-  end
-
-  def apply_registration_policy_for_run_signups(run_signups)
-    move_results = []
-    immovable_signups = []
-    new_signups = []
-
-    run_signups.each do |signup|
-      if signup.confirmed? && !signup.bucket_key
-        new_signups << signup
-        next
-      end
-
-      destination_bucket = SignupBucketFinder.new(
-        new_registration_policy,
-        signup.requested_bucket_key,
-        new_signups,
-        allow_movement: false
-      ).find_bucket
-
-      if !destination_bucket
-        immovable_signups << signup if signup.confirmed?
-      elsif destination_bucket.key == signup.bucket_key
-        new_signup = signup.dup
-        new_signup.assign_attributes(counted: destination_bucket.counted?)
-        new_signups << new_signup
-      else
-        move_results << SignupMoveResult.new(
-          signup.id,
-          'confirmed',
-          destination_bucket.key,
-          signup.state,
-          signup.bucket_key
-        )
-
-        new_signup = signup.dup
-        new_signup.assign_attributes(
-          bucket_key: destination_bucket.key,
-          state: 'confirmed',
-          counted: destination_bucket.counted?
-        )
-        new_signups << new_signup
-      end
-    end
-
-    [move_results, immovable_signups]
   end
 
   def notify_moved_signup(result)

--- a/app/services/event_signup_service.rb
+++ b/app/services/event_signup_service.rb
@@ -196,11 +196,11 @@ sign up for events."
     movable_signup_bucket_finder = SignupBucketFinder.new(
       run.registration_policy,
       nil,
-      new_signups,
+      bucket_finder.other_signups,
       allow_movement: true
     )
 
-    destination_bucket = movable_signup_bucket_finder.prioritized_buckets_with_capacity_except(from_bucket).first
+    destination_bucket = movable_signup_bucket_finder.prioritized_buckets_with_capacity_except(actual_bucket).first
 
     movable_signup.update!(bucket_key: destination_bucket.key)
     movable_signup

--- a/app/services/event_signup_service.rb
+++ b/app/services/event_signup_service.rb
@@ -193,10 +193,14 @@ sign up for events."
 
   def move_signup
     movable_signup = bucket_finder.movable_signups_for_bucket(actual_bucket).first
+    movable_signup_bucket_finder = SignupBucketFinder.new(
+      registration_policy,
+      nil,
+      new_signups,
+      allow_movement: false
+    )
 
-    destination_bucket = bucket_finder.buckets_with_capacity.sort_by do |bucket|
-      bucket.anything? ? 0 : 1
-    end.first
+    destination_bucket = movable_signup_bucket_finder.prioritized_buckets_with_capacity_except(from_bucket).first
 
     movable_signup.update!(bucket_key: destination_bucket.key)
     movable_signup

--- a/app/services/event_signup_service.rb
+++ b/app/services/event_signup_service.rb
@@ -193,14 +193,11 @@ sign up for events."
 
   def move_signup
     movable_signup = bucket_finder.movable_signups_for_bucket(actual_bucket).first
-    movable_signup_bucket_finder = SignupBucketFinder.new(
-      run.registration_policy,
-      nil,
-      bucket_finder.other_signups,
-      allow_movement: true
-    )
 
-    destination_bucket = movable_signup_bucket_finder.prioritized_buckets_with_capacity_except(actual_bucket).first
+    destination_bucket = bucket_finder
+      .no_preference_bucket_finder
+      .prioritized_buckets_with_capacity_except(actual_bucket)
+      .first
 
     movable_signup.update!(bucket_key: destination_bucket.key)
     movable_signup

--- a/app/services/event_signup_service.rb
+++ b/app/services/event_signup_service.rb
@@ -194,10 +194,10 @@ sign up for events."
   def move_signup
     movable_signup = bucket_finder.movable_signups_for_bucket(actual_bucket).first
     movable_signup_bucket_finder = SignupBucketFinder.new(
-      registration_policy,
+      run.registration_policy,
       nil,
       new_signups,
-      allow_movement: false
+      allow_movement: true
     )
 
     destination_bucket = movable_signup_bucket_finder.prioritized_buckets_with_capacity_except(from_bucket).first

--- a/app/services/signup_bucket_finder.rb
+++ b/app/services/signup_bucket_finder.rb
@@ -13,15 +13,13 @@ class SignupBucketFinder
     @actual_bucket ||= begin
       # try not to bump people out of their signup buckets...
       prioritized_buckets_with_capacity.first ||
-      # but do it if you have to
-      prioritized_buckets.find { |bucket| movable_signups_for_bucket(bucket).any? }
+        # but do it if you have to
+        prioritized_buckets.find { |bucket| movable_signups_for_bucket(bucket).any? }
     end
   end
 
   def movable_signups_for_bucket(bucket)
     return [] unless allow_movement
-
-    no_preference_bucket_finder = SignupBucketFinder.new(registration_policy, nil, other_signups, allow_movement: true)
     return [] unless no_preference_bucket_finder.prioritized_buckets_with_capacity.any?
 
     other_signups.select do |signup|

--- a/app/services/signup_bucket_finder.rb
+++ b/app/services/signup_bucket_finder.rb
@@ -10,8 +10,11 @@ class SignupBucketFinder
   end
 
   def find_bucket
-    @actual_bucket ||= prioritized_buckets.find do |bucket|
-      !bucket.full?(other_signups) || movable_signups_for_bucket(bucket).any?
+    @actual_bucket ||= begin
+      # try not to bump people out of their signup buckets...
+      prioritized_buckets_with_capacity.first ||
+      # but do it if you have to
+      prioritized_buckets.find { |bucket| movable_signups_for_bucket(bucket).any? }
     end
   end
 

--- a/app/services/signup_bucket_finder.rb
+++ b/app/services/signup_bucket_finder.rb
@@ -49,4 +49,13 @@ class SignupBucketFinder
     bucket_keys = buckets.map(&:key)
     prioritized_buckets_with_capacity.reject { |bucket| bucket_keys.include?(bucket.key) }
   end
+
+  def no_preference_bucket_finder
+    SignupBucketFinder.new(
+      registration_policy,
+      nil,
+      other_signups,
+      allow_movement: allow_movement
+    )
+  end
 end

--- a/app/services/signup_bucket_finder.rb
+++ b/app/services/signup_bucket_finder.rb
@@ -36,13 +36,17 @@ class SignupBucketFinder
           (requested_bucket&.not_counted? ? nil : registration_policy.anything_bucket)
         ].compact
       else
-        registration_policy.buckets.select(&:counted?).select(&:slots_limited?).sort_by { |bucket| bucket.anything? ? 0 : 1 }
+        registration_policy.buckets.select(&:counted?).select(&:slots_limited?).sort_by do |bucket|
+          bucket.anything? ? 0 : 1
+        end
       end
     end
   end
 
   def prioritized_buckets_with_capacity
-    @prioritized_buckets_with_capacity ||= prioritized_buckets.reject { |bucket| bucket.full?(other_signups) }
+    @prioritized_buckets_with_capacity ||= prioritized_buckets.reject do |bucket|
+      bucket.full?(other_signups)
+    end
   end
 
   def prioritized_buckets_with_capacity_except(*buckets)

--- a/test/services/event_signup_service_test.rb
+++ b/test/services/event_signup_service_test.rb
@@ -420,7 +420,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase
       end
 
       describe 'when there are signups without a requested bucket' do
-        it 'moves them into the flex bucket if possible' do
+        it 'does not move them if you could go into flex' do
           # we'll assume there used to be 4 in the flex bucket, but one dropped
           3.times { create_other_signup 'anything' }
           immovable_signup = create_other_signup 'cats'
@@ -430,10 +430,10 @@ class EventSignupServiceTest < ActiveSupport::TestCase
           result.must_be :success?
           result.signup.must_be :confirmed?
           result.signup.requested_bucket_key.must_equal 'cats'
-          result.signup.bucket_key.must_equal 'cats'
+          result.signup.bucket_key.must_equal 'anything'
 
           movable_signup.reload
-          movable_signup.bucket_key.must_equal 'anything'
+          movable_signup.bucket_key.must_equal 'cats'
           movable_signup.requested_bucket_key.must_be_nil
         end
 


### PR DESCRIPTION
This is the end result of a whole bunch of issues exposed during round 2 of NELCO 2018 signups.  These changes fix the following problems:

* EventChangeRegistrationPolicyService wasn't actually setting the `counted` flag on signups when the counted status of buckets changed
* EventChangeRegistrationPolicyService wasn't simulating moves for no-preference signups in the way that EventSignupService would have moved them
* SignupBucketFinder was prioritizing moving no-preference signups when it could have placed a preference signup in the flex bucket instead