### PR TITLE
Wildcard certs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,9 +86,7 @@ gem 'skylight'
 gem 'icalendar'
 gem 'dalli'
 gem 'browser'
-
-# Heroku prod fix
-gem 'rails_12factor', group: 'stage'
+gem 'platform-api'
 
 gem 'faker', group: 'development', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
       dotenv (= 2.7.2)
       railties (>= 3.2, < 6.1)
     erubi (1.8.0)
+    erubis (2.7.0)
     eu_central_bank (1.4.2)
       money (~> 6.13)
       nokogiri (~> 1.8)
@@ -206,6 +207,11 @@ GEM
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
+    heroics (0.0.25)
+      erubis (~> 2.0)
+      excon
+      moneta
+      multi_json (>= 1.9.2)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.6.0)
@@ -264,6 +270,7 @@ GEM
     minitest-spec-rails (5.5.0)
       minitest (~> 5.0)
       rails (>= 4.1)
+    moneta (1.0.0)
     monetize (1.9.1)
       money (~> 6.12)
     money (6.13.3)
@@ -290,6 +297,9 @@ GEM
     orm_adapter (0.5.0)
     parallel (1.17.0)
     pg (1.1.4)
+    platform-api (2.2.0)
+      heroics (~> 0.0.25)
+      moneta (~> 1.0.0)
     promise.rb (0.7.4)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -335,11 +345,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.2.3)
       actionpack (= 5.2.3)
       activesupport (= 5.2.3)
@@ -493,13 +498,13 @@ DEPENDENCIES
   oj (~> 3.7.12)
   parallel
   pg
+  platform-api
   pry-rails
   pry-remote
   puma
   rack-mini-profiler
   rails (= 5.2.3)
   rails-controller-testing
-  rails_12factor
   recaptcha
   redcarpet
   reverse_markdown

--- a/app/services/refresh_ssl_certificate_service.rb
+++ b/app/services/refresh_ssl_certificate_service.rb
@@ -1,0 +1,56 @@
+require 'English'
+
+class RefreshSSLCertificateService < CivilService::Service
+  attr_reader :heroku_api_token, :heroku_app_name, :no_wildcard_domains, :skip_domains, :staging
+
+  def initialize(
+    heroku_api_token:,
+    heroku_app_name:,
+    no_wildcard_domains: [],
+    skip_domains: [],
+    staging: false
+  )
+    @heroku_api_token = heroku_api_token
+    @heroku_app_name = heroku_app_name
+    @no_wildcard_domains = no_wildcard_domains
+    @skip_domains = skip_domains
+    @staging = staging
+  end
+
+  private
+
+  def inner_call
+    Rails.logger.info 'Connecting to Heroku Platform API'
+    heroku = PlatformAPI.connect_oauth(heroku_api_token)
+
+    Rails.logger.info 'Getting app domains'
+    all_domains = heroku.domain.list(heroku_app_name).map { |domain| domain['hostname'] }
+    ssl_domains = ['neilhosting.net'] + all_domains.map do |domain|
+      ssl_domain(domain)
+    end.compact.uniq
+    domain_args = ssl_domains.map do |domain|
+      "-d #{Shellwords.escape domain}"
+    end
+
+    Rails.logger.info 'Installing acme.sh'
+    sh 'curl https://get.acme.sh | sh'
+
+    Rails.logger.info 'Requesting certificates'
+    sh "~/.acme.sh/acme.sh #{staging ? '--staging ' : ''}\
+--issue --challenge-alias neilhosting.net --dns dns_aws \
+#{domain_args.join(' ')}"
+  end
+
+  def ssl_domain(host)
+    return nil if host =~ /herokuapp\.com\z/
+    return nil if skip_domains.include?(host)
+    return host if no_wildcard_domains.include?(host)
+    parts = host.split('.').reverse
+    [*parts.take([2, parts.size - 1].max), '*'].reverse.join('.')
+  end
+
+  def sh(cmd)
+    result = system("bash -c #{Shellwords.escape(cmd)}")
+    raise "Command exited with status #{$CHILD_STATUS}" unless result
+  end
+end

--- a/app/services/refresh_ssl_certificate_service.rb
+++ b/app/services/refresh_ssl_certificate_service.rb
@@ -71,7 +71,7 @@ class RefreshSSLCertificateService < CivilService::Service
     else
       sni_endpoints.each do |endpoint|
         Rails.logger.info("Deleting unusable SNI endpoint #{endpoint['name']}")
-        heroku.sni_endpoint.delete(heroku_app_name, existing_endpoint['id'])
+        heroku.sni_endpoint.delete(heroku_app_name, endpoint['id'])
       end
       Rails.logger.info("Creating SNI endpoint")
       new_endpoint = heroku.sni_endpoint.create(heroku_app_name, body)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.default_url_options = {
-    host: ENV['INTERCODE_HOST'] || '2.interconlarp.org'
+    host: ENV['INTERCODE_HOST'] || 'neilhosting.net'
   }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.

--- a/lib/tasks/refresh_certs.rake
+++ b/lib/tasks/refresh_certs.rake
@@ -1,7 +1,8 @@
 desc 'Refresh app TLS certificates'
 task refresh_certs: :environment do
   RefreshSSLCertificateService.new(
-    heroku_api_key: ENV['HEROKU_API_KEY'],
-    heroku_app_name: ENV['HEROKU_APP_NAME']
+    heroku_api_token: ENV['HEROKU_API_TOKEN'],
+    heroku_app_name: ENV['HEROKU_APP_NAME'],
+    root_domain: ENV['INTERCODE_HOST']
   ).call!
 end

--- a/lib/tasks/refresh_certs.rake
+++ b/lib/tasks/refresh_certs.rake
@@ -1,5 +1,6 @@
 desc 'Refresh app TLS certificates'
 task refresh_certs: :environment do
+  Rails.logger = Logger.new(STDERR)
   RefreshSSLCertificateService.new(
     heroku_api_token: ENV['HEROKU_API_TOKEN'],
     heroku_app_name: ENV['HEROKU_APP_NAME'],

--- a/lib/tasks/refresh_certs.rake
+++ b/lib/tasks/refresh_certs.rake
@@ -4,6 +4,11 @@ task refresh_certs: :environment do
   RefreshSSLCertificateService.new(
     heroku_api_token: ENV['HEROKU_API_TOKEN'],
     heroku_app_name: ENV['HEROKU_APP_NAME'],
-    root_domain: ENV['INTERCODE_HOST']
+    root_domain: ENV['INTERCODE_HOST'],
+    **{
+      no_wildcard_domains: ENV['INTERCODE_CERTS_NO_WILDCARD_DOMAINS']&.split(' '),
+      skip_domains: ENV['INTERCODE_CERTS_SKIP_DOMAINS']&.split(' '),
+      staging: ENV['INTERCODE_CERTS_STAGING']
+    }.compact
   ).call!
 end

--- a/lib/tasks/refresh_certs.rake
+++ b/lib/tasks/refresh_certs.rake
@@ -1,0 +1,7 @@
+desc 'Refresh app TLS certificates'
+task refresh_certs: :environment do
+  RefreshSSLCertificateService.new(
+    heroku_api_key: ENV['HEROKU_API_KEY'],
+    heroku_app_name: ENV['HEROKU_APP_NAME']
+  ).call!
+end


### PR DESCRIPTION
This branch introduces a new service object and corresponding Rake task that can be used to automatically request and install TLS certificates.  It accomplishes that using the Heroku platform API (for introspecting the app's domains and installing certificates) and acme.sh (for doing the certificate request).