### PR TITLE
Add a {% cookie_consent %} Liquid tag

### DIFF
--- a/app/javascript/UIComponents/CookieConsent.tsx
+++ b/app/javascript/UIComponents/CookieConsent.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactCookieConsent from 'react-cookie-consent';
+import { Trans, useTranslation } from 'react-i18next';
+
+export type CookieConsentProps = {
+  cookiePolicyUrl: string,
+};
+
+function CookieConsent({ cookiePolicyUrl }) {
+  const { t } = useTranslation();
+
+  return (
+    <ReactCookieConsent
+      location="bottom"
+      buttonText={t('cookieConsent.buttonText', 'I understand')}
+      buttonClasses="btn btn-warning mr-2"
+      overlay
+      overlayClasses="fixed-bottom bg-dark text-white py-2"
+      disableStyles
+      containerClasses="container d-flex align-items-center"
+      contentClasses="flex-grow-1"
+    >
+      <div className="container">
+        <Trans i18nKey="cookieConsent.text">
+          This web site uses cookies to enhance the user experience.  For more information,
+          please see
+          {' '}
+          <a
+            href={cookiePolicyUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-warning"
+          >
+            our cookie policy
+          </a>
+          .
+        </Trans>
+      </div>
+    </ReactCookieConsent>
+  );
+}
+
+export default CookieConsent;

--- a/app/javascript/parseCmsContent.js
+++ b/app/javascript/parseCmsContent.js
@@ -1,5 +1,6 @@
 import { lazyWithBundleHashCheck } from './checkBundleHash';
 import parsePageContent, { DEFAULT_COMPONENT_MAP } from './parsePageContent';
+import CookieConsent from './UIComponents/CookieConsent';
 
 const AddToCalendarDropdown = lazyWithBundleHashCheck(() => import(/* webpackChunkName: "my-profile" */ './EventsApp/SignupAdmin/AddToCalendarDropdown'));
 const EventAdminMenu = lazyWithBundleHashCheck(() => import(/* webpackChunkName: "events-app" */ './EventsApp/EventPage/EventAdminMenu'));
@@ -12,6 +13,7 @@ const WithdrawMySignupButton = lazyWithBundleHashCheck(() => import(/* webpackCh
 export const CMS_COMPONENT_MAP = {
   ...DEFAULT_COMPONENT_MAP,
   AddToCalendarDropdown,
+  CookieConsent,
   EventAdminMenu,
   LongFormEventDetails,
   ProposeEventButton,

--- a/lib/intercode/liquid/tags.rb
+++ b/lib/intercode/liquid/tags.rb
@@ -1,6 +1,7 @@
 require 'intercode/liquid/tags/app_component_renderer'
 require 'intercode/liquid/tags/add_to_calendar_dropdown'
 require 'intercode/liquid/tags/assign_graphql_result'
+require 'intercode/liquid/tags/cookie_consent'
 require 'intercode/liquid/tags/event_admin_menu'
 require 'intercode/liquid/tags/event_runs_section'
 require 'intercode/liquid/tags/long_form_event_details'

--- a/lib/intercode/liquid/tags/cookie_consent.rb
+++ b/lib/intercode/liquid/tags/cookie_consent.rb
@@ -1,0 +1,38 @@
+module Intercode
+  module Liquid
+    module Tags
+      # Renders a cookie consent.  Requires a URL for a cookie policy to link to.
+      #
+      # @liquid_tag_name cookie_consent
+      # @example
+      #   {% cookie_consent https://www.neilhosting.net/pages/cookies %}
+      class CookieConsent < ::Liquid::Tag
+        include AppComponentRenderer
+
+        attr_reader :cookie_policy_url
+
+        def initialize(tag_name, args, _options)
+          super
+          @cookie_policy_url = args.strip
+        end
+
+        def render(context)
+          render_react_component(context)
+        end
+
+        def component_name(_context)
+          'CookieConsent'
+        end
+
+        def props(context)
+          { cookiePolicyUrl: cookie_policy_url }
+        end
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag(
+  'cookie_consent',
+  Intercode::Liquid::Tags::CookieConsent
+)

--- a/lib/intercode/liquid/tags/cookie_consent.rb
+++ b/lib/intercode/liquid/tags/cookie_consent.rb
@@ -24,7 +24,7 @@ module Intercode
           'CookieConsent'
         end
 
-        def props(context)
+        def props(_context)
           { cookiePolicyUrl: cookie_policy_url }
         end
       end

--- a/liquid_doc.json
+++ b/liquid_doc.json
@@ -5001,6 +5001,84 @@
       ]
     },
     {
+      "name": "Intercode::Liquid::Tags::CookieConsent",
+      "superclasses": [
+        "Intercode::Liquid::Tags::CookieConsent",
+        "Liquid::Tag"
+      ],
+      "docstring": "Renders a cookie consent.  Requires a URL for a cookie policy to link to.",
+      "tags": [
+        {
+          "tag_name": "example",
+          "name": "",
+          "text": "{% cookie_consent https://www.neilhosting.net/pages/cookies %}",
+          "types": null
+        },
+        {
+          "tag_name": "liquid_tag_name",
+          "name": null,
+          "text": "cookie_consent",
+          "types": null
+        }
+      ],
+      "methods": [
+        {
+          "name": "cookie_policy_url",
+          "docstring": "Returns the value of attribute cookie_policy_url.",
+          "tags": [
+
+          ]
+        },
+        {
+          "name": "initialize",
+          "docstring": "",
+          "tags": [
+            {
+              "tag_name": "return",
+              "name": null,
+              "text": "a new instance of CookieConsent",
+              "types": [
+                "CookieConsent"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "render",
+          "docstring": "",
+          "tags": [
+
+          ]
+        },
+        {
+          "name": "component_name",
+          "docstring": "",
+          "tags": [
+
+          ]
+        },
+        {
+          "name": "props",
+          "docstring": "",
+          "tags": [
+
+          ]
+        },
+        {
+          "name": "render_react_component",
+          "docstring": "",
+          "tags": [
+            {
+              "tag_name": "api",
+              "name": null,
+              "text": "",
+              "types": null
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "Intercode::Liquid::Tags::EventAdminMenu",
       "superclasses": [
         "Intercode::Liquid::Tags::EventAdminMenu",

--- a/locales/en.json
+++ b/locales/en.json
@@ -145,6 +145,10 @@
       }
     }
   },
+  "cookieConsent": {
+    "buttonText": "I understand",
+    "text": "This web site uses cookies to enhance the user experience.  For more information, please see <2>our cookie policy</2>."
+  },
   "copyToClipboard": {
     "defaultSuccess": "Copied!",
     "defaultText": "Copy to clipboard"

--- a/locales/es.json
+++ b/locales/es.json
@@ -145,6 +145,10 @@
       }
     }
   },
+  "cookieConsent": {
+    "buttonText": "Acepto",
+    "text": "Esta página web usa cookies para mejorar la experiencia de usuario. Para más información, por favor consulta nuestra <2>política de cookies</2>."
+  },
   "copyToClipboard": {
     "defaultSuccess": "¡Copiado!",
     "defaultText": "Copiado al portapapeles"

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "react-clipboard.js": "^2.0.16",
     "react-codemirror2": "^7.2.1",
     "react-color": "^2.18.1",
+    "react-cookie-consent": "^5.1.2",
     "react-dnd": "^11.1.1",
     "react-dnd-html5-backend": "^11.1.3",
     "react-dnd-multi-backend": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8843,6 +8843,11 @@ js-base64@^2.1.9:
   version "2.4.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03"
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 js-search@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-search/-/js-search-2.0.0.tgz#84dc9d44e34ca0870d067e04b86d8038b77edc26"
@@ -11925,6 +11930,13 @@ react-color@^2.18.1:
     prop-types "^15.5.10"
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
+
+react-cookie-consent@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-cookie-consent/-/react-cookie-consent-5.1.2.tgz#553c4851f8be1e3a91f40f36f350e99b47276731"
+  integrity sha512-FsTLsypqJpg2VjBa6nMT0jNMrk+4C/TUQkRm6mtDFnR6HNPrzMCWi3OHRXVptyL4h8ZbJLk74qZcL0VDUS1+cQ==
+  dependencies:
+    js-cookie "^2.2.1"
 
 react-dnd-html5-backend@^11.1.3:
   version "11.1.3"


### PR DESCRIPTION
This was requested by the Cyberol organizers but I could imagine all kinds of sites using it.  Example usage:

```liquid
{% cookie_consent "https://www.neilhosting.net/pages/cookies" %}
```