### PR TITLE
Run tsrange optimizations

### DIFF
--- a/app/graphql/my_signup_requests_loader.rb
+++ b/app/graphql/my_signup_requests_loader.rb
@@ -7,8 +7,6 @@ class MySignupRequestsLoader < GraphQL::Batch::Loader
 
   def perform(keys)
     signup_request_scope = user_con_profile.signup_requests.where(target_run_id: keys.map(&:id))
-      .includes(target_run: { event: :convention })
-
     signup_requests_by_run_id = signup_request_scope.to_a.group_by(&:run_id)
     keys.each do |run|
       fulfill(run, signup_requests_by_run_id[run.id] || [])

--- a/app/graphql/my_signups_loader.rb
+++ b/app/graphql/my_signups_loader.rb
@@ -7,7 +7,6 @@ class MySignupsLoader < GraphQL::Batch::Loader
 
   def perform(keys)
     signup_scope = user_con_profile.signups.where(run_id: keys.map(&:id))
-      .includes(run: { event: :convention })
     signups_by_run_id = signup_scope.to_a.group_by(&:run_id)
     keys.each do |run|
       fulfill(run, signups_by_run_id[run.id] || [])

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -104,6 +104,8 @@ class Event < ApplicationRecord
 
   validate :event_category_must_be_from_same_convention
 
+  validates :length_seconds, numericality: { greater_than_or_equal_to: 0 }
+
   # Runs specify how many instances of this event there are on the schedule.
   # An event may have 0 or more runs.
   has_many :runs, dependent: :destroy

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -10,11 +10,7 @@ class Run < ApplicationRecord
   delegate :bucket_with_key, to: :registration_policy
 
   scope :between, ->(start, finish) do
-    joins(:event).where(
-      "tsrange(?, ?, '[)') && \
-tsrange(starts_at, starts_at + make_interval(secs := events.length_seconds), '[)')",
-      start, finish
-    )
+    where("tsrange(?, ?, '[)') && timespan_tsrange", start, finish)
   end
 
   def ends_at

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -10,20 +10,11 @@ class Run < ApplicationRecord
   delegate :bucket_with_key, to: :registration_policy
 
   scope :between, ->(start, finish) do
-    run_scope = self
-    if start
-      run_scope = run_scope.joins(:event).where(
-        'starts_at >= ? or (starts_at + make_interval(secs := events.length_seconds)) > ?',
-        start, start
-      )
-    end
-    if finish
-      run_scope = run_scope.joins(:event).where(
-        'starts_at < ? or (starts_at + make_interval(secs := events.length_seconds)) >= ?',
-        finish, finish
-      )
-    end
-    run_scope
+    joins(:event).where(
+      "tsrange(?, ?, '[)') && \
+tsrange(starts_at, starts_at + make_interval(secs := events.length_seconds), '[)')",
+      start, finish
+    )
   end
 
   def ends_at

--- a/db/migrate/20201201184155_add_timespan_tsrange_to_runs.rb
+++ b/db/migrate/20201201184155_add_timespan_tsrange_to_runs.rb
@@ -1,0 +1,80 @@
+class AddTimespanTsrangeToRuns < ActiveRecord::Migration[6.0]
+  def up
+    change_column_null :events, :length_seconds, false
+
+    add_column :runs, :timespan_tsrange, :tsrange
+    add_index :runs, :timespan_tsrange, using: :gist
+
+    execute <<~SQL
+      CREATE FUNCTION run_update_timespan_tsrange() RETURNS trigger AS $$
+        BEGIN
+          UPDATE runs
+          SET timespan_tsrange = tsrange(
+            runs.starts_at, runs.starts_at + make_interval(secs := events.length_seconds),
+            '[)'
+          )
+          FROM events
+          WHERE runs.id = NEW.id AND events.id = runs.event_id;
+          RETURN null;
+        END
+      $$
+      LANGUAGE 'plpgsql';
+    SQL
+
+    execute <<~SQL
+      CREATE FUNCTION event_update_all_runs_timespan_tsrange() RETURNS trigger AS $$
+        BEGIN
+          UPDATE runs
+          SET timespan_tsrange = tsrange(
+            runs.starts_at, runs.starts_at + make_interval(secs := events.length_seconds),
+            '[)'
+          )
+          FROM events
+          WHERE events.id = NEW.id AND events.id = runs.event_id;
+          RETURN null;
+        END
+      $$
+      LANGUAGE 'plpgsql';
+    SQL
+
+    execute <<~SQL
+      CREATE TRIGGER run_update_timespan_tsrange AFTER INSERT OR UPDATE OF starts_at
+      ON runs FOR EACH ROW EXECUTE PROCEDURE
+      run_update_timespan_tsrange();
+    SQL
+
+    execute <<~SQL
+      CREATE TRIGGER event_update_all_runs_timespan_tsrange AFTER INSERT OR UPDATE OF length_seconds
+      ON events FOR EACH ROW EXECUTE PROCEDURE
+      event_update_all_runs_timespan_tsrange();
+    SQL
+
+    # Force a trigger on all runs
+    execute <<~SQL
+      UPDATE runs SET starts_at = starts_at;
+    SQL
+
+    change_column_null :runs, :timespan_tsrange, false
+  end
+
+  def down
+    execute <<~SQL
+      DROP TRIGGER event_update_all_runs_timespan_tsrange;
+    SQL
+
+    execute <<~SQL
+      DROP TRIGGER run_update_timespan_tsrange;
+    SQL
+
+    execute <<~SQL
+      DROP TRIGGER event_update_all_runs_timespan_tsrange;
+    SQL
+
+    execute <<~SQL
+      DROP FUNCTION run_update_timespan_tsrange;
+    SQL
+
+    remove_column :runs, :timespan_tsrange
+    change_column_null :events, :length_seconds, true
+  end
+end


### PR DESCRIPTION
To be honest the actual performance improvement here is kind of marginal (the data we're querying isn't actually that big) but this is a way more elegant way to find runs within a certain timespan, and also, when it comes to the schedule grid, every little bit helps.