### PR TITLE
Permissions checks on event editing pages

### DIFF
--- a/app/javascript/EventAdmin/index.jsx
+++ b/app/javascript/EventAdmin/index.jsx
@@ -46,6 +46,10 @@ function EventAdmin({ location }) {
     return <ErrorDisplay graphQLError={error} />;
   }
 
+  if (!data.currentAbility.can_manage_runs) {
+    return <Redirect to="/" />;
+  }
+
   if (data.convention.site_mode === 'single_event') {
     if (data.events.length === 0) {
       return (

--- a/app/javascript/EventAdmin/queries.gql
+++ b/app/javascript/EventAdmin/queries.gql
@@ -124,6 +124,7 @@ fragment EventPageEventCategoryFields on EventCategory {
 query EventAdminEventsQuery {
   currentAbility {
     can_override_maximum_event_provided_tickets
+    can_manage_runs
   }
 
   convention {

--- a/app/javascript/EventsApp/StandaloneEditEvent/index.jsx
+++ b/app/javascript/EventsApp/StandaloneEditEvent/index.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Redirect } from 'react-router-dom';
 import { useApolloClient, useMutation } from 'react-apollo-hooks';
 
 import deserializeEvent from '../../EventAdmin/deserializeEvent';
@@ -13,13 +13,13 @@ import {
   StandaloneDeleteMaximumEventProvidedTicketsOverride,
   StandaloneUpdateMaximumEventProvidedTicketsOverride,
 } from './mutations.gql';
-import useQuerySuspended from '../../useQuerySuspended';
 import useEventForm, { EventForm } from '../../EventAdmin/useEventForm';
 import useMEPTOMutations from '../../BuiltInFormControls/useMEPTOMutations';
 import EditEvent from '../../BuiltInForms/EditEvent';
 import MaximumEventProvidedTicketsOverrideEditor from '../../BuiltInFormControls/MaximumEventProvidedTicketsOverrideEditor';
 import usePageTitle from '../../usePageTitle';
 import useValueUnless from '../../useValueUnless';
+import useQuerySuspended from '../../useQuerySuspended';
 
 function StandaloneEditEvent({ eventId, eventPath, history }) {
   const queryOptions = { variables: { eventId } };
@@ -107,6 +107,10 @@ function StandaloneEditEvent({ eventId, eventPath, history }) {
 
   if (error) {
     return <ErrorDisplay graphQLError={error} />;
+  }
+
+  if (!data.currentAbility.can_update_event) {
+    return <Redirect to="/" />;
   }
 
   return (

--- a/app/javascript/EventsApp/StandaloneEditEvent/queries.gql
+++ b/app/javascript/EventsApp/StandaloneEditEvent/queries.gql
@@ -40,6 +40,7 @@ query StandaloneEditEventQuery($eventId: Int!) {
   currentAbility {
     can_override_maximum_event_provided_tickets
     can_delete_event(event_id: $eventId)
+    can_update_event(event_id: $eventId)
   }
 
   convention {


### PR DESCRIPTION
This is less an actual security fix and more a fix for something that _looks_ like a security issue.  Right now, the JS app doesn't check whether the user could actually edit an event when rendering the form to edit that event.  Submitting it will fail, but the form implies to the user that they could edit it, which would be very bad.