### PR TITLE
More free text input options

### DIFF
--- a/app/graphql/concerns/form_response_attrs_fields.rb
+++ b/app/graphql/concerns/form_response_attrs_fields.rb
@@ -17,7 +17,9 @@ module FormResponseAttrsFields
   def form_response_attrs_json_with_rendered_markdown
     form.then do |form|
       AssociationLoader.for(Form, :form_items).load(form).then do |_form_items|
-        FormResponsePresenter.new(form, object).as_json_with_rendered_markdown('event', object, '')
+        can_view_hidden_values = Pundit.policy(context[:pundit_user], object).view_hidden_values?
+        FormResponsePresenter.new(form, object, can_view_hidden_values: can_view_hidden_values)
+          .as_json_with_rendered_markdown('event', object, '')
       end
     end
   end

--- a/app/javascript/EventsApp/EventPage/EventAdminMenu.tsx
+++ b/app/javascript/EventsApp/EventPage/EventAdminMenu.tsx
@@ -47,7 +47,7 @@ function EventAdminMenu({ eventId }: EventAdminMenuProps) {
         </li>
         <li className="list-group-item">
           <Link to={`${eventPath}/history`}>
-            {t('events.adminMenu.historyLink', 'Vew edit history')}
+            {t('events.adminMenu.historyLink', 'View edit history')}
           </Link>
         </li>
       </ul>

--- a/app/javascript/EventsApp/EventPage/index.tsx
+++ b/app/javascript/EventsApp/EventPage/index.tsx
@@ -71,24 +71,27 @@ function EventPage({ eventId, eventPath }: EventPageProps) {
           )}
 
           <EventAdminMenu eventId={eventId} />
+
+          {secretFormItems.map((item) =>
+            formResponse[item.identifier ?? ''] &&
+            formResponse[item.identifier ?? ''].trim() !== '' ? (
+              <section
+                className="my-2 card bg-light"
+                id={item.identifier ?? `item${item.id}`}
+                key={item.identifier ?? `item${item.id}`}
+              >
+                <div className="card-header">
+                  <strong>{item.public_description}</strong>
+                </div>
+
+                <div className="card-body">
+                  {parsePageContent(formResponse[item.identifier ?? '']).bodyComponents}
+                </div>
+              </section>
+            ) : null,
+          )}
         </div>
       </div>
-
-      {secretFormItems.map((item) =>
-        formResponse[item.identifier ?? ''] && formResponse[item.identifier ?? ''].trim() !== '' ? (
-          <section
-            className="my-2 rounded bg-light shadow-sm p-2"
-            id={item.identifier ?? `item${item.id}`}
-            key={item.identifier ?? `item${item.id}`}
-          >
-            <h5>
-              <strong>{item.public_description}</strong>
-            </h5>
-
-            {parsePageContent(formResponse[item.identifier ?? '']).bodyComponents}
-          </section>
-        ) : null,
-      )}
 
       <section className="my-4">
         <RunsSection eventId={eventId} />

--- a/app/javascript/EventsApp/EventPage/index.tsx
+++ b/app/javascript/EventsApp/EventPage/index.tsx
@@ -13,6 +13,8 @@ import AppRootContext from '../../AppRootContext';
 import useRateEvent from '../../EventRatings/useRateEvent';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
 import { useEventPageQueryQuery } from './queries.generated';
