### PR TITLE
Papercuts late 2020

### DIFF
--- a/app/javascript/EventsApp/ScheduleGrid/ScheduleGrid.tsx
+++ b/app/javascript/EventsApp/ScheduleGrid/ScheduleGrid.tsx
@@ -45,7 +45,11 @@ function ScheduleGrid({ timespan }: ScheduleGridProps) {
               layoutBlock={layoutBlock}
               rowHeader={options.rowHeader}
               renderEventRun={({ layoutResult, runDimensions }) => (
-                <ScheduleGridEventRun layoutResult={layoutResult} runDimensions={runDimensions} />
+                <ScheduleGridEventRun
+                  layoutResult={layoutResult}
+                  runDimensions={runDimensions}
+                  scheduleLayoutBlock={layoutBlock}
+                />
               )}
             />
           </div>

--- a/app/javascript/EventsApp/ScheduleGrid/ScheduleGridEventRun.tsx
+++ b/app/javascript/EventsApp/ScheduleGrid/ScheduleGridEventRun.tsx
@@ -4,19 +4,31 @@ import { ScheduleGridContext } from './ScheduleGridContext';
 import SignupCountData from '../SignupCountData';
 import RunDetails from './RunDetails';
 import RunDisplay from './RunDisplay';
-import { RunDimensions, ScheduleLayoutResult } from './ScheduleLayout/ScheduleLayoutBlock';
+import ScheduleLayoutBlock, {
+  RunDimensions,
+  ScheduleLayoutResult,
+} from './ScheduleLayout/ScheduleLayoutBlock';
 import { useIntercodePopper } from '../../UIComponents/PopperUtils';
 
 export type ScheduleGridEventRunProps = {
   runDimensions: RunDimensions;
   layoutResult: ScheduleLayoutResult;
+  scheduleLayoutBlock: ScheduleLayoutBlock;
 };
 
-function ScheduleGridEventRun({ runDimensions, layoutResult }: ScheduleGridEventRunProps) {
-  const { schedule, toggleRunDetailsVisibility, visibleRunDetailsIds } = useContext(
+function ScheduleGridEventRun({
+  runDimensions,
+  layoutResult,
+  scheduleLayoutBlock,
+}: ScheduleGridEventRunProps) {
+  const { schedule, toggleRunDetailsVisibility, isRunDetailsVisible } = useContext(
     ScheduleGridContext,
   );
-  const detailsVisible = visibleRunDetailsIds.has(runDimensions.runId);
+  const detailsVisible = useMemo(
+    () =>
+      isRunDetailsVisible({ runId: runDimensions.runId, scheduleBlockId: scheduleLayoutBlock.id }),
+    [isRunDetailsVisible, runDimensions.runId, scheduleLayoutBlock.id],
+  );
 
   const [runDisplayElement, setRunDisplayElement] = useState<HTMLDivElement | null>(null);
   const [runDetailsElement, setRunDetailsElement] = useState<HTMLDivElement | null>(null);
@@ -45,12 +57,12 @@ function ScheduleGridEventRun({ runDimensions, layoutResult }: ScheduleGridEvent
   const toggleVisibility = useCallback(() => {
     const runId = run?.id;
     if (runId) {
-      toggleRunDetailsVisibility(runId);
+      toggleRunDetailsVisibility({ runId, scheduleBlockId: scheduleLayoutBlock.id });
       if (update) {
         update();
       }
     }
-  }, [run, toggleRunDetailsVisibility, update]);
+  }, [run, toggleRunDetailsVisibility, update, scheduleLayoutBlock.id]);
 
   if (event == null || run == null) {
     return null;

--- a/app/javascript/EventsApp/ScheduleGrid/index.tsx
+++ b/app/javascript/EventsApp/ScheduleGrid/index.tsx
@@ -14,6 +14,7 @@ import { parseIntOrNull } from '../../ValueUtils';
 import useReactRouterReactTable from '../../Tables/useReactRouterReactTable';
 import { FilterCodecs, buildFieldFilterCodecs } from '../../Tables/FilterUtils';
 import ErrorDisplay from '../../ErrorDisplay';
+import { formatLCM, useAppDateTimeFormat } from '../../TimeUtils';
 
 const filterCodecs = buildFieldFilterCodecs({
   my_rating: FilterCodecs.integerArray,
@@ -36,6 +37,7 @@ function ScheduleGridApp({ configKey }: ScheduleGridAppProps) {
   const { filters, updateSearch } = useReactRouterReactTable({ ...filterCodecs });
   const config = getConfig(configKey);
   const storageKey = `schedule:${configKey}:personalFilters`;
+  const format = useAppDateTimeFormat();
 
   const loadPersonalFilters = useCallback(() => {
     const storedValue = window.localStorage.getItem(storageKey);
@@ -97,7 +99,7 @@ function ScheduleGridApp({ configKey }: ScheduleGridAppProps) {
         {(timespan) => (
           <div className="mb-4">
             {config.showPersonalFilters && myProfile && (
-              <div className="d-flex flex-column flex-md-row bg-light border-bottom">
+              <div className="d-flex flex-column flex-md-row bg-light">
                 <div className="d-flex btn">
                   <span className="mr-2">Show:</span>
                   <ChoiceSet
@@ -111,6 +113,7 @@ function ScheduleGridApp({ configKey }: ScheduleGridAppProps) {
                 </div>
               </div>
             )}
+            <h3 className="m-0 p-2 border-bottom">{format(timespan.start, 'longDate')}</h3>
             <ScheduleGrid timespan={timespan} />
             <div className="font-italic">
               {t('schedule.timezoneMessage', 'All times displayed in {{ offsetName }}.', {

--- a/app/javascript/EventsApp/ScheduleGrid/index.tsx
+++ b/app/javascript/EventsApp/ScheduleGrid/index.tsx
@@ -14,7 +14,7 @@ import { parseIntOrNull } from '../../ValueUtils';
 import useReactRouterReactTable from '../../Tables/useReactRouterReactTable';
 import { FilterCodecs, buildFieldFilterCodecs } from '../../Tables/FilterUtils';
 import ErrorDisplay from '../../ErrorDisplay';
-import { formatLCM, useAppDateTimeFormat } from '../../TimeUtils';
+import { useAppDateTimeFormat } from '../../TimeUtils';
 
 const filterCodecs = buildFieldFilterCodecs({
   my_rating: FilterCodecs.integerArray,
@@ -113,17 +113,19 @@ function ScheduleGridApp({ configKey }: ScheduleGridAppProps) {
                 </div>
               </div>
             )}
-            <h3 className="m-0 p-2 border-bottom">{format(timespan.start, 'longDate')}</h3>
-            <ScheduleGrid timespan={timespan} />
-            <div className="font-italic">
-              {t('schedule.timezoneMessage', 'All times displayed in {{ offsetName }}.', {
-                offsetName: timespan.start
-                  .reconfigure({
-                    locale: language,
-                  })
-                  .setZone(timezoneName).offsetNameLong,
-              })}
+            <div className="m-0 p-2 border-bottom">
+              <h3 className="p-0 m-0">{format(timespan.start, 'longWeekdayDate')}</h3>
+              <div className="font-italic">
+                {t('schedule.timezoneMessage', 'All times displayed in {{ offsetName }}.', {
+                  offsetName: timespan.start
+                    .reconfigure({
+                      locale: language,
+                    })
+                    .setZone(timezoneName).offsetNameLong,
+                })}
+              </div>
             </div>
+            <ScheduleGrid timespan={timespan} />
           </div>
         )}
       </ScheduleGridProvider>

--- a/app/javascript/EventsApp/StandaloneEditEvent/index.tsx
+++ b/app/javascript/EventsApp/StandaloneEditEvent/index.tsx
@@ -142,8 +142,9 @@ function StandaloneEditEventForm({
               {...meptoMutations}
               ticketName={convention.ticket_name}
               ticketTypes={convention.ticket_types}
-              overrides={event.maximum_event_provided_tickets_overrides}
-              eventId={event.id}
+              // we use initialEvent here because we want it to be controlled by the query result
+              overrides={initialEvent.maximum_event_provided_tickets_overrides}
+              eventId={initialEvent.id}
             />
           )}
       </EventForm>

--- a/app/javascript/TimeUtils.ts
+++ b/app/javascript/TimeUtils.ts
@@ -52,9 +52,8 @@ export function useAppDateTimeFormat() {
   return format;
 }
 
-export const humanizeTime = (time: DateTime, t: TFunction, includeDay?: boolean) => {
-  return formatLCM(time, humanTimeFormat(time, t, includeDay));
-};
+export const humanizeTime = (time: DateTime, t: TFunction, includeDay?: boolean) =>
+  formatLCM(time, humanTimeFormat(time, t, includeDay));
 
 export const timesAreSameOrBothNull = (a?: DateTime | null, b?: DateTime | null) => {
   if (onlyOneIsNull(a, b)) {


### PR DESCRIPTION
Fixes three user-reported issues:

* Make the maximum ticket quota editor show the updates it's just made
* If a run appears in multiple schedule blocks (such as when it spams multiple rooms and you're looking at the schedule-by-room view), only show one details popup for it
* Show the full date on top of the schedule grid, rather than just a weekday name