### PR TITLE
NEIL Hosting beta launch

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
   def app_component_props
     {
       authenticityToken: graphql_authenticity_token,
-      stripePublishableKey: Rails.configuration.stripe[:publishable_key]
+      stripePublishableKey: convention&.stripe_publishable_key
     }
   end
   helper_method :app_component_props

--- a/app/graphql/mutations/cancel_order.rb
+++ b/app/graphql/mutations/cancel_order.rb
@@ -10,12 +10,12 @@ Mutations::CancelOrder = GraphQL::Relay::Mutation.define do
 
     refund = nil
     if order.charge_id
-      charge = Stripe::Charge.retrieve(order.charge_id)
+      charge = Stripe::Charge.retrieve(order.charge_id, api_key: ctx[:convention].stripe_secret_key)
 
       if charge.refunded
         refund = charge.refunds.first
       else
-        refund = Stripe::Refund.create(charge: order.charge_id)
+        refund = Stripe::Refund.create({ charge: order.charge_id }, api_key: ctx[:convention].stripe_secret_key)
       end
     end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -355,7 +355,8 @@ class Ability
     }
     can token_scope_action(:manage_conventions), TeamMember, event: { convention_id: con_ids_with_privilege(:gm_liaison, :con_com) }
 
-    can :read, User if staff_con_ids.any?
+    # TODO: Re-enable this once Organizations exist
+    # can :read, User if staff_con_ids.any?
 
     can :read_admin_notes, Event,
       convention_id: con_ids_with_privilege(:gm_liaison, :scheduling)

--- a/app/services/delete_ticket_service.rb
+++ b/app/services/delete_ticket_service.rb
@@ -18,11 +18,11 @@ class DeleteTicketService < CivilService::Service
 
     if refund
       raise 'Ticket cannot be refunded because there is no Stripe charge ID' unless ticket.charge_id
-      charge = Stripe::Charge.retrieve(ticket.charge_id)
+      charge = Stripe::Charge.retrieve(ticket.charge_id, api_key: convention.stripe_secret_key)
       if charge.refunded
         refund_status = :already_refunded
       else
-        Stripe::Refund.create(charge: ticket.charge_id)
+        Stripe::Refund.create({ charge: ticket.charge_id }, api_key: convention.stripe_secret_key)
         refund_status = :refunded
       end
     end
@@ -30,5 +30,9 @@ class DeleteTicketService < CivilService::Service
     ticket.destroy!
 
     success(refund_status: refund_status)
+  end
+
+  def convention
+    @convention ||= ticket.convention
   end
 end

--- a/app/services/pay_order_service.rb
+++ b/app/services/pay_order_service.rb
@@ -30,15 +30,21 @@ class PayOrderService < CivilService::Service
 
   def create_charge
     customer = Stripe::Customer.create(
-      email: order.user_con_profile.email,
-      source: stripe_token
+      {
+        email: order.user_con_profile.email,
+        source: stripe_token
+      },
+      api_key: convention.stripe_secret_key
     )
 
     Stripe::Charge.create(
-      customer: customer.id,
-      amount: order.total_price.fractional,
-      description: "#{description} for #{convention.name}",
-      currency: order.total_price.currency.iso_code.downcase
+      {
+        customer: customer.id,
+        amount: order.total_price.fractional,
+        description: "#{description} for #{convention.name}",
+        currency: order.total_price.currency.iso_code.downcase
+      },
+      api_key: convention.stripe_secret_key
     )
   end
 

--- a/app/services/purchase_ticket_service.rb
+++ b/app/services/purchase_ticket_service.rb
@@ -39,15 +39,21 @@ class PurchaseTicketService < CivilService::Service
 
   def create_charge
     customer = Stripe::Customer.create(
-      email: user_con_profile.email,
-      source: stripe_token
+      {
+        email: user_con_profile.email,
+        source: stripe_token
+      },
+      api_key: convention.stripe_secret_key
     )
 
     Stripe::Charge.create(
-      customer: customer.id,
-      amount: current_price.fractional,
-      description: "#{ticket_type.description} for #{convention.name}",
-      currency: current_price.currency.iso_code.downcase
+      {
+        customer: customer.id,
+        amount: current_price.fractional,
+        description: "#{ticket_type.description} for #{convention.name}",
+        currency: current_price.currency.iso_code.downcase
+      },
+      api_key: convention.stripe_secret_key
     )
   end
 

--- a/bin/load_production_database
+++ b/bin/load_production_database
@@ -13,6 +13,9 @@ pg_restore -h postgres -U postgres -w -v --no-owner -j4 -d intercode_production_
 echo 'Changing convention domains and names for development'
 echo "UPDATE conventions SET domain = regexp_replace(lower(name), '[^a-z0-9]', '', 'g') || '.intercode.test', name = name || ' [dev]';" | psql -h postgres -U postgres -w intercode_production_tmp
 
+echo 'Changing Stripe keys for development'
+echo "UPDATE conventions SET stripe_publishable_key = 'pk_test_uD3hl7sRFOjcbdSG6KaH9olQ', stripe_secret_key = 'sk_test_VRD1WlpRoaPdwhmzRTIoqRrr';" | psql -h postgres -U postgres -w intercode_production_tmp
+
 echo 'Dropping intercode_development database'
 dropdb --if-exists -h postgres -U postgres -w intercode_development
 

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,6 +1,0 @@
-Rails.configuration.stripe = {
-  publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'] || 'pk_test_uD3hl7sRFOjcbdSG6KaH9olQ',
-  secret_key: ENV['STRIPE_SECRET_KEY'] || 'sk_test_VRD1WlpRoaPdwhmzRTIoqRrr'
-}
-
-Stripe.api_key = Rails.configuration.stripe[:secret_key]

--- a/db/migrate/20190126155504_add_stripe_keys_to_conventions.rb
+++ b/db/migrate/20190126155504_add_stripe_keys_to_conventions.rb
@@ -1,0 +1,14 @@
+class AddStripeKeysToConventions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :conventions, :stripe_publishable_key, :text
+    add_column :conventions, :stripe_secret_key, :text
+
+    reversible do |dir|
+      dir.up do
+        quoted_publishable_key = ActiveRecord::Base.connection.quote(Rails.configuration.stripe[:publishable_key])
+        quoted_secret_key = ActiveRecord::Base.connection.quote(Rails.configuration.stripe[:secret_key])
+        execute "UPDATE conventions SET stripe_publishable_key = #{quoted_publishable_key}, stripe_secret_key = #{quoted_secret_key};"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_16_034950) do
+ActiveRecord::Schema.define(version: 2019_01_26_155504) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,6 +138,8 @@ ActiveRecord::Schema.define(version: 2019_01_16_034950) do
     t.bigint "user_con_profile_form_id"
     t.string "ticket_name", default: "ticket", null: false
     t.text "event_mailing_list_domain"
+    t.text "stripe_publishable_key"
+    t.text "stripe_secret_key"
     t.index ["default_layout_id"], name: "index_conventions_on_default_layout_id"
     t.index ["domain"], name: "index_conventions_on_domain", unique: true
     t.index ["updated_by_id"], name: "index_conventions_on_updated_by_id"


### PR DESCRIPTION
This PR contains two features:

* Temporarily disabling viewing arbitrary users for everyone except site admins (closes #1798).  This functionality will be partially restored when #1619 is implemented.
* Making Stripe configuration a per-convention setting, so that organizations besides NEIL can get paid for convention tickets and product sales (closes #1797).