+import useSectionizedFormItems from './useSectionizedFormItems';
+import parsePageContent from '../../parsePageContent';
 
 export type EventPageProps = {
   eventId: number;
@@ -23,6 +25,7 @@ function EventPage({ eventId, eventPath }: EventPageProps) {
   const { myProfile } = useContext(AppRootContext);
   const { data, loading, error } = useEventPageQueryQuery({ variables: { eventId } });
   const rateEvent = useRateEvent();
+  const { secretFormItems, formResponse } = useSectionizedFormItems(data?.event);
 
   usePageTitle(useValueUnless(() => data!.event.title, error || loading));
 
@@ -70,6 +73,22 @@ function EventPage({ eventId, eventPath }: EventPageProps) {
           <EventAdminMenu eventId={eventId} />
         </div>
       </div>
+
+      {secretFormItems.map((item) =>
+        formResponse[item.identifier ?? ''] && formResponse[item.identifier ?? ''].trim() !== '' ? (
+          <section
+            className="my-2 rounded bg-light shadow-sm p-2"
+            id={item.identifier ?? `item${item.id}`}
+            key={item.identifier ?? `item${item.id}`}
+          >
+            <h5>
+              <strong>{item.public_description}</strong>
+            </h5>
+
+            {parsePageContent(formResponse[item.identifier ?? '']).bodyComponents}
+          </section>
+        ) : null,
+      )}
 
       <section className="my-4">
         <RunsSection eventId={eventId} />

--- a/app/javascript/EventsApp/EventPage/useSectionizedFormItems.ts
+++ b/app/javascript/EventsApp/EventPage/useSectionizedFormItems.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { TypedFormItem } from '../../FormAdmin/FormItemUtils';
+import { FreeTextFormItem, TypedFormItem } from '../../FormAdmin/FormItemUtils';
 
 import { getSortedParsedFormItems } from '../../Models/Form';
 import { EventPageQueryQuery } from './queries.generated';
@@ -16,9 +16,12 @@ function getSectionizedFormItems(formData: EventPageForm, formResponse: { [x: st
       formResponse[item.identifier],
   );
   const shortFormItems: TypedFormItem[] = [];
+  const secretFormItems: FreeTextFormItem[] = [];
   const longFormItems: TypedFormItem[] = [];
   displayFormItems.forEach((item) => {
-    if (item.item_type === 'free_text' && item.rendered_properties.format === 'markdown') {
+    if (item.item_type === 'free_text' && item.rendered_properties.hide_from_public) {
+      secretFormItems.push(item);
+    } else if (item.item_type === 'free_text' && item.rendered_properties.format === 'markdown') {
       longFormItems.push(item);
     } else {
       shortFormItems.push(item);
@@ -36,7 +39,7 @@ function getSectionizedFormItems(formData: EventPageForm, formResponse: { [x: st
     return 0;
   });
 
-  return { shortFormItems, longFormItems };
+  return { shortFormItems, secretFormItems, longFormItems };
 }
 
 export default function useSectionizedFormItems(event?: EventPageQueryQuery['event']) {
@@ -45,17 +48,18 @@ export default function useSectionizedFormItems(event?: EventPageQueryQuery['eve
     [event],
   );
 
-  const { shortFormItems, longFormItems } = useMemo(
+  const { shortFormItems, secretFormItems, longFormItems } = useMemo(
     () =>
       event?.form
         ? getSectionizedFormItems(event.form, formResponse)
         : {
             shortFormItems: [] as TypedFormItem[],
+            secretFormItems: [] as FreeTextFormItem[],
             longFormItems: [] as TypedFormItem[],
             formResponse: {},
           },
     [event, formResponse],
   );
 
-  return { shortFormItems, longFormItems, formResponse };
+  return { shortFormItems, longFormItems, secretFormItems, formResponse };
 }

--- a/app/javascript/FormAdmin/FormItemUtils.ts
+++ b/app/javascript/FormAdmin/FormItemUtils.ts
@@ -128,6 +128,8 @@ export type FreeTextProperties = CommonQuestionProperties & {
   free_text_type: 'text' | 'email' | 'number' | 'tel' | 'url' | null;
   format: 'text' | 'markdown';
   hide_from_public?: boolean;
+  advisory_word_limit?: number;
+  advisory_character_limit?: number;
 };
 
 export type FreeTextFormItem = WithRequiredIdentifier<

--- a/app/javascript/FormAdmin/FormItemUtils.ts
+++ b/app/javascript/FormAdmin/FormItemUtils.ts
@@ -127,6 +127,7 @@ export type FreeTextProperties = CommonQuestionProperties & {
   lines: number;
   free_text_type: 'text' | 'email' | 'number' | 'tel' | 'url' | null;
   format: 'text' | 'markdown';
+  hide_from_public?: boolean;
 };
 
 export type FreeTextFormItem = WithRequiredIdentifier<

--- a/app/javascript/FormAdmin/ItemEditors/FreeTextEditor.tsx
+++ b/app/javascript/FormAdmin/ItemEditors/FreeTextEditor.tsx
@@ -5,7 +5,7 @@ import LiquidInput from '../../BuiltInFormControls/LiquidInput';
 import useUniqueId from '../../useUniqueId';
 import { formItemPropertyUpdater, FreeTextFormItem } from '../FormItemUtils';
 import BootstrapFormInput from '../../BuiltInFormControls/BootstrapFormInput';
-import { Transforms } from '../../ComposableFormUtils';
+import { parseIntOrNull, Transforms } from '../../ComposableFormUtils';
 import { FormEditorContext, FormItemEditorContext } from '../FormEditorContexts';
 import { FormItemEditorProps } from '../FormItemEditorProps';
 import BooleanInput from '../../BuiltInFormControls/BooleanInput';
@@ -54,6 +54,51 @@ function FreeTextEditor({ formItem, setFormItem }: FreeTextEditorProps) {
         min="1"
         label="Lines"
       />
+
+      <fieldset className="card bg-light">
+        <div className="card-header">
+          <legend className="col-form-label pt-0">Advisory limits</legend>
+          <small className="helptext">
+            You can specify an advisory character or word limit for this field. These limits won’t
+            be enforced, but will appear when filling out the form along with a word or character
+            counter.
+          </small>
+        </div>
+
+        <div className="card-body">
+          <div className="row">
+            <div className="col-6">
+              <BootstrapFormInput
+                disabled={disabled}
+                value={(formItem.properties.advisory_character_limit || '').toString()}
+                onTextChange={(value) =>
+                  formItemPropertyUpdater(
+                    'advisory_character_limit',
+                    setFormItem,
+                  )(parseIntOrNull(value))
+                }
+                type="number"
+                min="1"
+                label="Advisory character limit"
+              />
+            </div>
+
+            <div className="col-6">
+              <BootstrapFormInput
+                disabled={disabled}
+                value={(formItem.properties.advisory_word_limit || '').toString()}
+                onTextChange={(value) =>
+                  formItemPropertyUpdater('advisory_word_limit', setFormItem)(parseIntOrNull(value))
+                }
+                type="number"
+                min="1"
+                label="Advisory word limit"
+              />
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
       {form.form_type === 'event' && (
         <BooleanInput
           disabled={disabled}

--- a/app/javascript/FormAdmin/ItemEditors/FreeTextEditor.tsx
+++ b/app/javascript/FormAdmin/ItemEditors/FreeTextEditor.tsx
@@ -6,11 +6,14 @@ import useUniqueId from '../../useUniqueId';
 import { formItemPropertyUpdater, FreeTextFormItem } from '../FormItemUtils';
 import BootstrapFormInput from '../../BuiltInFormControls/BootstrapFormInput';
 import { Transforms } from '../../ComposableFormUtils';
-import { FormItemEditorContext } from '../FormEditorContexts';
+import { FormEditorContext, FormItemEditorContext } from '../FormEditorContexts';
 import { FormItemEditorProps } from '../FormItemEditorProps';
+import BooleanInput from '../../BuiltInFormControls/BooleanInput';
+import HelpPopover from '../../UIComponents/HelpPopover';
 
 export type FreeTextEditorProps = FormItemEditorProps<FreeTextFormItem>;
 function FreeTextEditor({ formItem, setFormItem }: FreeTextEditorProps) {
+  const { form } = useContext(FormEditorContext);
   const { disabled } = useContext(FormItemEditorContext);
   const captionInputId = useUniqueId('static-text-caption-');
   const responseFormat =
@@ -51,6 +54,23 @@ function FreeTextEditor({ formItem, setFormItem }: FreeTextEditorProps) {
         min="1"
         label="Lines"
       />
+      {form.form_type === 'event' && (
+        <BooleanInput
+          disabled={disabled}
+          caption={
+            <>
+              Hide value from public view?
+              <HelpPopover>
+                If selected, this item will only appear on the event page for attendees and staff.
+                Typically, you would use this to reveal information only attendees should know, such
+                as the URL of a Zoom call for the event.
+              </HelpPopover>
+            </>
+          }
+          value={formItem.properties.hide_from_public ?? false}
+          onChange={formItemPropertyUpdater('hide_from_public', setFormItem)}
+        />
+      )}
       <BootstrapFormSelect
         disabled={disabled}
         value={responseFormat}

--- a/app/javascript/styles/_schedule_grid.scss
+++ b/app/javascript/styles/_schedule_grid.scss
@@ -65,11 +65,15 @@ $signed-up-event-background-color: rgba(0, 0, 0, 0.4);
 
   &.truncated-start {
     border-left-width: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
     mask-image: linear-gradient(to right, transparent 0%, black 7px, black 100%);
   }
 
   &.truncated-finish {
     border-right-width: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
     mask-image: linear-gradient(to left, transparent 0%, black 7px, black 100%);
   }
 

--- a/app/models/form_item.rb
+++ b/app/models/form_item.rb
@@ -25,7 +25,9 @@ class FormItem < ApplicationRecord
       free_text_type: :optional,
       required: :optional,
       format: :optional,
-      hide_from_public: :optional
+      hide_from_public: :optional,
+      advisory_word_limit: :optional,
+      advisory_character_limit: :optional
     },
     multiple_choice: {
       identifier: :required,

--- a/app/models/form_item.rb
+++ b/app/models/form_item.rb
@@ -24,7 +24,8 @@ class FormItem < ApplicationRecord
       lines: :required,
       free_text_type: :optional,
       required: :optional,
-      format: :optional
+      format: :optional,
+      hide_from_public: :optional
     },
     multiple_choice: {
       identifier: :required,

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -70,6 +70,13 @@ class EventPolicy < ApplicationPolicy
     site_admin_manage?
   end
 
+  def view_hidden_values?
+    confirmed_for_event?(record) ||
+      team_member_for_event?(record) ||
+      has_applicable_permission?('update_events') ||
+      site_admin_manage?
+  end
+
   private
 
   def has_applicable_permission?(*permissions)

--- a/app/policies/event_proposal_policy.rb
+++ b/app/policies/event_proposal_policy.rb
@@ -74,6 +74,10 @@ class EventProposalPolicy < ApplicationPolicy
     site_admin_manage?
   end
 
+  def view_hidden_values?
+    user_is_owner? || update?
+  end
+
   private
 
   def has_applicable_permission?(*permissions)

--- a/app/policies/queries/signup_query_manager.rb
+++ b/app/policies/queries/signup_query_manager.rb
@@ -9,8 +9,18 @@ class Queries::SignupQueryManager < Queries::QueryManager
     my_active_signup_run_ids.include?(run.id)
   end
 
+  def confirmed_for_event?(event)
+    return false unless event && user
+
+    my_confirmed_signup_event_ids.include?(event.id)
+  end
+
   def my_active_signup_run_ids
     @my_active_signup_run_ids ||= Set.new(my_active_signups.pluck(:run_id))
+  end
+
+  def my_confirmed_signup_event_ids
+    @my_active_signup_event_ids ||= Set.new(runs_where_confirmed.pluck(:event_id))
   end
 
   def my_active_signups
@@ -23,6 +33,10 @@ class Queries::SignupQueryManager < Queries::QueryManager
 
   def runs_where_signed_up
     Run.where(id: my_active_signups.select(:run_id))
+  end
+
+  def runs_where_confirmed
+    Run.where(id: my_active_signups.where(state: 'confirmed').select(:run_id))
   end
 
   def user_con_profiles_in_signed_up_runs

--- a/app/presenters/form_response_presenter.rb
+++ b/app/presenters/form_response_presenter.rb
@@ -21,7 +21,7 @@ class FormResponsePresenter
     render_promises = form.form_items.map do |form_item|
       field = form_item.identifier.to_s
 
-      if form_item.properties['hide_from_public'] && !can_view_hidden_values
+      if form_item.properties['hide_from_public'] && !can_view_hidden_values && raw_json[field].present?
         if form_item.item_type == 'free_text' && form_item.properties['format'] == 'markdown'
           next [field, '<em>This information is only available to confirmed attendees.</em>']
         else

--- a/app/presenters/form_response_presenter.rb
+++ b/app/presenters/form_response_presenter.rb
@@ -19,28 +19,7 @@ class FormResponsePresenter
   def as_json_with_rendered_markdown(group_cache_key, object_cache_key, default_content)
     raw_json = as_json
     render_promises = form.form_items.map do |form_item|
-      field = form_item.identifier.to_s
-
-      if form_item.properties['hide_from_public'] && !can_view_hidden_values && raw_json[field].present?
-        if form_item.item_type == 'free_text' && form_item.properties['format'] == 'markdown'
-          next [field, '<em>This information is only available to confirmed attendees.</em>']
-        else
-          next [field, 'This information is only available to confirmed attendees.']
-        end
-      end
-
-      next unless form_item.item_type == 'free_text' && form_item.properties['format'] == 'markdown'
-
-      markdown = raw_json[field]
-      render_markdown_for_field(
-        field,
-        markdown,
-        group_cache_key,
-        object_cache_key,
-        default_content
-      ).then do |html|
-        [field, html]
-      end
+      render_form_item(group_cache_key, object_cache_key, default_content, form_item, raw_json)
     end.compact
 
     Promise.all(render_promises).then do |render_results|
@@ -49,6 +28,39 @@ class FormResponsePresenter
   end
 
   private
+
+  def render_form_item(group_cache_key, object_cache_key, default_content, form_item, raw_json)
+    field = form_item.identifier.to_s
+
+    replacement_content = replacement_content_for_form_item(field, form_item, raw_json)
+    return replacement_content if replacement_content
+
+    unless form_item.item_type == 'free_text' && form_item.properties['format'] == 'markdown'
+      return Promise.resolve([field, raw_json[field]])
+    end
+
+    markdown = raw_json[field]
+    render_markdown_for_field(
+      field,
+      markdown,
+      group_cache_key,
+      object_cache_key,
+      default_content
+    ).then do |html|
+      [field, html]
+    end
+  end
+
+  def replacement_content_for_form_item(field, form_item, raw_json)
+    return unless form_item.properties['hide_from_public'] && raw_json[field].present?
+    return if can_view_hidden_values
+
+    if form_item.item_type == 'free_text' && form_item.properties['format'] == 'markdown'
+      Promise.resolve([field, '<em>This information is only available to confirmed attendees.</em>'])
+    else
+      Promise.resolve([field, 'This information is only available to confirmed attendees.'])
+    end
+  end
 
   def render_markdown_for_field(field, value, group_cache_key, object_cache_key, default_content)
     loader = MarkdownLoader.for(group_cache_key, default_content)

--- a/app/presenters/form_response_presenter.rb
+++ b/app/presenters/form_response_presenter.rb
@@ -56,9 +56,9 @@ class FormResponsePresenter
     return if can_view_hidden_values
 
     if form_item.item_type == 'free_text' && form_item.properties['format'] == 'markdown'
-      Promise.resolve([field, '<em>This information is only available to confirmed attendees.</em>'])
+      Promise.resolve([field, "<em>#{I18n.t('forms.hidden_from_public_text')}</em>"])
     else
-      Promise.resolve([field, 'This information is only available to confirmed attendees.'])
+      Promise.resolve([field, I18n.t('forms.hidden_from_public_text')])
     end
   end
 

--- a/app/presenters/markdown_presenter.rb
+++ b/app/presenters/markdown_presenter.rb
@@ -1,4 +1,13 @@
 class MarkdownPresenter
+  class MarkdownRenderer < Redcarpet::Render::HTML
+    include Redcarpet::Render::SmartyPants
+    include ActionView::Helpers::AssetTagHelper
+
+    def image(link, title, alt_text)
+      image_tag(link, title: title, alt_text: alt_text, class: 'img-fluid')
+    end
+  end
+
   ALLOWED_LIQUID_NODE_CLASSES = [
     String, Intercode::Liquid::Tags::Spoiler, Intercode::Liquid::Tags::Youtube
   ]
@@ -8,7 +17,7 @@ class MarkdownPresenter
 
   def self.markdown_processor
     @markdown_processor ||= Redcarpet::Markdown.new(
-      Redcarpet::Render::HTML.new(link_attributes: { target: '_blank', rel: 'noreferrer' }),
+      MarkdownRenderer.new(link_attributes: { target: '_blank', rel: 'noreferrer' }),
       no_intra_emphasis: true,
       autolink: true,
       footnotes: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,3 +51,5 @@ en:
       manage_events: 'Update events and event proposals you manage'
       manage_conventions: 'Update conventions you manage'
       manage_organizations: 'Update privileged data about organizations on the site'
+  forms:
+    hidden_from_public_text: 'This information is only available to confirmed attendees.'

--- a/locales/en.json
+++ b/locales/en.json
@@ -191,7 +191,7 @@
       "editLink": "Edit event",
       "editTeamMembersLink": "Edit {{ teamMemberNamePlural }}",
       "header": "Event Admin",
-      "historyLink": "Vew edit history"
+      "historyLink": "View edit history"
     },
     "edit": {
       "dropButton": "Drop event",


### PR DESCRIPTION
This adds two new features for free text form fields:

* Hide from public (only for event forms): allows event teams to add content that's only visible to confirmed event attendees, team members, and convention admins.  This is intended to allow online events to post secret meeting info (e.g. Zoom or Hangouts links).
* Advisory limits: allows convention admins to set character or word limits on form fields.  These aren't enforced, but they do show up in the lower-right corner of the input along with a running count that changes color depending on how close to the limit you are.

Closes #3836.