### PR TITLE
Deduplicate type names

### DIFF
--- a/app/javascript/AppRoot.tsx
+++ b/app/javascript/AppRoot.tsx
@@ -2,7 +2,7 @@ import { Suspense, useMemo, useState, useEffect } from 'react';
 import { Switch, Route, useLocation, useHistory } from 'react-router-dom';
 import { Settings } from 'luxon';
 
-import { useAppRootQueryQuery } from './appRootQueries.generated';
+import { useAppRootQuery } from './appRootQueries.generated';
 import AppRouter from './AppRouter';
 import ErrorDisplay from './ErrorDisplay';
 import PageLoadingIndicator from './PageLoadingIndicator';
@@ -37,7 +37,7 @@ function normalizePathForLayout(path: string) {
 function AppRoot() {
   const location = useLocation();
   const history = useHistory();
-  const { data, loading, error } = useAppRootQueryQuery({
+  const { data, loading, error } = useAppRootQuery({
     variables: { path: normalizePathForLayout(location.pathname) },
   });
 

--- a/app/javascript/AppRootContext.tsx
+++ b/app/javascript/AppRootContext.tsx
@@ -1,28 +1,28 @@
 import { createContext } from 'react';
 import { SignupMode, SiteMode, TicketMode } from './graphqlTypes.generated';
-import { AppRootQueryQuery } from './appRootQueries.generated';
+import { AppRootQueryData } from './appRootQueries.generated';
 import type Timespan from './Timespan';
 
 type AppRootContext = {
-  assumedIdentityFromProfile?: AppRootQueryQuery['assumedIdentityFromProfile'];
-  cmsNavigationItems: AppRootQueryQuery['cmsNavigationItems'];
+  assumedIdentityFromProfile?: AppRootQueryData['assumedIdentityFromProfile'];
+  cmsNavigationItems: AppRootQueryData['cmsNavigationItems'];
   conventionAcceptingProposals?: boolean | null;
   conventionCanceled?: boolean | null;
   conventionDomain?: string | null;
   conventionName?: string | null;
   conventionTimespan?: Timespan;
-  currentAbility: AppRootQueryQuery['currentAbility'];
-  currentPendingOrder?: AppRootQueryQuery['currentPendingOrder'];
-  currentUser?: AppRootQueryQuery['currentUser'];
+  currentAbility: AppRootQueryData['currentAbility'];
+  currentPendingOrder?: AppRootQueryData['currentPendingOrder'];
+  currentUser?: AppRootQueryData['currentUser'];
   language: string;
-  myProfile?: AppRootQueryQuery['myProfile'];
+  myProfile?: AppRootQueryData['myProfile'];
   rootSiteName?: string | null;
   signupMode?: SignupMode;
   siteMode?: SiteMode;
   ticketsAvailableForPurchase?: boolean | null;
   ticketMode?: TicketMode | null;
   ticketName?: string;
-  ticketTypes?: NonNullable<AppRootQueryQuery['convention']>['ticket_types'];
+  ticketTypes?: NonNullable<AppRootQueryData['convention']>['ticket_types'];
   timezoneName: string;
 };
 

--- a/app/javascript/Authentication/AccountFormContent.tsx
+++ b/app/javascript/Authentication/AccountFormContent.tsx
@@ -1,8 +1,8 @@
 import parseCmsContent from '../parseCmsContent';
-import { useAccountFormContentQueryQuery } from './queries.generated';
+import { useAccountFormContentQuery } from './queries.generated';
 
 function AccountFormContent() {
-  const { data, loading, error } = useAccountFormContentQueryQuery();
+  const { data, loading, error } = useAccountFormContentQuery();
 
   if (error || loading) {
     return <></>;

--- a/app/javascript/Authentication/EditUser.tsx
+++ b/app/javascript/Authentication/EditUser.tsx
@@ -15,7 +15,7 @@ import UserFormFields, { UserFormState } from './UserFormFields';
 import usePageTitle from '../usePageTitle';
 import LoadingIndicator from '../LoadingIndicator';
 import { lazyWithBundleHashCheck } from '../checkBundleHash';
-import { useEditUserQueryQuery } from './queries.generated';
+import { useEditUserQuery } from './queries.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 
 const PasswordInputWithStrengthCheck = lazyWithBundleHashCheck(
@@ -68,102 +68,106 @@ async function updateUser(
   }
 }
 
-export default LoadQueryWrapper(useEditUserQueryQuery, function EditUserForm({
-  data: { currentUser: initialFormState },
-}) {
-  const { t } = useTranslation();
-  const authenticityToken = useContext(AuthenticityTokensContext).updateUser;
-  const [formState, setFormState] = useState<UserFormState | undefined>(
-    initialFormState ?? undefined,
-  );
-  const [password, setPassword] = useState('');
-  const [passwordConfirmation, setPasswordConfirmation] = useState('');
-  const [currentPassword, setCurrentPassword] = useState('');
-  const [updateUserAsync, updateUserError, updateUserInProgress] = useAsyncFunction(updateUser);
-  const passwordFieldId = useUniqueId('password-');
-  usePageTitle('Update Your Account');
-
-  if (!formState) {
-    return <Redirect to="/" />;
-  }
-
-  const onSubmit = async (event: React.SyntheticEvent) => {
-    event.preventDefault();
-    if (!formState) {
-      return;
-    }
-    await updateUserAsync(
-      authenticityToken!,
-      formState,
-      password,
-      passwordConfirmation,
-      currentPassword,
+export default LoadQueryWrapper(
+  useEditUserQuery,
+  function EditUserForm({ data: { currentUser: initialFormState } }) {
+    const { t } = useTranslation();
+    const authenticityToken = useContext(AuthenticityTokensContext).updateUser;
+    const [formState, setFormState] = useState<UserFormState | undefined>(
+      initialFormState ?? undefined,
     );
-    window.location.href = '/';
-  };
+    const [password, setPassword] = useState('');
+    const [passwordConfirmation, setPasswordConfirmation] = useState('');
+    const [currentPassword, setCurrentPassword] = useState('');
+    const [updateUserAsync, updateUserError, updateUserInProgress] = useAsyncFunction(updateUser);
+    const passwordFieldId = useUniqueId('password-');
+    usePageTitle('Update Your Account');
 
-  return (
-    <>
-      <h1 className="mb-4">{t('authentication.editUser.header', 'Update your account')}</h1>
+    if (!formState) {
+      return <Redirect to="/" />;
+    }
 
-      <AccountFormContent />
+    const onSubmit = async (event: React.SyntheticEvent) => {
+      event.preventDefault();
+      if (!formState) {
+        return;
+      }
+      await updateUserAsync(
+        authenticityToken!,
+        formState,
+        password,
+        passwordConfirmation,
+        currentPassword,
+      );
+      window.location.href = '/';
+    };
 
-      <form onSubmit={onSubmit} className="card">
-        <div className="card-header">
-          {t('authentication.editUser.accountDataHeader', 'Account data')}
-        </div>
+    return (
+      <>
+        <h1 className="mb-4">{t('authentication.editUser.header', 'Update your account')}</h1>
 
-        <div className="card-body">
-          <UserFormFields formState={formState} setFormState={setFormState} showNameWarning />
-          <div className="form-group">
-            <label htmlFor={passwordFieldId}>
-              {t('authentication.editUser.passwordLabel', 'Password')}
-            </label>
-            <Suspense fallback={<LoadingIndicator />}>
-              <PasswordInputWithStrengthCheck
-                id={passwordFieldId}
-                value={password}
-                onChange={setPassword}
-              />
-            </Suspense>
-            <small className="form-text text-muted">
-              {t(
-                'authentication.editUser.passwordHelpText',
-                'Leave blank if you don’t want to change it',
-              )}
-            </small>
+        <AccountFormContent />
+
+        <form onSubmit={onSubmit} className="card">
+          <div className="card-header">
+            {t('authentication.editUser.accountDataHeader', 'Account data')}
           </div>
-          <PasswordConfirmationInput
-            password={password}
-            value={passwordConfirmation}
-            onChange={setPasswordConfirmation}
-          />
-          <BootstrapFormInput
-            label={t('authentication.editUser.currentPasswordLabel', 'Current password')}
-            helpText={t(
-              'authentication.editUser.currentPasswordHelpText',
-              'We need your current password to verify your identity',
-            )}
-            type="password"
-            value={currentPassword}
-            onTextChange={setCurrentPassword}
-          />
 
-          <ErrorDisplay stringError={(updateUserError || {}).message} />
-        </div>
-
-        <div className="card-footer text-right">
-          <div>
-            <input
-              type="submit"
-              className="btn btn-primary"
-              disabled={updateUserInProgress}
-              value={t('authentication.editUser.updateAccountButton', 'Update account').toString()}
-              aria-label={t('authentication.editUser.updateAccountButton', 'Update account')}
+          <div className="card-body">
+            <UserFormFields formState={formState} setFormState={setFormState} showNameWarning />
+            <div className="form-group">
+              <label htmlFor={passwordFieldId}>
+                {t('authentication.editUser.passwordLabel', 'Password')}
+              </label>
+              <Suspense fallback={<LoadingIndicator />}>
+                <PasswordInputWithStrengthCheck
+                  id={passwordFieldId}
+                  value={password}
+                  onChange={setPassword}
+                />
+              </Suspense>
+              <small className="form-text text-muted">
+                {t(
+                  'authentication.editUser.passwordHelpText',
+                  'Leave blank if you don’t want to change it',
+                )}
+              </small>
+            </div>
+            <PasswordConfirmationInput
+              password={password}
+              value={passwordConfirmation}
+              onChange={setPasswordConfirmation}
             />
+            <BootstrapFormInput
+              label={t('authentication.editUser.currentPasswordLabel', 'Current password')}
+              helpText={t(
+                'authentication.editUser.currentPasswordHelpText',
+                'We need your current password to verify your identity',
+              )}
+              type="password"
+              value={currentPassword}
+              onTextChange={setCurrentPassword}
+            />
+
+            <ErrorDisplay stringError={(updateUserError || {}).message} />
           </div>
-        </div>
-      </form>
-    </>
-  );
-});
+
+          <div className="card-footer text-right">
+            <div>
+              <input
+                type="submit"
+                className="btn btn-primary"
+                disabled={updateUserInProgress}
+                value={t(
+                  'authentication.editUser.updateAccountButton',
+                  'Update account',
+                ).toString()}
+                aria-label={t('authentication.editUser.updateAccountButton', 'Update account')}
+              />
+            </div>
+          </div>
+        </form>
+      </>
+    );
+  },
+);

--- a/app/javascript/Authentication/queries.generated.ts
+++ b/app/javascript/Authentication/queries.generated.ts
@@ -3,18 +3,19 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type AccountFormContentQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+const defaultOptions =  {}
+export type AccountFormContentQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type AccountFormContentQueryQuery = (
+export type AccountFormContentQueryData = (
   { __typename: 'Query' }
   & Pick<Types.Query, 'accountFormContentHtml'>
 );
 
-export type EditUserQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type EditUserQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type EditUserQueryQuery = (
+export type EditUserQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -33,29 +34,31 @@ export const AccountFormContentQueryDocument = gql`
     `;
 
 /**
- * __useAccountFormContentQueryQuery__
+ * __useAccountFormContentQuery__
  *
- * To run a query within a React component, call `useAccountFormContentQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useAccountFormContentQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAccountFormContentQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAccountFormContentQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useAccountFormContentQueryQuery({
+ * const { data, loading, error } = useAccountFormContentQuery({
  *   variables: {
  *   },
  * });
  */
-export function useAccountFormContentQueryQuery(baseOptions?: Apollo.QueryHookOptions<AccountFormContentQueryQuery, AccountFormContentQueryQueryVariables>) {
-        return Apollo.useQuery<AccountFormContentQueryQuery, AccountFormContentQueryQueryVariables>(AccountFormContentQueryDocument, baseOptions);
+export function useAccountFormContentQuery(baseOptions?: Apollo.QueryHookOptions<AccountFormContentQueryData, AccountFormContentQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AccountFormContentQueryData, AccountFormContentQueryVariables>(AccountFormContentQueryDocument, options);
       }
-export function useAccountFormContentQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AccountFormContentQueryQuery, AccountFormContentQueryQueryVariables>) {
-          return Apollo.useLazyQuery<AccountFormContentQueryQuery, AccountFormContentQueryQueryVariables>(AccountFormContentQueryDocument, baseOptions);
+export function useAccountFormContentQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AccountFormContentQueryData, AccountFormContentQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AccountFormContentQueryData, AccountFormContentQueryVariables>(AccountFormContentQueryDocument, options);
         }
-export type AccountFormContentQueryQueryHookResult = ReturnType<typeof useAccountFormContentQueryQuery>;
+export type AccountFormContentQueryHookResult = ReturnType<typeof useAccountFormContentQuery>;
 export type AccountFormContentQueryLazyQueryHookResult = ReturnType<typeof useAccountFormContentQueryLazyQuery>;
-export type AccountFormContentQueryQueryResult = Apollo.QueryResult<AccountFormContentQueryQuery, AccountFormContentQueryQueryVariables>;
+export type AccountFormContentQueryDataResult = Apollo.QueryResult<AccountFormContentQueryData, AccountFormContentQueryVariables>;
 export const EditUserQueryDocument = gql`
     query EditUserQuery {
   convention {
@@ -72,26 +75,28 @@ export const EditUserQueryDocument = gql`
     `;
 
 /**
- * __useEditUserQueryQuery__
+ * __useEditUserQuery__
  *
- * To run a query within a React component, call `useEditUserQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEditUserQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEditUserQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEditUserQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEditUserQueryQuery({
+ * const { data, loading, error } = useEditUserQuery({
  *   variables: {
  *   },
  * });
  */
-export function useEditUserQueryQuery(baseOptions?: Apollo.QueryHookOptions<EditUserQueryQuery, EditUserQueryQueryVariables>) {
-        return Apollo.useQuery<EditUserQueryQuery, EditUserQueryQueryVariables>(EditUserQueryDocument, baseOptions);
+export function useEditUserQuery(baseOptions?: Apollo.QueryHookOptions<EditUserQueryData, EditUserQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EditUserQueryData, EditUserQueryVariables>(EditUserQueryDocument, options);
       }
-export function useEditUserQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EditUserQueryQuery, EditUserQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EditUserQueryQuery, EditUserQueryQueryVariables>(EditUserQueryDocument, baseOptions);
+export function useEditUserQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EditUserQueryData, EditUserQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EditUserQueryData, EditUserQueryVariables>(EditUserQueryDocument, options);
         }
-export type EditUserQueryQueryHookResult = ReturnType<typeof useEditUserQueryQuery>;
+export type EditUserQueryHookResult = ReturnType<typeof useEditUserQuery>;
 export type EditUserQueryLazyQueryHookResult = ReturnType<typeof useEditUserQueryLazyQuery>;
-export type EditUserQueryQueryResult = Apollo.QueryResult<EditUserQueryQuery, EditUserQueryQueryVariables>;
+export type EditUserQueryDataResult = Apollo.QueryResult<EditUserQueryData, EditUserQueryVariables>;

--- a/app/javascript/BuiltInFormControls/EventSelect.tsx
+++ b/app/javascript/BuiltInFormControls/EventSelect.tsx
@@ -3,10 +3,10 @@ import type { DocumentNode } from 'graphql';
 
 import { DefaultEventsQuery } from './selectDefaultQueries';
 import GraphQLAsyncSelect, { GraphQLAsyncSelectProps } from './GraphQLAsyncSelect';
-import { DefaultEventsQueryQuery } from './selectDefaultQueries.generated';
+import { DefaultEventsQueryData } from './selectDefaultQueries.generated';
 
-type DQ = DefaultEventsQueryQuery;
-type DO<QueryType extends DefaultEventsQueryQuery> = NonNullable<
+type DQ = DefaultEventsQueryData;
+type DO<QueryType extends DefaultEventsQueryData> = NonNullable<
   QueryType['convention']
 >['events_paginated']['entries'][0];
 export type DefaultEventSelectOptionType = DO<DQ>;

--- a/app/javascript/BuiltInFormControls/LiquidInput.tsx
+++ b/app/javascript/BuiltInFormControls/LiquidInput.tsx
@@ -15,10 +15,7 @@ import ErrorDisplay from '../ErrorDisplay';
 import FilePreview from '../CmsAdmin/CmsFilesAdmin/FilePreview';
 import SelectWithLabel from './SelectWithLabel';
 import FileUploadForm from '../CmsAdmin/CmsFilesAdmin/FileUploadForm';
-import {
-  PreviewNotifierLiquidQueryQuery,
-  PreviewLiquidQueryQuery,
-} from './previewQueries.generated';
+import { PreviewNotifierLiquidQueryData, PreviewLiquidQueryData } from './previewQueries.generated';
 import { CmsFile } from '../graphqlTypes.generated';
 import type { SyncCodeInputProps } from './SyncCodeInput';
 
@@ -143,7 +140,7 @@ function LiquidInput(props: LiquidInputProps) {
     ? undefined
     : async (liquid: string) => {
         if (notifierEventKey) {
-          const response = await client.query<PreviewNotifierLiquidQueryQuery>({
+          const response = await client.query<PreviewNotifierLiquidQueryData>({
             query: PreviewNotifierLiquidQuery,
             variables: { liquid, eventKey: notifierEventKey },
             fetchPolicy: 'no-cache',
@@ -151,7 +148,7 @@ function LiquidInput(props: LiquidInputProps) {
           return response.data?.previewLiquid ?? '';
         }
 
-        const response = await client.query<PreviewLiquidQueryQuery>({
+        const response = await client.query<PreviewLiquidQueryData>({
           query: PreviewLiquidQuery,
           variables: { liquid },
           fetchPolicy: 'no-cache',

--- a/app/javascript/BuiltInFormControls/MarkdownInput.tsx
+++ b/app/javascript/BuiltInFormControls/MarkdownInput.tsx
@@ -1,7 +1,7 @@
 import { useApolloClient } from '@apollo/client';
 import CodeInput from './CodeInput';
 import { PreviewMarkdownQuery } from './previewQueries';
-import { PreviewMarkdownQueryQuery } from './previewQueries.generated';
+import { PreviewMarkdownQueryData } from './previewQueries.generated';
 import type { SyncCodeInputProps } from './SyncCodeInput';
 
 export type MarkdownInputProps = Omit<SyncCodeInputProps, 'mode' | 'getPreviewContent'>;
@@ -14,7 +14,7 @@ const MarkdownInput = (props: MarkdownInputProps) => {
       {...props}
       mode="liquid-markdown"
       getPreviewContent={async (markdown) => {
-        const response = await client.query<PreviewMarkdownQueryQuery>({
+        const response = await client.query<PreviewMarkdownQueryData>({
           query: PreviewMarkdownQuery,
           variables: { markdown },
           fetchPolicy: 'no-cache',

--- a/app/javascript/BuiltInFormControls/ProductSelect.tsx
+++ b/app/javascript/BuiltInFormControls/ProductSelect.tsx
@@ -5,15 +5,15 @@ import { DocumentNode, useQuery } from '@apollo/client';
 import { AdminProductsQuery } from '../Store/queries';
 import LoadingIndicator from '../LoadingIndicator';
 import ErrorDisplay from '../ErrorDisplay';
-import { AdminProductsQueryQuery } from '../Store/queries.generated';
+import { AdminProductsQueryData } from '../Store/queries.generated';
 
-export type ProductSelectProps<QueryType extends AdminProductsQueryQuery> = SelectProps<
+export type ProductSelectProps<QueryType extends AdminProductsQueryData> = SelectProps<
   Pick<QueryType['convention']['products'][0], '__typename' | 'id' | 'name'>
 > & {
   productsQuery?: DocumentNode;
 };
 
-function ProductSelect<QueryType extends AdminProductsQueryQuery>({
+function ProductSelect<QueryType extends AdminProductsQueryData>({
   productsQuery,
   ...otherProps
 }: ProductSelectProps<QueryType>) {

--- a/app/javascript/BuiltInFormControls/UserConProfileSelect.tsx
+++ b/app/javascript/BuiltInFormControls/UserConProfileSelect.tsx
@@ -3,10 +3,10 @@ import type { OptionTypeBase } from 'react-select';
 
 import { DefaultUserConProfilesQuery } from './selectDefaultQueries';
 import GraphQLAsyncSelect, { GraphQLAsyncSelectProps } from './GraphQLAsyncSelect';
-import { DefaultUserConProfilesQueryQuery } from './selectDefaultQueries.generated';
+import { DefaultUserConProfilesQueryData } from './selectDefaultQueries.generated';
 
-type DQ = DefaultUserConProfilesQueryQuery;
-type DO<QueryType extends DefaultUserConProfilesQueryQuery> = NonNullable<
+type DQ = DefaultUserConProfilesQueryData;
+type DO<QueryType extends DefaultUserConProfilesQueryData> = NonNullable<
   QueryType['convention']
 >['user_con_profiles_paginated']['entries'][0];
 

--- a/app/javascript/BuiltInFormControls/UserSelect.tsx
+++ b/app/javascript/BuiltInFormControls/UserSelect.tsx
@@ -3,10 +3,7 @@ import { components, OptionTypeBase } from 'react-select';
 import type { DocumentNode } from 'graphql';
 
 import GraphQLAsyncSelect, { GraphQLAsyncSelectProps } from './GraphQLAsyncSelect';
-import {
-  DefaultUsersQueryQuery,
-  DefaultUsersQueryDocument,
-} from './selectDefaultQueries.generated';
+import { DefaultUsersQueryData, DefaultUsersQueryDocument } from './selectDefaultQueries.generated';
 
 type UserNameLabelProps = {
   data: {
@@ -22,8 +19,8 @@ function UserNameLabel({ children, ...otherProps }: UserNameLabelProps) {
   );
 }
 
-type DQ = DefaultUsersQueryQuery;
-type DO<QueryType extends DefaultUsersQueryQuery> = NonNullable<
+type DQ = DefaultUsersQueryData;
+type DO<QueryType extends DefaultUsersQueryData> = NonNullable<
   QueryType['users_paginated']
 >['entries'][0];
 

--- a/app/javascript/BuiltInFormControls/previewQueries.generated.ts
+++ b/app/javascript/BuiltInFormControls/previewQueries.generated.ts
@@ -3,33 +3,34 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type PreviewLiquidQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type PreviewLiquidQueryVariables = Types.Exact<{
   liquid: Types.Scalars['String'];
 }>;
 
 
-export type PreviewLiquidQueryQuery = (
+export type PreviewLiquidQueryData = (
   { __typename: 'Query' }
   & Pick<Types.Query, 'previewLiquid'>
 );
 
-export type PreviewMarkdownQueryQueryVariables = Types.Exact<{
+export type PreviewMarkdownQueryVariables = Types.Exact<{
   markdown: Types.Scalars['String'];
 }>;
 
 
-export type PreviewMarkdownQueryQuery = (
+export type PreviewMarkdownQueryData = (
   { __typename: 'Query' }
   & Pick<Types.Query, 'previewMarkdown'>
 );
 
-export type PreviewNotifierLiquidQueryQueryVariables = Types.Exact<{
+export type PreviewNotifierLiquidQueryVariables = Types.Exact<{
   eventKey: Types.Scalars['String'];
   liquid: Types.Scalars['String'];
 }>;
 
 
-export type PreviewNotifierLiquidQueryQuery = (
+export type PreviewNotifierLiquidQueryData = (
   { __typename: 'Query' }
   & { previewLiquid: Types.Query['previewNotifierLiquid'] }
 );
@@ -42,30 +43,32 @@ export const PreviewLiquidQueryDocument = gql`
     `;
 
 /**
- * __usePreviewLiquidQueryQuery__
+ * __usePreviewLiquidQuery__
  *
- * To run a query within a React component, call `usePreviewLiquidQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `usePreviewLiquidQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `usePreviewLiquidQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePreviewLiquidQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = usePreviewLiquidQueryQuery({
+ * const { data, loading, error } = usePreviewLiquidQuery({
  *   variables: {
  *      liquid: // value for 'liquid'
  *   },
  * });
  */
-export function usePreviewLiquidQueryQuery(baseOptions: Apollo.QueryHookOptions<PreviewLiquidQueryQuery, PreviewLiquidQueryQueryVariables>) {
-        return Apollo.useQuery<PreviewLiquidQueryQuery, PreviewLiquidQueryQueryVariables>(PreviewLiquidQueryDocument, baseOptions);
+export function usePreviewLiquidQuery(baseOptions: Apollo.QueryHookOptions<PreviewLiquidQueryData, PreviewLiquidQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PreviewLiquidQueryData, PreviewLiquidQueryVariables>(PreviewLiquidQueryDocument, options);
       }
-export function usePreviewLiquidQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PreviewLiquidQueryQuery, PreviewLiquidQueryQueryVariables>) {
-          return Apollo.useLazyQuery<PreviewLiquidQueryQuery, PreviewLiquidQueryQueryVariables>(PreviewLiquidQueryDocument, baseOptions);
+export function usePreviewLiquidQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PreviewLiquidQueryData, PreviewLiquidQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PreviewLiquidQueryData, PreviewLiquidQueryVariables>(PreviewLiquidQueryDocument, options);
         }
-export type PreviewLiquidQueryQueryHookResult = ReturnType<typeof usePreviewLiquidQueryQuery>;
+export type PreviewLiquidQueryHookResult = ReturnType<typeof usePreviewLiquidQuery>;
 export type PreviewLiquidQueryLazyQueryHookResult = ReturnType<typeof usePreviewLiquidQueryLazyQuery>;
-export type PreviewLiquidQueryQueryResult = Apollo.QueryResult<PreviewLiquidQueryQuery, PreviewLiquidQueryQueryVariables>;
+export type PreviewLiquidQueryDataResult = Apollo.QueryResult<PreviewLiquidQueryData, PreviewLiquidQueryVariables>;
 export const PreviewMarkdownQueryDocument = gql`
     query PreviewMarkdownQuery($markdown: String!) {
   previewMarkdown(markdown: $markdown)
@@ -73,30 +76,32 @@ export const PreviewMarkdownQueryDocument = gql`
     `;
 
 /**
- * __usePreviewMarkdownQueryQuery__
+ * __usePreviewMarkdownQuery__
  *
- * To run a query within a React component, call `usePreviewMarkdownQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `usePreviewMarkdownQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `usePreviewMarkdownQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePreviewMarkdownQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = usePreviewMarkdownQueryQuery({
+ * const { data, loading, error } = usePreviewMarkdownQuery({
  *   variables: {
  *      markdown: // value for 'markdown'
  *   },
  * });
  */
-export function usePreviewMarkdownQueryQuery(baseOptions: Apollo.QueryHookOptions<PreviewMarkdownQueryQuery, PreviewMarkdownQueryQueryVariables>) {
-        return Apollo.useQuery<PreviewMarkdownQueryQuery, PreviewMarkdownQueryQueryVariables>(PreviewMarkdownQueryDocument, baseOptions);
+export function usePreviewMarkdownQuery(baseOptions: Apollo.QueryHookOptions<PreviewMarkdownQueryData, PreviewMarkdownQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PreviewMarkdownQueryData, PreviewMarkdownQueryVariables>(PreviewMarkdownQueryDocument, options);
       }
-export function usePreviewMarkdownQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PreviewMarkdownQueryQuery, PreviewMarkdownQueryQueryVariables>) {
-          return Apollo.useLazyQuery<PreviewMarkdownQueryQuery, PreviewMarkdownQueryQueryVariables>(PreviewMarkdownQueryDocument, baseOptions);
+export function usePreviewMarkdownQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PreviewMarkdownQueryData, PreviewMarkdownQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PreviewMarkdownQueryData, PreviewMarkdownQueryVariables>(PreviewMarkdownQueryDocument, options);
         }
-export type PreviewMarkdownQueryQueryHookResult = ReturnType<typeof usePreviewMarkdownQueryQuery>;
+export type PreviewMarkdownQueryHookResult = ReturnType<typeof usePreviewMarkdownQuery>;
 export type PreviewMarkdownQueryLazyQueryHookResult = ReturnType<typeof usePreviewMarkdownQueryLazyQuery>;
-export type PreviewMarkdownQueryQueryResult = Apollo.QueryResult<PreviewMarkdownQueryQuery, PreviewMarkdownQueryQueryVariables>;
+export type PreviewMarkdownQueryDataResult = Apollo.QueryResult<PreviewMarkdownQueryData, PreviewMarkdownQueryVariables>;
 export const PreviewNotifierLiquidQueryDocument = gql`
     query PreviewNotifierLiquidQuery($eventKey: String!, $liquid: String!) {
   previewLiquid: previewNotifierLiquid(eventKey: $eventKey, content: $liquid)
@@ -104,28 +109,30 @@ export const PreviewNotifierLiquidQueryDocument = gql`
     `;
 
 /**
- * __usePreviewNotifierLiquidQueryQuery__
+ * __usePreviewNotifierLiquidQuery__
  *
- * To run a query within a React component, call `usePreviewNotifierLiquidQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `usePreviewNotifierLiquidQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `usePreviewNotifierLiquidQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePreviewNotifierLiquidQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = usePreviewNotifierLiquidQueryQuery({
+ * const { data, loading, error } = usePreviewNotifierLiquidQuery({
  *   variables: {
  *      eventKey: // value for 'eventKey'
  *      liquid: // value for 'liquid'
  *   },
  * });
  */
-export function usePreviewNotifierLiquidQueryQuery(baseOptions: Apollo.QueryHookOptions<PreviewNotifierLiquidQueryQuery, PreviewNotifierLiquidQueryQueryVariables>) {
-        return Apollo.useQuery<PreviewNotifierLiquidQueryQuery, PreviewNotifierLiquidQueryQueryVariables>(PreviewNotifierLiquidQueryDocument, baseOptions);
+export function usePreviewNotifierLiquidQuery(baseOptions: Apollo.QueryHookOptions<PreviewNotifierLiquidQueryData, PreviewNotifierLiquidQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PreviewNotifierLiquidQueryData, PreviewNotifierLiquidQueryVariables>(PreviewNotifierLiquidQueryDocument, options);
       }
-export function usePreviewNotifierLiquidQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PreviewNotifierLiquidQueryQuery, PreviewNotifierLiquidQueryQueryVariables>) {
-          return Apollo.useLazyQuery<PreviewNotifierLiquidQueryQuery, PreviewNotifierLiquidQueryQueryVariables>(PreviewNotifierLiquidQueryDocument, baseOptions);
+export function usePreviewNotifierLiquidQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PreviewNotifierLiquidQueryData, PreviewNotifierLiquidQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PreviewNotifierLiquidQueryData, PreviewNotifierLiquidQueryVariables>(PreviewNotifierLiquidQueryDocument, options);
         }
-export type PreviewNotifierLiquidQueryQueryHookResult = ReturnType<typeof usePreviewNotifierLiquidQueryQuery>;
+export type PreviewNotifierLiquidQueryHookResult = ReturnType<typeof usePreviewNotifierLiquidQuery>;
 export type PreviewNotifierLiquidQueryLazyQueryHookResult = ReturnType<typeof usePreviewNotifierLiquidQueryLazyQuery>;
-export type PreviewNotifierLiquidQueryQueryResult = Apollo.QueryResult<PreviewNotifierLiquidQueryQuery, PreviewNotifierLiquidQueryQueryVariables>;
+export type PreviewNotifierLiquidQueryDataResult = Apollo.QueryResult<PreviewNotifierLiquidQueryData, PreviewNotifierLiquidQueryVariables>;

--- a/app/javascript/BuiltInFormControls/selectDefaultQueries.generated.ts
+++ b/app/javascript/BuiltInFormControls/selectDefaultQueries.generated.ts
@@ -3,12 +3,13 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type DefaultEventsQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type DefaultEventsQueryVariables = Types.Exact<{
   title?: Types.Maybe<Types.Scalars['String']>;
 }>;
 
 
-export type DefaultEventsQueryQuery = (
+export type DefaultEventsQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -23,12 +24,12 @@ export type DefaultEventsQueryQuery = (
   )> }
 );
 
-export type DefaultUserConProfilesQueryQueryVariables = Types.Exact<{
+export type DefaultUserConProfilesQueryVariables = Types.Exact<{
   name?: Types.Maybe<Types.Scalars['String']>;
 }>;
 
 
-export type DefaultUserConProfilesQueryQuery = (
+export type DefaultUserConProfilesQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -43,12 +44,12 @@ export type DefaultUserConProfilesQueryQuery = (
   )> }
 );
 
-export type DefaultUsersQueryQueryVariables = Types.Exact<{
+export type DefaultUsersQueryVariables = Types.Exact<{
   name?: Types.Maybe<Types.Scalars['String']>;
 }>;
 
 
-export type DefaultUsersQueryQuery = (
+export type DefaultUsersQueryData = (
   { __typename: 'Query' }
   & { users_paginated: (
     { __typename: 'UsersPagination' }
@@ -75,30 +76,32 @@ export const DefaultEventsQueryDocument = gql`
     `;
 
 /**
- * __useDefaultEventsQueryQuery__
+ * __useDefaultEventsQuery__
  *
- * To run a query within a React component, call `useDefaultEventsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useDefaultEventsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useDefaultEventsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDefaultEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useDefaultEventsQueryQuery({
+ * const { data, loading, error } = useDefaultEventsQuery({
  *   variables: {
  *      title: // value for 'title'
  *   },
  * });
  */
-export function useDefaultEventsQueryQuery(baseOptions?: Apollo.QueryHookOptions<DefaultEventsQueryQuery, DefaultEventsQueryQueryVariables>) {
-        return Apollo.useQuery<DefaultEventsQueryQuery, DefaultEventsQueryQueryVariables>(DefaultEventsQueryDocument, baseOptions);
+export function useDefaultEventsQuery(baseOptions?: Apollo.QueryHookOptions<DefaultEventsQueryData, DefaultEventsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<DefaultEventsQueryData, DefaultEventsQueryVariables>(DefaultEventsQueryDocument, options);
       }
-export function useDefaultEventsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DefaultEventsQueryQuery, DefaultEventsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<DefaultEventsQueryQuery, DefaultEventsQueryQueryVariables>(DefaultEventsQueryDocument, baseOptions);
+export function useDefaultEventsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DefaultEventsQueryData, DefaultEventsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<DefaultEventsQueryData, DefaultEventsQueryVariables>(DefaultEventsQueryDocument, options);
         }
-export type DefaultEventsQueryQueryHookResult = ReturnType<typeof useDefaultEventsQueryQuery>;
+export type DefaultEventsQueryHookResult = ReturnType<typeof useDefaultEventsQuery>;
 export type DefaultEventsQueryLazyQueryHookResult = ReturnType<typeof useDefaultEventsQueryLazyQuery>;
-export type DefaultEventsQueryQueryResult = Apollo.QueryResult<DefaultEventsQueryQuery, DefaultEventsQueryQueryVariables>;
+export type DefaultEventsQueryDataResult = Apollo.QueryResult<DefaultEventsQueryData, DefaultEventsQueryVariables>;
 export const DefaultUserConProfilesQueryDocument = gql`
     query DefaultUserConProfilesQuery($name: String) {
   convention {
@@ -115,30 +118,32 @@ export const DefaultUserConProfilesQueryDocument = gql`
     `;
 
 /**
- * __useDefaultUserConProfilesQueryQuery__
+ * __useDefaultUserConProfilesQuery__
  *
- * To run a query within a React component, call `useDefaultUserConProfilesQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useDefaultUserConProfilesQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useDefaultUserConProfilesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDefaultUserConProfilesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useDefaultUserConProfilesQueryQuery({
+ * const { data, loading, error } = useDefaultUserConProfilesQuery({
  *   variables: {
  *      name: // value for 'name'
  *   },
  * });
  */
-export function useDefaultUserConProfilesQueryQuery(baseOptions?: Apollo.QueryHookOptions<DefaultUserConProfilesQueryQuery, DefaultUserConProfilesQueryQueryVariables>) {
-        return Apollo.useQuery<DefaultUserConProfilesQueryQuery, DefaultUserConProfilesQueryQueryVariables>(DefaultUserConProfilesQueryDocument, baseOptions);
+export function useDefaultUserConProfilesQuery(baseOptions?: Apollo.QueryHookOptions<DefaultUserConProfilesQueryData, DefaultUserConProfilesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<DefaultUserConProfilesQueryData, DefaultUserConProfilesQueryVariables>(DefaultUserConProfilesQueryDocument, options);
       }
-export function useDefaultUserConProfilesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DefaultUserConProfilesQueryQuery, DefaultUserConProfilesQueryQueryVariables>) {
-          return Apollo.useLazyQuery<DefaultUserConProfilesQueryQuery, DefaultUserConProfilesQueryQueryVariables>(DefaultUserConProfilesQueryDocument, baseOptions);
+export function useDefaultUserConProfilesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DefaultUserConProfilesQueryData, DefaultUserConProfilesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<DefaultUserConProfilesQueryData, DefaultUserConProfilesQueryVariables>(DefaultUserConProfilesQueryDocument, options);
         }
-export type DefaultUserConProfilesQueryQueryHookResult = ReturnType<typeof useDefaultUserConProfilesQueryQuery>;
+export type DefaultUserConProfilesQueryHookResult = ReturnType<typeof useDefaultUserConProfilesQuery>;
 export type DefaultUserConProfilesQueryLazyQueryHookResult = ReturnType<typeof useDefaultUserConProfilesQueryLazyQuery>;
-export type DefaultUserConProfilesQueryQueryResult = Apollo.QueryResult<DefaultUserConProfilesQueryQuery, DefaultUserConProfilesQueryQueryVariables>;
+export type DefaultUserConProfilesQueryDataResult = Apollo.QueryResult<DefaultUserConProfilesQueryData, DefaultUserConProfilesQueryVariables>;
 export const DefaultUsersQueryDocument = gql`
     query DefaultUsersQuery($name: String) {
   users_paginated(filters: {name: $name}, per_page: 50) {
@@ -152,27 +157,29 @@ export const DefaultUsersQueryDocument = gql`
     `;
 
 /**
- * __useDefaultUsersQueryQuery__
+ * __useDefaultUsersQuery__
  *
- * To run a query within a React component, call `useDefaultUsersQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useDefaultUsersQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useDefaultUsersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDefaultUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useDefaultUsersQueryQuery({
+ * const { data, loading, error } = useDefaultUsersQuery({
  *   variables: {
  *      name: // value for 'name'
  *   },
  * });
  */
-export function useDefaultUsersQueryQuery(baseOptions?: Apollo.QueryHookOptions<DefaultUsersQueryQuery, DefaultUsersQueryQueryVariables>) {
-        return Apollo.useQuery<DefaultUsersQueryQuery, DefaultUsersQueryQueryVariables>(DefaultUsersQueryDocument, baseOptions);
+export function useDefaultUsersQuery(baseOptions?: Apollo.QueryHookOptions<DefaultUsersQueryData, DefaultUsersQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<DefaultUsersQueryData, DefaultUsersQueryVariables>(DefaultUsersQueryDocument, options);
       }
-export function useDefaultUsersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DefaultUsersQueryQuery, DefaultUsersQueryQueryVariables>) {
-          return Apollo.useLazyQuery<DefaultUsersQueryQuery, DefaultUsersQueryQueryVariables>(DefaultUsersQueryDocument, baseOptions);
+export function useDefaultUsersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DefaultUsersQueryData, DefaultUsersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<DefaultUsersQueryData, DefaultUsersQueryVariables>(DefaultUsersQueryDocument, options);
         }
-export type DefaultUsersQueryQueryHookResult = ReturnType<typeof useDefaultUsersQueryQuery>;
+export type DefaultUsersQueryHookResult = ReturnType<typeof useDefaultUsersQuery>;
 export type DefaultUsersQueryLazyQueryHookResult = ReturnType<typeof useDefaultUsersQueryLazyQuery>;
-export type DefaultUsersQueryQueryResult = Apollo.QueryResult<DefaultUsersQueryQuery, DefaultUsersQueryQueryVariables>;
+export type DefaultUsersQueryDataResult = Apollo.QueryResult<DefaultUsersQueryData, DefaultUsersQueryVariables>;

--- a/app/javascript/BuiltInForms/RunFormFields.tsx
+++ b/app/javascript/BuiltInForms/RunFormFields.tsx
@@ -14,8 +14,8 @@ import FormGroupWithLabel from '../BuiltInFormControls/FormGroupWithLabel';
 import RoomSelect, { RoomForSelect } from '../BuiltInFormControls/RoomSelect';
 import AppRootContext from '../AppRootContext';
 import {
-  useEventAdminEventsQueryQuery,
-  EventAdminEventsQueryQuery,
+  useEventAdminEventsQuery,
+  EventAdminEventsQueryData,
 } from '../EventAdmin/queries.generated';
 import { Run } from '../graphqlTypes.generated';
 import { useAppDateTimeFormat } from '../TimeUtils';
@@ -35,7 +35,7 @@ type WithStartsAt<RunType extends RunForRunFormFields> = Omit<RunType, 'starts_a
 
 export type RunFormFieldsProps<RunType extends RunForRunFormFields> = {
   run: RunType;
-  event: EventAdminEventsQueryQuery['events'][0];
+  event: EventAdminEventsQueryData['events'][0];
   onChange: React.Dispatch<React.SetStateAction<RunType>>;
 };
 
@@ -47,7 +47,7 @@ function RunFormFields<RunType extends RunForRunFormFields>({
   const { t } = useTranslation();
   const { timezoneName } = useContext(AppRootContext);
   const format = useAppDateTimeFormat();
-  const { data, loading, error } = useEventAdminEventsQueryQuery();
+  const { data, loading, error } = useEventAdminEventsQuery();
 
   const startsAt = useMemo(
     () =>

--- a/app/javascript/ClickwrapAgreement/index.tsx
+++ b/app/javascript/ClickwrapAgreement/index.tsx
@@ -9,11 +9,9 @@ import AuthenticityTokensContext from '../AuthenticityTokensContext';
 import useLoginRequired from '../Authentication/useLoginRequired';
 import { useAcceptClickwrapAgreementMutation } from './mutations.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useClickwrapAgreementQueryQuery } from './queries.generated';
+import { useClickwrapAgreementQuery } from './queries.generated';
 
-export default LoadQueryWrapper(useClickwrapAgreementQueryQuery, function ClickwrapAgreement({
-  data,
-}) {
+export default LoadQueryWrapper(useClickwrapAgreementQuery, function ClickwrapAgreement({ data }) {
   const { t } = useTranslation();
   const history = useHistory();
   const [

--- a/app/javascript/ClickwrapAgreement/mutations.generated.ts
+++ b/app/javascript/ClickwrapAgreement/mutations.generated.ts
@@ -3,10 +3,11 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type AcceptClickwrapAgreementMutationVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type AcceptClickwrapAgreementMutation = (
+export type AcceptClickwrapAgreementMutationData = (
   { __typename: 'Mutation' }
   & { acceptClickwrapAgreement?: Types.Maybe<(
     { __typename: 'AcceptClickwrapAgreementPayload' }
@@ -28,7 +29,7 @@ export const AcceptClickwrapAgreementDocument = gql`
   }
 }
     `;
-export type AcceptClickwrapAgreementMutationFn = Apollo.MutationFunction<AcceptClickwrapAgreementMutation, AcceptClickwrapAgreementMutationVariables>;
+export type AcceptClickwrapAgreementMutationFn = Apollo.MutationFunction<AcceptClickwrapAgreementMutationData, AcceptClickwrapAgreementMutationVariables>;
 
 /**
  * __useAcceptClickwrapAgreementMutation__
@@ -46,9 +47,10 @@ export type AcceptClickwrapAgreementMutationFn = Apollo.MutationFunction<AcceptC
  *   },
  * });
  */
-export function useAcceptClickwrapAgreementMutation(baseOptions?: Apollo.MutationHookOptions<AcceptClickwrapAgreementMutation, AcceptClickwrapAgreementMutationVariables>) {
-        return Apollo.useMutation<AcceptClickwrapAgreementMutation, AcceptClickwrapAgreementMutationVariables>(AcceptClickwrapAgreementDocument, baseOptions);
+export function useAcceptClickwrapAgreementMutation(baseOptions?: Apollo.MutationHookOptions<AcceptClickwrapAgreementMutationData, AcceptClickwrapAgreementMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AcceptClickwrapAgreementMutationData, AcceptClickwrapAgreementMutationVariables>(AcceptClickwrapAgreementDocument, options);
       }
 export type AcceptClickwrapAgreementMutationHookResult = ReturnType<typeof useAcceptClickwrapAgreementMutation>;
-export type AcceptClickwrapAgreementMutationResult = Apollo.MutationResult<AcceptClickwrapAgreementMutation>;
-export type AcceptClickwrapAgreementMutationOptions = Apollo.BaseMutationOptions<AcceptClickwrapAgreementMutation, AcceptClickwrapAgreementMutationVariables>;
+export type AcceptClickwrapAgreementMutationResult = Apollo.MutationResult<AcceptClickwrapAgreementMutationData>;
+export type AcceptClickwrapAgreementMutationOptions = Apollo.BaseMutationOptions<AcceptClickwrapAgreementMutationData, AcceptClickwrapAgreementMutationVariables>;

--- a/app/javascript/ClickwrapAgreement/queries.generated.ts
+++ b/app/javascript/ClickwrapAgreement/queries.generated.ts
@@ -3,10 +3,11 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type ClickwrapAgreementQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+const defaultOptions =  {}
+export type ClickwrapAgreementQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type ClickwrapAgreementQueryQuery = (
+export type ClickwrapAgreementQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -33,26 +34,28 @@ export const ClickwrapAgreementQueryDocument = gql`
     `;
 
 /**
- * __useClickwrapAgreementQueryQuery__
+ * __useClickwrapAgreementQuery__
  *
- * To run a query within a React component, call `useClickwrapAgreementQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useClickwrapAgreementQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useClickwrapAgreementQuery` and pass it any options that fit your needs.
+ * When your component renders, `useClickwrapAgreementQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useClickwrapAgreementQueryQuery({
+ * const { data, loading, error } = useClickwrapAgreementQuery({
  *   variables: {
  *   },
  * });
  */
-export function useClickwrapAgreementQueryQuery(baseOptions?: Apollo.QueryHookOptions<ClickwrapAgreementQueryQuery, ClickwrapAgreementQueryQueryVariables>) {
-        return Apollo.useQuery<ClickwrapAgreementQueryQuery, ClickwrapAgreementQueryQueryVariables>(ClickwrapAgreementQueryDocument, baseOptions);
+export function useClickwrapAgreementQuery(baseOptions?: Apollo.QueryHookOptions<ClickwrapAgreementQueryData, ClickwrapAgreementQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ClickwrapAgreementQueryData, ClickwrapAgreementQueryVariables>(ClickwrapAgreementQueryDocument, options);
       }
-export function useClickwrapAgreementQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ClickwrapAgreementQueryQuery, ClickwrapAgreementQueryQueryVariables>) {
-          return Apollo.useLazyQuery<ClickwrapAgreementQueryQuery, ClickwrapAgreementQueryQueryVariables>(ClickwrapAgreementQueryDocument, baseOptions);
+export function useClickwrapAgreementQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ClickwrapAgreementQueryData, ClickwrapAgreementQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ClickwrapAgreementQueryData, ClickwrapAgreementQueryVariables>(ClickwrapAgreementQueryDocument, options);
         }
-export type ClickwrapAgreementQueryQueryHookResult = ReturnType<typeof useClickwrapAgreementQueryQuery>;
+export type ClickwrapAgreementQueryHookResult = ReturnType<typeof useClickwrapAgreementQuery>;
 export type ClickwrapAgreementQueryLazyQueryHookResult = ReturnType<typeof useClickwrapAgreementQueryLazyQuery>;
-export type ClickwrapAgreementQueryQueryResult = Apollo.QueryResult<ClickwrapAgreementQueryQuery, ClickwrapAgreementQueryQueryVariables>;
+export type ClickwrapAgreementQueryDataResult = Apollo.QueryResult<ClickwrapAgreementQueryData, ClickwrapAgreementQueryVariables>;

--- a/app/javascript/CmsAdmin/CmsContentGroupsAdmin/CmsContentGroupFormFields.tsx
+++ b/app/javascript/CmsAdmin/CmsContentGroupsAdmin/CmsContentGroupFormFields.tsx
@@ -11,7 +11,7 @@ import {
   permissionEquals,
   getPermissionNamesForModelType,
 } from '../../Permissions/PermissionUtils';
-import { CmsContentGroupsAdminQueryQuery } from './queries.generated';
+import { CmsContentGroupsAdminQueryData } from './queries.generated';
 import ChangeSet from '../../ChangeSet';
 import { PermissionedModelTypeIndicator } from '../../graphqlTypes.generated';
 import { notEmpty } from '../../ValueUtils';
@@ -21,7 +21,7 @@ const ContentGroupPermissionNames = getPermissionNamesForModelType(
   PermissionedModelTypeIndicator.CmsContentGroup,
 );
 
-type ContentGroupTypeWithRequiredId = CmsContentGroupsAdminQueryQuery['cmsContentGroups'][0];
+type ContentGroupTypeWithRequiredId = CmsContentGroupsAdminQueryData['cmsContentGroups'][0];
 type ContentGroupType = Omit<ContentGroupTypeWithRequiredId, 'id'> &
   Partial<Pick<ContentGroupTypeWithRequiredId, 'id'>>;
 type PermissionType = ContentGroupType['permissions'][0];
@@ -29,7 +29,7 @@ type RoleType = PermissionType['role'];
 
 export type CmsContentGroupFormFieldsProps = {
   contentGroup: ContentGroupType;
-  convention: CmsContentGroupsAdminQueryQuery['convention'];
+  convention: CmsContentGroupsAdminQueryData['convention'];
   setContentGroup?: React.Dispatch<ContentGroupType>;
   disabled?: boolean;
   readOnly?: boolean;

--- a/app/javascript/CmsAdmin/CmsContentGroupsAdmin/CmsContentGroupsAdminTable.tsx
+++ b/app/javascript/CmsAdmin/CmsContentGroupsAdmin/CmsContentGroupsAdminTable.tsx
@@ -9,10 +9,10 @@ import { useConfirm } from '../../ModalDialogs/Confirm';
 import { useDeleteMutation } from '../../MutationUtils';
 import usePageTitle from '../../usePageTitle';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { useCmsContentGroupsAdminQueryQuery } from './queries.generated';
+import { useCmsContentGroupsAdminQuery } from './queries.generated';
 
 function CmsContentGroupsAdminTable() {
-  const { data, loading, error } = useCmsContentGroupsAdminQueryQuery();
+  const { data, loading, error } = useCmsContentGroupsAdminQuery();
   const confirm = useConfirm();
   const deleteContentGroupMutate = useDeleteMutation(DeleteContentGroup, {
     query: CmsContentGroupsAdminQuery,

--- a/app/javascript/CmsAdmin/CmsContentGroupsAdmin/CmsContentSelect.tsx
+++ b/app/javascript/CmsAdmin/CmsContentGroupsAdmin/CmsContentSelect.tsx
@@ -2,12 +2,12 @@ import GraphQLAsyncSelect, {
   GraphQLAsyncSelectProps,
 } from '../../BuiltInFormControls/GraphQLAsyncSelect';
 import { SearchCmsContentQuery } from './queries';
-import { SearchCmsContentQueryQuery } from './queries.generated';
+import { SearchCmsContentQueryData } from './queries.generated';
 
-export type CmsContentOption = SearchCmsContentQueryQuery['searchCmsContent'][0];
+export type CmsContentOption = SearchCmsContentQueryData['searchCmsContent'][0];
 
 export type CmsContentSelectProps<IsMulti extends boolean> = Omit<
-  GraphQLAsyncSelectProps<SearchCmsContentQueryQuery, CmsContentOption, IsMulti>,
+  GraphQLAsyncSelectProps<SearchCmsContentQueryData, CmsContentOption, IsMulti>,
   'getOptions' | 'getVariables' | 'getOptionValue' | 'formatOptionLabel' | 'query'
 >;
 
@@ -15,7 +15,7 @@ function CmsContentSelect<IsMulti extends boolean = false>(props: CmsContentSele
   const { ...otherProps } = props;
 
   return (
-    <GraphQLAsyncSelect<SearchCmsContentQueryQuery, CmsContentOption, IsMulti>
+    <GraphQLAsyncSelect<SearchCmsContentQueryData, CmsContentOption, IsMulti>
       getOptions={(data) => data.searchCmsContent}
       getVariables={(inputValue) => ({ name: inputValue })}
       getOptionValue={({ id: optionId, __typename }: CmsContentOption) =>

--- a/app/javascript/CmsAdmin/CmsContentGroupsAdmin/EditCmsContentGroup.tsx
+++ b/app/javascript/CmsAdmin/CmsContentGroupsAdmin/EditCmsContentGroup.tsx
@@ -8,17 +8,14 @@ import { buildPermissionInput } from '../../Permissions/PermissionUtils';
 import useAsyncFunction from '../../useAsyncFunction';
 import { useChangeSet } from '../../ChangeSet';
 import CmsContentGroupFormFields from './CmsContentGroupFormFields';
-import {
-  CmsContentGroupsAdminQueryQuery,
-  useCmsContentGroupsAdminQueryQuery,
-} from './queries.generated';
+import { CmsContentGroupsAdminQueryData, useCmsContentGroupsAdminQuery } from './queries.generated';
 import { notEmpty } from '../../ValueUtils';
 import { useUpdateContentGroupMutation } from './mutations.generated';
 import { CmsContentTypeIndicator } from '../../graphqlTypes.generated';
 import { LoadSingleValueFromCollectionWrapper } from '../../GraphqlLoadingWrappers';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useCmsContentGroupsAdminQueryQuery,
+  useCmsContentGroupsAdminQuery,
   (data, id) => data.cmsContentGroups.find((contentGroup) => contentGroup.id.toString() === id),
 
   function EditCmsContentGroupForm({ data: { convention }, value: initialContentGroup }) {
@@ -26,7 +23,7 @@ export default LoadSingleValueFromCollectionWrapper(
     const [updateCmsContentGroup] = useUpdateContentGroupMutation();
     const [contentGroup, setContentGroup] = useState(initialContentGroup);
     const [permissionsChangeSet, addPermission, removePermission] = useChangeSet<
-      CmsContentGroupsAdminQueryQuery['cmsContentGroups'][0]['permissions'][0]
+      CmsContentGroupsAdminQueryData['cmsContentGroups'][0]['permissions'][0]
     >();
     const apolloClient = useApolloClient();
 

--- a/app/javascript/CmsAdmin/CmsContentGroupsAdmin/NewCmsContentGroup.tsx
+++ b/app/javascript/CmsAdmin/CmsContentGroupsAdmin/NewCmsContentGroup.tsx
@@ -13,14 +13,11 @@ import { useCreateMutation } from '../../MutationUtils';
 import usePageTitle from '../../usePageTitle';
 import CmsContentGroupFormFields from './CmsContentGroupFormFields';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import {
-  CmsContentGroupsAdminQueryQuery,
-  useCmsContentGroupsAdminQueryQuery,
-} from './queries.generated';
+import { CmsContentGroupsAdminQueryData, useCmsContentGroupsAdminQuery } from './queries.generated';
 
 function NewCmsContentGroup() {
   const history = useHistory();
-  const { data, loading, error } = useCmsContentGroupsAdminQueryQuery();
+  const { data, loading, error } = useCmsContentGroupsAdminQuery();
   const mutate = useCreateMutation(CreateContentGroup, {
     query: CmsContentGroupsAdminQuery,
     arrayPath: ['cmsContentGroups'],
@@ -28,7 +25,7 @@ function NewCmsContentGroup() {
   });
   const [createCmsContentGroup, createError, createInProgress] = useAsyncFunction(mutate);
   const [contentGroup, setContentGroup] = useState<
-    Omit<CmsContentGroupsAdminQueryQuery['cmsContentGroups'][0], 'id'>
+    Omit<CmsContentGroupsAdminQueryData['cmsContentGroups'][0], 'id'>
   >({
     __typename: 'CmsContentGroup',
     name: '',
@@ -38,7 +35,7 @@ function NewCmsContentGroup() {
     current_ability_can_update: true,
   });
   const [permissionsChangeSet, addPermission, removePermission] = useChangeSet<
-    CmsContentGroupsAdminQueryQuery['cmsContentGroups'][0]['permissions'][0]
+    CmsContentGroupsAdminQueryData['cmsContentGroups'][0]['permissions'][0]
   >();
 
   usePageTitle('New Content Group');

--- a/app/javascript/CmsAdmin/CmsContentGroupsAdmin/ViewCmsContentGroup.tsx
+++ b/app/javascript/CmsAdmin/CmsContentGroupsAdmin/ViewCmsContentGroup.tsx
@@ -5,12 +5,12 @@ import ErrorDisplay from '../../ErrorDisplay';
 import usePageTitle from '../../usePageTitle';
 import CmsContentGroupFormFields from './CmsContentGroupFormFields';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { useCmsContentGroupsAdminQueryQuery } from './queries.generated';
+import { useCmsContentGroupsAdminQuery } from './queries.generated';
 import FourOhFourPage from '../../FourOhFourPage';
 
 function ViewCmsContentGroup() {
   const { params } = useRouteMatch<{ id: string }>();
-  const { data, loading, error } = useCmsContentGroupsAdminQueryQuery();
+  const { data, loading, error } = useCmsContentGroupsAdminQuery();
   const contentGroup = useMemo(() => {
     if (loading || error || !data) {
       return null;

--- a/app/javascript/CmsAdmin/CmsContentGroupsAdmin/mutations.generated.ts
+++ b/app/javascript/CmsAdmin/CmsContentGroupsAdmin/mutations.generated.ts
@@ -5,13 +5,14 @@ import { CmsContentGroupFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { CmsContentGroupFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateContentGroupMutationVariables = Types.Exact<{
   cmsContentGroup: Types.CmsContentGroupInput;
   permissions?: Types.Maybe<Array<Types.PermissionInput> | Types.PermissionInput>;
 }>;
 
 
-export type CreateContentGroupMutation = (
+export type CreateContentGroupMutationData = (
   { __typename: 'Mutation' }
   & { createCmsContentGroup?: Types.Maybe<(
     { __typename: 'CreateCmsContentGroupPayload' }
@@ -31,7 +32,7 @@ export type UpdateContentGroupMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateContentGroupMutation = (
+export type UpdateContentGroupMutationData = (
   { __typename: 'Mutation' }
   & { updateCmsContentGroup?: Types.Maybe<(
     { __typename: 'UpdateCmsContentGroupPayload' }
@@ -48,7 +49,7 @@ export type DeleteContentGroupMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteContentGroupMutation = (
+export type DeleteContentGroupMutationData = (
   { __typename: 'Mutation' }
   & { deleteCmsContentGroup?: Types.Maybe<(
     { __typename: 'DeleteCmsContentGroupPayload' }
@@ -69,7 +70,7 @@ export const CreateContentGroupDocument = gql`
   }
 }
     ${CmsContentGroupFieldsFragmentDoc}`;
-export type CreateContentGroupMutationFn = Apollo.MutationFunction<CreateContentGroupMutation, CreateContentGroupMutationVariables>;
+export type CreateContentGroupMutationFn = Apollo.MutationFunction<CreateContentGroupMutationData, CreateContentGroupMutationVariables>;
 
 /**
  * __useCreateContentGroupMutation__
@@ -89,12 +90,13 @@ export type CreateContentGroupMutationFn = Apollo.MutationFunction<CreateContent
  *   },
  * });
  */
-export function useCreateContentGroupMutation(baseOptions?: Apollo.MutationHookOptions<CreateContentGroupMutation, CreateContentGroupMutationVariables>) {
-        return Apollo.useMutation<CreateContentGroupMutation, CreateContentGroupMutationVariables>(CreateContentGroupDocument, baseOptions);
+export function useCreateContentGroupMutation(baseOptions?: Apollo.MutationHookOptions<CreateContentGroupMutationData, CreateContentGroupMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateContentGroupMutationData, CreateContentGroupMutationVariables>(CreateContentGroupDocument, options);
       }
 export type CreateContentGroupMutationHookResult = ReturnType<typeof useCreateContentGroupMutation>;
-export type CreateContentGroupMutationResult = Apollo.MutationResult<CreateContentGroupMutation>;
-export type CreateContentGroupMutationOptions = Apollo.BaseMutationOptions<CreateContentGroupMutation, CreateContentGroupMutationVariables>;
+export type CreateContentGroupMutationResult = Apollo.MutationResult<CreateContentGroupMutationData>;
+export type CreateContentGroupMutationOptions = Apollo.BaseMutationOptions<CreateContentGroupMutationData, CreateContentGroupMutationVariables>;
 export const UpdateContentGroupDocument = gql`
     mutation UpdateContentGroup($id: Int!, $cmsContentGroup: CmsContentGroupInput!, $grantPermissions: [PermissionInput!], $revokePermissions: [PermissionInput!]) {
   updateCmsContentGroup(
@@ -107,7 +109,7 @@ export const UpdateContentGroupDocument = gql`
   }
 }
     ${CmsContentGroupFieldsFragmentDoc}`;
-export type UpdateContentGroupMutationFn = Apollo.MutationFunction<UpdateContentGroupMutation, UpdateContentGroupMutationVariables>;
+export type UpdateContentGroupMutationFn = Apollo.MutationFunction<UpdateContentGroupMutationData, UpdateContentGroupMutationVariables>;
 
 /**
  * __useUpdateContentGroupMutation__
@@ -129,12 +131,13 @@ export type UpdateContentGroupMutationFn = Apollo.MutationFunction<UpdateContent
  *   },
  * });
  */
-export function useUpdateContentGroupMutation(baseOptions?: Apollo.MutationHookOptions<UpdateContentGroupMutation, UpdateContentGroupMutationVariables>) {
-        return Apollo.useMutation<UpdateContentGroupMutation, UpdateContentGroupMutationVariables>(UpdateContentGroupDocument, baseOptions);
+export function useUpdateContentGroupMutation(baseOptions?: Apollo.MutationHookOptions<UpdateContentGroupMutationData, UpdateContentGroupMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateContentGroupMutationData, UpdateContentGroupMutationVariables>(UpdateContentGroupDocument, options);
       }
 export type UpdateContentGroupMutationHookResult = ReturnType<typeof useUpdateContentGroupMutation>;
-export type UpdateContentGroupMutationResult = Apollo.MutationResult<UpdateContentGroupMutation>;
-export type UpdateContentGroupMutationOptions = Apollo.BaseMutationOptions<UpdateContentGroupMutation, UpdateContentGroupMutationVariables>;
+export type UpdateContentGroupMutationResult = Apollo.MutationResult<UpdateContentGroupMutationData>;
+export type UpdateContentGroupMutationOptions = Apollo.BaseMutationOptions<UpdateContentGroupMutationData, UpdateContentGroupMutationVariables>;
 export const DeleteContentGroupDocument = gql`
     mutation DeleteContentGroup($id: Int!) {
   deleteCmsContentGroup(input: {id: $id}) {
@@ -142,7 +145,7 @@ export const DeleteContentGroupDocument = gql`
   }
 }
     `;
-export type DeleteContentGroupMutationFn = Apollo.MutationFunction<DeleteContentGroupMutation, DeleteContentGroupMutationVariables>;
+export type DeleteContentGroupMutationFn = Apollo.MutationFunction<DeleteContentGroupMutationData, DeleteContentGroupMutationVariables>;
 
 /**
  * __useDeleteContentGroupMutation__
@@ -161,9 +164,10 @@ export type DeleteContentGroupMutationFn = Apollo.MutationFunction<DeleteContent
  *   },
  * });
  */
-export function useDeleteContentGroupMutation(baseOptions?: Apollo.MutationHookOptions<DeleteContentGroupMutation, DeleteContentGroupMutationVariables>) {
-        return Apollo.useMutation<DeleteContentGroupMutation, DeleteContentGroupMutationVariables>(DeleteContentGroupDocument, baseOptions);
+export function useDeleteContentGroupMutation(baseOptions?: Apollo.MutationHookOptions<DeleteContentGroupMutationData, DeleteContentGroupMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteContentGroupMutationData, DeleteContentGroupMutationVariables>(DeleteContentGroupDocument, options);
       }
 export type DeleteContentGroupMutationHookResult = ReturnType<typeof useDeleteContentGroupMutation>;
-export type DeleteContentGroupMutationResult = Apollo.MutationResult<DeleteContentGroupMutation>;
-export type DeleteContentGroupMutationOptions = Apollo.BaseMutationOptions<DeleteContentGroupMutation, DeleteContentGroupMutationVariables>;
+export type DeleteContentGroupMutationResult = Apollo.MutationResult<DeleteContentGroupMutationData>;
+export type DeleteContentGroupMutationOptions = Apollo.BaseMutationOptions<DeleteContentGroupMutationData, DeleteContentGroupMutationVariables>;

--- a/app/javascript/CmsAdmin/CmsContentGroupsAdmin/queries.generated.ts
+++ b/app/javascript/CmsAdmin/CmsContentGroupsAdmin/queries.generated.ts
@@ -5,6 +5,7 @@ import { PermissionedModelFields_CmsContentGroup_Fragment, PermissionedModelFiel
 import { gql } from '@apollo/client';
 import { PermissionedModelFieldsFragmentDoc, PermissionedRoleFieldsFragmentDoc } from '../../Permissions/fragments.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CmsContentFields_CmsLayout_Fragment = (
   { __typename: 'CmsLayout' }
   & Pick<Types.CmsLayout, 'id' | 'name'>
@@ -56,10 +57,10 @@ export type CmsContentGroupFieldsFragment = (
   )> }
 );
 
-export type CmsContentGroupsAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CmsContentGroupsAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CmsContentGroupsAdminQueryQuery = (
+export type CmsContentGroupsAdminQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -78,12 +79,12 @@ export type CmsContentGroupsAdminQueryQuery = (
   ) }
 );
 
-export type SearchCmsContentQueryQueryVariables = Types.Exact<{
+export type SearchCmsContentQueryVariables = Types.Exact<{
   name?: Types.Maybe<Types.Scalars['String']>;
 }>;
 
 
-export type SearchCmsContentQueryQuery = (
+export type SearchCmsContentQueryData = (
   { __typename: 'Query' }
   & { searchCmsContent: Array<(
     { __typename: 'CmsLayout' }
@@ -158,29 +159,31 @@ export const CmsContentGroupsAdminQueryDocument = gql`
     ${CmsContentGroupFieldsFragmentDoc}`;
 
 /**
- * __useCmsContentGroupsAdminQueryQuery__
+ * __useCmsContentGroupsAdminQuery__
  *
- * To run a query within a React component, call `useCmsContentGroupsAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCmsContentGroupsAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCmsContentGroupsAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCmsContentGroupsAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCmsContentGroupsAdminQueryQuery({
+ * const { data, loading, error } = useCmsContentGroupsAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCmsContentGroupsAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<CmsContentGroupsAdminQueryQuery, CmsContentGroupsAdminQueryQueryVariables>) {
-        return Apollo.useQuery<CmsContentGroupsAdminQueryQuery, CmsContentGroupsAdminQueryQueryVariables>(CmsContentGroupsAdminQueryDocument, baseOptions);
+export function useCmsContentGroupsAdminQuery(baseOptions?: Apollo.QueryHookOptions<CmsContentGroupsAdminQueryData, CmsContentGroupsAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CmsContentGroupsAdminQueryData, CmsContentGroupsAdminQueryVariables>(CmsContentGroupsAdminQueryDocument, options);
       }
-export function useCmsContentGroupsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsContentGroupsAdminQueryQuery, CmsContentGroupsAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CmsContentGroupsAdminQueryQuery, CmsContentGroupsAdminQueryQueryVariables>(CmsContentGroupsAdminQueryDocument, baseOptions);
+export function useCmsContentGroupsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsContentGroupsAdminQueryData, CmsContentGroupsAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CmsContentGroupsAdminQueryData, CmsContentGroupsAdminQueryVariables>(CmsContentGroupsAdminQueryDocument, options);
         }
-export type CmsContentGroupsAdminQueryQueryHookResult = ReturnType<typeof useCmsContentGroupsAdminQueryQuery>;
+export type CmsContentGroupsAdminQueryHookResult = ReturnType<typeof useCmsContentGroupsAdminQuery>;
 export type CmsContentGroupsAdminQueryLazyQueryHookResult = ReturnType<typeof useCmsContentGroupsAdminQueryLazyQuery>;
-export type CmsContentGroupsAdminQueryQueryResult = Apollo.QueryResult<CmsContentGroupsAdminQueryQuery, CmsContentGroupsAdminQueryQueryVariables>;
+export type CmsContentGroupsAdminQueryDataResult = Apollo.QueryResult<CmsContentGroupsAdminQueryData, CmsContentGroupsAdminQueryVariables>;
 export const SearchCmsContentQueryDocument = gql`
     query SearchCmsContentQuery($name: String) {
   searchCmsContent(name: $name) {
@@ -190,27 +193,29 @@ export const SearchCmsContentQueryDocument = gql`
     ${CmsContentFieldsFragmentDoc}`;
 
 /**
- * __useSearchCmsContentQueryQuery__
+ * __useSearchCmsContentQuery__
  *
- * To run a query within a React component, call `useSearchCmsContentQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useSearchCmsContentQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSearchCmsContentQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSearchCmsContentQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSearchCmsContentQueryQuery({
+ * const { data, loading, error } = useSearchCmsContentQuery({
  *   variables: {
  *      name: // value for 'name'
  *   },
  * });
  */
-export function useSearchCmsContentQueryQuery(baseOptions?: Apollo.QueryHookOptions<SearchCmsContentQueryQuery, SearchCmsContentQueryQueryVariables>) {
-        return Apollo.useQuery<SearchCmsContentQueryQuery, SearchCmsContentQueryQueryVariables>(SearchCmsContentQueryDocument, baseOptions);
+export function useSearchCmsContentQuery(baseOptions?: Apollo.QueryHookOptions<SearchCmsContentQueryData, SearchCmsContentQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SearchCmsContentQueryData, SearchCmsContentQueryVariables>(SearchCmsContentQueryDocument, options);
       }
-export function useSearchCmsContentQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SearchCmsContentQueryQuery, SearchCmsContentQueryQueryVariables>) {
-          return Apollo.useLazyQuery<SearchCmsContentQueryQuery, SearchCmsContentQueryQueryVariables>(SearchCmsContentQueryDocument, baseOptions);
+export function useSearchCmsContentQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SearchCmsContentQueryData, SearchCmsContentQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SearchCmsContentQueryData, SearchCmsContentQueryVariables>(SearchCmsContentQueryDocument, options);
         }
-export type SearchCmsContentQueryQueryHookResult = ReturnType<typeof useSearchCmsContentQueryQuery>;
+export type SearchCmsContentQueryHookResult = ReturnType<typeof useSearchCmsContentQuery>;
 export type SearchCmsContentQueryLazyQueryHookResult = ReturnType<typeof useSearchCmsContentQueryLazyQuery>;
-export type SearchCmsContentQueryQueryResult = Apollo.QueryResult<SearchCmsContentQueryQuery, SearchCmsContentQueryQueryVariables>;
+export type SearchCmsContentQueryDataResult = Apollo.QueryResult<SearchCmsContentQueryData, SearchCmsContentQueryVariables>;

--- a/app/javascript/CmsAdmin/CmsFilesAdmin/FileUploadForm.tsx
+++ b/app/javascript/CmsAdmin/CmsFilesAdmin/FileUploadForm.tsx
@@ -11,8 +11,8 @@ import { useCreateMutation } from '../../MutationUtils';
 import useAsyncFunction from '../../useAsyncFunction';
 import ErrorDisplay from '../../ErrorDisplay';
 import { CmsFile } from '../../graphqlTypes.generated';
-import { CmsFilesAdminQueryQuery, CmsFilesAdminQueryQueryVariables } from './queries.generated';
-import { CreateCmsFileMutationVariables, CreateCmsFileMutation } from './mutations.generated';
+import { CmsFilesAdminQueryData, CmsFilesAdminQueryVariables } from './queries.generated';
+import { CreateCmsFileMutationVariables, CreateCmsFileMutationData } from './mutations.generated';
 
 export type FileUploadFormProps = {
   onUpload?: (cmsFile: CmsFile) => void;
@@ -25,10 +25,10 @@ function FileUploadForm({ onUpload }: FileUploadFormProps) {
   const fileInputId = useUniqueId('file-');
   const [createMutate, createError, createInProgress] = useAsyncFunction(
     useCreateMutation<
-      CmsFilesAdminQueryQuery,
-      CmsFilesAdminQueryQueryVariables,
+      CmsFilesAdminQueryData,
+      CmsFilesAdminQueryVariables,
       CreateCmsFileMutationVariables,
-      CreateCmsFileMutation
+      CreateCmsFileMutationData
     >(CreateCmsFile, {
       query: CmsFilesAdminQuery,
       arrayPath: ['cmsFiles'],

--- a/app/javascript/CmsAdmin/CmsFilesAdmin/index.tsx
+++ b/app/javascript/CmsAdmin/CmsFilesAdmin/index.tsx
@@ -15,21 +15,21 @@ import PageLoadingIndicator from '../../PageLoadingIndicator';
 import CopyToClipboardButton from '../../UIComponents/CopyToClipboardButton';
 import {
   DeleteCmsFileMutationVariables,
-  DeleteCmsFileMutation,
+  DeleteCmsFileMutationData,
   useRenameCmsFileMutation,
 } from './mutations.generated';
-import { useCmsFilesAdminQueryQuery } from './queries.generated';
+import { useCmsFilesAdminQuery } from './queries.generated';
 
 function CmsFilesAdmin() {
-  const { data, loading, error, refetch } = useCmsFilesAdminQueryQuery();
-  const deleteFileMutate = useDeleteMutation<DeleteCmsFileMutationVariables, DeleteCmsFileMutation>(
-    DeleteCmsFile,
-    {
-      query: CmsFilesAdminQuery,
-      arrayPath: ['cmsFiles'],
-      idVariablePath: ['id'],
-    },
-  );
+  const { data, loading, error, refetch } = useCmsFilesAdminQuery();
+  const deleteFileMutate = useDeleteMutation<
+    DeleteCmsFileMutationVariables,
+    DeleteCmsFileMutationData
+  >(DeleteCmsFile, {
+    query: CmsFilesAdminQuery,
+    arrayPath: ['cmsFiles'],
+    idVariablePath: ['id'],
+  });
   const [renameFileMutate] = useRenameCmsFileMutation();
   const confirm = useConfirm();
 

--- a/app/javascript/CmsAdmin/CmsFilesAdmin/mutations.generated.ts
+++ b/app/javascript/CmsAdmin/CmsFilesAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { CmsFileFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { CmsFileFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateCmsFileMutationVariables = Types.Exact<{
   file: Types.Scalars['Upload'];
 }>;
 
 
-export type CreateCmsFileMutation = (
+export type CreateCmsFileMutationData = (
   { __typename: 'Mutation' }
   & { createCmsFile?: Types.Maybe<(
     { __typename: 'CreateCmsFilePayload' }
@@ -28,7 +29,7 @@ export type RenameCmsFileMutationVariables = Types.Exact<{
 }>;
 
 
-export type RenameCmsFileMutation = (
+export type RenameCmsFileMutationData = (
   { __typename: 'Mutation' }
   & { renameCmsFile?: Types.Maybe<(
     { __typename: 'RenameCmsFilePayload' }
@@ -45,7 +46,7 @@ export type DeleteCmsFileMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteCmsFileMutation = (
+export type DeleteCmsFileMutationData = (
   { __typename: 'Mutation' }
   & { deleteCmsFile?: Types.Maybe<(
     { __typename: 'DeleteCmsFilePayload' }
@@ -64,7 +65,7 @@ export const CreateCmsFileDocument = gql`
   }
 }
     ${CmsFileFieldsFragmentDoc}`;
-export type CreateCmsFileMutationFn = Apollo.MutationFunction<CreateCmsFileMutation, CreateCmsFileMutationVariables>;
+export type CreateCmsFileMutationFn = Apollo.MutationFunction<CreateCmsFileMutationData, CreateCmsFileMutationVariables>;
 
 /**
  * __useCreateCmsFileMutation__
@@ -83,12 +84,13 @@ export type CreateCmsFileMutationFn = Apollo.MutationFunction<CreateCmsFileMutat
  *   },
  * });
  */
-export function useCreateCmsFileMutation(baseOptions?: Apollo.MutationHookOptions<CreateCmsFileMutation, CreateCmsFileMutationVariables>) {
-        return Apollo.useMutation<CreateCmsFileMutation, CreateCmsFileMutationVariables>(CreateCmsFileDocument, baseOptions);
+export function useCreateCmsFileMutation(baseOptions?: Apollo.MutationHookOptions<CreateCmsFileMutationData, CreateCmsFileMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateCmsFileMutationData, CreateCmsFileMutationVariables>(CreateCmsFileDocument, options);
       }
 export type CreateCmsFileMutationHookResult = ReturnType<typeof useCreateCmsFileMutation>;
-export type CreateCmsFileMutationResult = Apollo.MutationResult<CreateCmsFileMutation>;
-export type CreateCmsFileMutationOptions = Apollo.BaseMutationOptions<CreateCmsFileMutation, CreateCmsFileMutationVariables>;
+export type CreateCmsFileMutationResult = Apollo.MutationResult<CreateCmsFileMutationData>;
+export type CreateCmsFileMutationOptions = Apollo.BaseMutationOptions<CreateCmsFileMutationData, CreateCmsFileMutationVariables>;
 export const RenameCmsFileDocument = gql`
     mutation RenameCmsFile($id: Int!, $filename: String!) {
   renameCmsFile(input: {id: $id, filename: $filename}) {
@@ -99,7 +101,7 @@ export const RenameCmsFileDocument = gql`
   }
 }
     ${CmsFileFieldsFragmentDoc}`;
-export type RenameCmsFileMutationFn = Apollo.MutationFunction<RenameCmsFileMutation, RenameCmsFileMutationVariables>;
+export type RenameCmsFileMutationFn = Apollo.MutationFunction<RenameCmsFileMutationData, RenameCmsFileMutationVariables>;
 
 /**
  * __useRenameCmsFileMutation__
@@ -119,12 +121,13 @@ export type RenameCmsFileMutationFn = Apollo.MutationFunction<RenameCmsFileMutat
  *   },
  * });
  */
-export function useRenameCmsFileMutation(baseOptions?: Apollo.MutationHookOptions<RenameCmsFileMutation, RenameCmsFileMutationVariables>) {
-        return Apollo.useMutation<RenameCmsFileMutation, RenameCmsFileMutationVariables>(RenameCmsFileDocument, baseOptions);
+export function useRenameCmsFileMutation(baseOptions?: Apollo.MutationHookOptions<RenameCmsFileMutationData, RenameCmsFileMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RenameCmsFileMutationData, RenameCmsFileMutationVariables>(RenameCmsFileDocument, options);
       }
 export type RenameCmsFileMutationHookResult = ReturnType<typeof useRenameCmsFileMutation>;
-export type RenameCmsFileMutationResult = Apollo.MutationResult<RenameCmsFileMutation>;
-export type RenameCmsFileMutationOptions = Apollo.BaseMutationOptions<RenameCmsFileMutation, RenameCmsFileMutationVariables>;
+export type RenameCmsFileMutationResult = Apollo.MutationResult<RenameCmsFileMutationData>;
+export type RenameCmsFileMutationOptions = Apollo.BaseMutationOptions<RenameCmsFileMutationData, RenameCmsFileMutationVariables>;
 export const DeleteCmsFileDocument = gql`
     mutation DeleteCmsFile($id: Int!) {
   deleteCmsFile(input: {id: $id}) {
@@ -132,7 +135,7 @@ export const DeleteCmsFileDocument = gql`
   }
 }
     `;
-export type DeleteCmsFileMutationFn = Apollo.MutationFunction<DeleteCmsFileMutation, DeleteCmsFileMutationVariables>;
+export type DeleteCmsFileMutationFn = Apollo.MutationFunction<DeleteCmsFileMutationData, DeleteCmsFileMutationVariables>;
 
 /**
  * __useDeleteCmsFileMutation__
@@ -151,9 +154,10 @@ export type DeleteCmsFileMutationFn = Apollo.MutationFunction<DeleteCmsFileMutat
  *   },
  * });
  */
-export function useDeleteCmsFileMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCmsFileMutation, DeleteCmsFileMutationVariables>) {
-        return Apollo.useMutation<DeleteCmsFileMutation, DeleteCmsFileMutationVariables>(DeleteCmsFileDocument, baseOptions);
+export function useDeleteCmsFileMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCmsFileMutationData, DeleteCmsFileMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteCmsFileMutationData, DeleteCmsFileMutationVariables>(DeleteCmsFileDocument, options);
       }
 export type DeleteCmsFileMutationHookResult = ReturnType<typeof useDeleteCmsFileMutation>;
-export type DeleteCmsFileMutationResult = Apollo.MutationResult<DeleteCmsFileMutation>;
-export type DeleteCmsFileMutationOptions = Apollo.BaseMutationOptions<DeleteCmsFileMutation, DeleteCmsFileMutationVariables>;
+export type DeleteCmsFileMutationResult = Apollo.MutationResult<DeleteCmsFileMutationData>;
+export type DeleteCmsFileMutationOptions = Apollo.BaseMutationOptions<DeleteCmsFileMutationData, DeleteCmsFileMutationVariables>;

--- a/app/javascript/CmsAdmin/CmsFilesAdmin/queries.generated.ts
+++ b/app/javascript/CmsAdmin/CmsFilesAdmin/queries.generated.ts
@@ -3,15 +3,16 @@ import * as Types from '../../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CmsFileFieldsFragment = (
   { __typename: 'CmsFile' }
   & Pick<Types.CmsFile, 'id' | 'filename' | 'url' | 'content_type' | 'size' | 'current_ability_can_delete'>
 );
 
-export type CmsFilesAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CmsFilesAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CmsFilesAdminQueryQuery = (
+export type CmsFilesAdminQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -53,26 +54,28 @@ export const CmsFilesAdminQueryDocument = gql`
     ${CmsFileFieldsFragmentDoc}`;
 
 /**
- * __useCmsFilesAdminQueryQuery__
+ * __useCmsFilesAdminQuery__
  *
- * To run a query within a React component, call `useCmsFilesAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCmsFilesAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCmsFilesAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCmsFilesAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCmsFilesAdminQueryQuery({
+ * const { data, loading, error } = useCmsFilesAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCmsFilesAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<CmsFilesAdminQueryQuery, CmsFilesAdminQueryQueryVariables>) {
-        return Apollo.useQuery<CmsFilesAdminQueryQuery, CmsFilesAdminQueryQueryVariables>(CmsFilesAdminQueryDocument, baseOptions);
+export function useCmsFilesAdminQuery(baseOptions?: Apollo.QueryHookOptions<CmsFilesAdminQueryData, CmsFilesAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CmsFilesAdminQueryData, CmsFilesAdminQueryVariables>(CmsFilesAdminQueryDocument, options);
       }
-export function useCmsFilesAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsFilesAdminQueryQuery, CmsFilesAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CmsFilesAdminQueryQuery, CmsFilesAdminQueryQueryVariables>(CmsFilesAdminQueryDocument, baseOptions);
+export function useCmsFilesAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsFilesAdminQueryData, CmsFilesAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CmsFilesAdminQueryData, CmsFilesAdminQueryVariables>(CmsFilesAdminQueryDocument, options);
         }
-export type CmsFilesAdminQueryQueryHookResult = ReturnType<typeof useCmsFilesAdminQueryQuery>;
+export type CmsFilesAdminQueryHookResult = ReturnType<typeof useCmsFilesAdminQuery>;
 export type CmsFilesAdminQueryLazyQueryHookResult = ReturnType<typeof useCmsFilesAdminQueryLazyQuery>;
-export type CmsFilesAdminQueryQueryResult = Apollo.QueryResult<CmsFilesAdminQueryQuery, CmsFilesAdminQueryQueryVariables>;
+export type CmsFilesAdminQueryDataResult = Apollo.QueryResult<CmsFilesAdminQueryData, CmsFilesAdminQueryVariables>;

--- a/app/javascript/CmsAdmin/CmsGraphqlQueriesAdmin/CmsGraphqlQueriesAdminTable.tsx
+++ b/app/javascript/CmsAdmin/CmsGraphqlQueriesAdmin/CmsGraphqlQueriesAdminTable.tsx
@@ -7,10 +7,10 @@ import ErrorDisplay from '../../ErrorDisplay';
 import usePageTitle from '../../usePageTitle';
 import { useDeleteMutation } from '../../MutationUtils';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { useCmsGraphqlQueriesQueryQuery } from './queries.generated';
+import { useCmsGraphqlQueriesQuery } from './queries.generated';
 
 function CmsGraphqlQueriesAdminTable() {
-  const { data, loading, error } = useCmsGraphqlQueriesQueryQuery(); // lolcry
+  const { data, loading, error } = useCmsGraphqlQueriesQuery(); // lolcry
   const deleteCmsGraphqlQuery = useDeleteMutation(DeleteCmsGraphqlQuery, {
     query: CmsGraphqlQueriesQuery,
     idVariablePath: ['id'],

--- a/app/javascript/CmsAdmin/CmsGraphqlQueriesAdmin/EditCmsGraphqlQuery.tsx
+++ b/app/javascript/CmsAdmin/CmsGraphqlQueriesAdmin/EditCmsGraphqlQuery.tsx
@@ -8,17 +8,17 @@ import useAsyncFunction from '../../useAsyncFunction';
 import usePageTitle from '../../usePageTitle';
 
 import 'graphiql/graphiql.css';
-import { useCmsGraphqlQueriesQueryQuery } from './queries.generated';
-import { useUpdateCmsGraphqlQueryMutation } from './mutations.generated';
+import { useCmsGraphqlQueriesQuery } from './queries.generated';
+import { useUpdateCmsGraphqlQuery } from './mutations.generated';
 import { LoadSingleValueFromCollectionWrapper } from '../../GraphqlLoadingWrappers';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useCmsGraphqlQueriesQueryQuery,
+  useCmsGraphqlQueriesQuery,
   (data, id) => data?.cmsGraphqlQueries.find((q) => q.id.toString() === id),
   function EditCmsGraphqlQuery({ value: initialQuery }) {
     const history = useHistory();
     const [query, setQuery] = useState(initialQuery);
-    const [updateMutate] = useUpdateCmsGraphqlQueryMutation();
+    const [updateMutate] = useUpdateCmsGraphqlQuery();
     const apolloClient = useApolloClient();
 
     const saveClicked = async () => {

--- a/app/javascript/CmsAdmin/CmsGraphqlQueriesAdmin/ViewCmsGraphqlQuerySource.tsx
+++ b/app/javascript/CmsAdmin/CmsGraphqlQueriesAdmin/ViewCmsGraphqlQuerySource.tsx
@@ -6,12 +6,12 @@ import PageLoadingIndicator from '../../PageLoadingIndicator';
 import ErrorDisplay from '../../ErrorDisplay';
 
 import 'graphiql/graphiql.css';
-import { useCmsGraphqlQueriesQueryQuery } from './queries.generated';
+import { useCmsGraphqlQueriesQuery } from './queries.generated';
 import FourOhFourPage from '../../FourOhFourPage';
 
 function ViewCmsGraphqlQuerySource() {
   const { id } = useParams<{ id: string }>();
-  const { data, loading, error } = useCmsGraphqlQueriesQueryQuery();
+  const { data, loading, error } = useCmsGraphqlQueriesQuery();
   const query =
     loading || error ? null : data?.cmsGraphqlQueries.find((q) => q.id.toString() === id);
 

--- a/app/javascript/CmsAdmin/CmsGraphqlQueriesAdmin/mutations.generated.ts
+++ b/app/javascript/CmsAdmin/CmsGraphqlQueriesAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { CmsGraphqlQueryFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { CmsGraphqlQueryFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateCmsGraphqlQueryMutationVariables = Types.Exact<{
   query: Types.CmsGraphqlQueryInput;
 }>;
 
 
-export type CreateCmsGraphqlQueryMutation = (
+export type CreateCmsGraphqlQueryMutationData = (
   { __typename: 'Mutation' }
   & { createCmsGraphqlQuery?: Types.Maybe<(
     { __typename: 'CreateCmsGraphqlQueryPayload' }
@@ -28,7 +29,7 @@ export type UpdateCmsGraphqlQueryMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateCmsGraphqlQueryMutation = (
+export type UpdateCmsGraphqlQueryMutationData = (
   { __typename: 'Mutation' }
   & { updateCmsGraphqlQuery?: Types.Maybe<(
     { __typename: 'UpdateCmsGraphqlQueryPayload' }
@@ -45,7 +46,7 @@ export type DeleteCmsGraphqlQueryMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteCmsGraphqlQueryMutation = (
+export type DeleteCmsGraphqlQueryMutationData = (
   { __typename: 'Mutation' }
   & { deleteCmsGraphqlQuery?: Types.Maybe<(
     { __typename: 'DeleteCmsGraphqlQueryPayload' }
@@ -67,31 +68,32 @@ export const CreateCmsGraphqlQueryDocument = gql`
   }
 }
     ${CmsGraphqlQueryFieldsFragmentDoc}`;
-export type CreateCmsGraphqlQueryMutationFn = Apollo.MutationFunction<CreateCmsGraphqlQueryMutation, CreateCmsGraphqlQueryMutationVariables>;
+export type CreateCmsGraphqlQueryMutationFn = Apollo.MutationFunction<CreateCmsGraphqlQueryMutationData, CreateCmsGraphqlQueryMutationVariables>;
 
 /**
- * __useCreateCmsGraphqlQueryMutation__
+ * __useCreateCmsGraphqlQuery__
  *
- * To run a mutation, you first call `useCreateCmsGraphqlQueryMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCreateCmsGraphqlQueryMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useCreateCmsGraphqlQuery` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateCmsGraphqlQuery` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [createCmsGraphqlQueryMutation, { data, loading, error }] = useCreateCmsGraphqlQueryMutation({
+ * const [createCmsGraphqlQuery, { data, loading, error }] = useCreateCmsGraphqlQuery({
  *   variables: {
  *      query: // value for 'query'
  *   },
  * });
  */
-export function useCreateCmsGraphqlQueryMutation(baseOptions?: Apollo.MutationHookOptions<CreateCmsGraphqlQueryMutation, CreateCmsGraphqlQueryMutationVariables>) {
-        return Apollo.useMutation<CreateCmsGraphqlQueryMutation, CreateCmsGraphqlQueryMutationVariables>(CreateCmsGraphqlQueryDocument, baseOptions);
+export function useCreateCmsGraphqlQuery(baseOptions?: Apollo.MutationHookOptions<CreateCmsGraphqlQueryMutationData, CreateCmsGraphqlQueryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateCmsGraphqlQueryMutationData, CreateCmsGraphqlQueryMutationVariables>(CreateCmsGraphqlQueryDocument, options);
       }
-export type CreateCmsGraphqlQueryMutationHookResult = ReturnType<typeof useCreateCmsGraphqlQueryMutation>;
-export type CreateCmsGraphqlQueryMutationResult = Apollo.MutationResult<CreateCmsGraphqlQueryMutation>;
-export type CreateCmsGraphqlQueryMutationOptions = Apollo.BaseMutationOptions<CreateCmsGraphqlQueryMutation, CreateCmsGraphqlQueryMutationVariables>;
+export type CreateCmsGraphqlQueryHookResult = ReturnType<typeof useCreateCmsGraphqlQuery>;
+export type CreateCmsGraphqlQueryMutationResult = Apollo.MutationResult<CreateCmsGraphqlQueryMutationData>;
+export type CreateCmsGraphqlQueryMutationOptions = Apollo.BaseMutationOptions<CreateCmsGraphqlQueryMutationData, CreateCmsGraphqlQueryMutationVariables>;
 export const UpdateCmsGraphqlQueryDocument = gql`
     mutation UpdateCmsGraphqlQuery($id: Int!, $query: CmsGraphqlQueryInput!) {
   updateCmsGraphqlQuery(input: {id: $id, query: $query}) {
@@ -102,32 +104,33 @@ export const UpdateCmsGraphqlQueryDocument = gql`
   }
 }
     ${CmsGraphqlQueryFieldsFragmentDoc}`;
-export type UpdateCmsGraphqlQueryMutationFn = Apollo.MutationFunction<UpdateCmsGraphqlQueryMutation, UpdateCmsGraphqlQueryMutationVariables>;
+export type UpdateCmsGraphqlQueryMutationFn = Apollo.MutationFunction<UpdateCmsGraphqlQueryMutationData, UpdateCmsGraphqlQueryMutationVariables>;
 
 /**
- * __useUpdateCmsGraphqlQueryMutation__
+ * __useUpdateCmsGraphqlQuery__
  *
- * To run a mutation, you first call `useUpdateCmsGraphqlQueryMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateCmsGraphqlQueryMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useUpdateCmsGraphqlQuery` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateCmsGraphqlQuery` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [updateCmsGraphqlQueryMutation, { data, loading, error }] = useUpdateCmsGraphqlQueryMutation({
+ * const [updateCmsGraphqlQuery, { data, loading, error }] = useUpdateCmsGraphqlQuery({
  *   variables: {
  *      id: // value for 'id'
  *      query: // value for 'query'
  *   },
  * });
  */
-export function useUpdateCmsGraphqlQueryMutation(baseOptions?: Apollo.MutationHookOptions<UpdateCmsGraphqlQueryMutation, UpdateCmsGraphqlQueryMutationVariables>) {
-        return Apollo.useMutation<UpdateCmsGraphqlQueryMutation, UpdateCmsGraphqlQueryMutationVariables>(UpdateCmsGraphqlQueryDocument, baseOptions);
+export function useUpdateCmsGraphqlQuery(baseOptions?: Apollo.MutationHookOptions<UpdateCmsGraphqlQueryMutationData, UpdateCmsGraphqlQueryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateCmsGraphqlQueryMutationData, UpdateCmsGraphqlQueryMutationVariables>(UpdateCmsGraphqlQueryDocument, options);
       }
-export type UpdateCmsGraphqlQueryMutationHookResult = ReturnType<typeof useUpdateCmsGraphqlQueryMutation>;
-export type UpdateCmsGraphqlQueryMutationResult = Apollo.MutationResult<UpdateCmsGraphqlQueryMutation>;
-export type UpdateCmsGraphqlQueryMutationOptions = Apollo.BaseMutationOptions<UpdateCmsGraphqlQueryMutation, UpdateCmsGraphqlQueryMutationVariables>;
+export type UpdateCmsGraphqlQueryHookResult = ReturnType<typeof useUpdateCmsGraphqlQuery>;
+export type UpdateCmsGraphqlQueryMutationResult = Apollo.MutationResult<UpdateCmsGraphqlQueryMutationData>;
+export type UpdateCmsGraphqlQueryMutationOptions = Apollo.BaseMutationOptions<UpdateCmsGraphqlQueryMutationData, UpdateCmsGraphqlQueryMutationVariables>;
 export const DeleteCmsGraphqlQueryDocument = gql`
     mutation DeleteCmsGraphqlQuery($id: Int!) {
   deleteCmsGraphqlQuery(input: {id: $id}) {
@@ -137,28 +140,29 @@ export const DeleteCmsGraphqlQueryDocument = gql`
   }
 }
     `;
-export type DeleteCmsGraphqlQueryMutationFn = Apollo.MutationFunction<DeleteCmsGraphqlQueryMutation, DeleteCmsGraphqlQueryMutationVariables>;
+export type DeleteCmsGraphqlQueryMutationFn = Apollo.MutationFunction<DeleteCmsGraphqlQueryMutationData, DeleteCmsGraphqlQueryMutationVariables>;
 
 /**
- * __useDeleteCmsGraphqlQueryMutation__
+ * __useDeleteCmsGraphqlQuery__
  *
- * To run a mutation, you first call `useDeleteCmsGraphqlQueryMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useDeleteCmsGraphqlQueryMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useDeleteCmsGraphqlQuery` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteCmsGraphqlQuery` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [deleteCmsGraphqlQueryMutation, { data, loading, error }] = useDeleteCmsGraphqlQueryMutation({
+ * const [deleteCmsGraphqlQuery, { data, loading, error }] = useDeleteCmsGraphqlQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useDeleteCmsGraphqlQueryMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCmsGraphqlQueryMutation, DeleteCmsGraphqlQueryMutationVariables>) {
-        return Apollo.useMutation<DeleteCmsGraphqlQueryMutation, DeleteCmsGraphqlQueryMutationVariables>(DeleteCmsGraphqlQueryDocument, baseOptions);
+export function useDeleteCmsGraphqlQuery(baseOptions?: Apollo.MutationHookOptions<DeleteCmsGraphqlQueryMutationData, DeleteCmsGraphqlQueryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteCmsGraphqlQueryMutationData, DeleteCmsGraphqlQueryMutationVariables>(DeleteCmsGraphqlQueryDocument, options);
       }
-export type DeleteCmsGraphqlQueryMutationHookResult = ReturnType<typeof useDeleteCmsGraphqlQueryMutation>;
-export type DeleteCmsGraphqlQueryMutationResult = Apollo.MutationResult<DeleteCmsGraphqlQueryMutation>;
-export type DeleteCmsGraphqlQueryMutationOptions = Apollo.BaseMutationOptions<DeleteCmsGraphqlQueryMutation, DeleteCmsGraphqlQueryMutationVariables>;
+export type DeleteCmsGraphqlQueryHookResult = ReturnType<typeof useDeleteCmsGraphqlQuery>;
+export type DeleteCmsGraphqlQueryMutationResult = Apollo.MutationResult<DeleteCmsGraphqlQueryMutationData>;
+export type DeleteCmsGraphqlQueryMutationOptions = Apollo.BaseMutationOptions<DeleteCmsGraphqlQueryMutationData, DeleteCmsGraphqlQueryMutationVariables>;

--- a/app/javascript/CmsAdmin/CmsGraphqlQueriesAdmin/queries.generated.ts
+++ b/app/javascript/CmsAdmin/CmsGraphqlQueriesAdmin/queries.generated.ts
@@ -3,15 +3,16 @@ import * as Types from '../../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CmsGraphqlQueryFieldsFragment = (
   { __typename: 'CmsGraphqlQuery' }
   & Pick<Types.CmsGraphqlQuery, 'id' | 'identifier' | 'query' | 'admin_notes' | 'current_ability_can_update' | 'current_ability_can_delete'>
 );
 
-export type CmsGraphqlQueriesQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CmsGraphqlQueriesQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CmsGraphqlQueriesQueryQuery = (
+export type CmsGraphqlQueriesQueryData = (
   { __typename: 'Query' }
   & { cmsGraphqlQueries: Array<(
     { __typename: 'CmsGraphqlQuery' }
@@ -46,26 +47,28 @@ export const CmsGraphqlQueriesQueryDocument = gql`
     ${CmsGraphqlQueryFieldsFragmentDoc}`;
 
 /**
- * __useCmsGraphqlQueriesQueryQuery__
+ * __useCmsGraphqlQueriesQuery__
  *
- * To run a query within a React component, call `useCmsGraphqlQueriesQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCmsGraphqlQueriesQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCmsGraphqlQueriesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCmsGraphqlQueriesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCmsGraphqlQueriesQueryQuery({
+ * const { data, loading, error } = useCmsGraphqlQueriesQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCmsGraphqlQueriesQueryQuery(baseOptions?: Apollo.QueryHookOptions<CmsGraphqlQueriesQueryQuery, CmsGraphqlQueriesQueryQueryVariables>) {
-        return Apollo.useQuery<CmsGraphqlQueriesQueryQuery, CmsGraphqlQueriesQueryQueryVariables>(CmsGraphqlQueriesQueryDocument, baseOptions);
+export function useCmsGraphqlQueriesQuery(baseOptions?: Apollo.QueryHookOptions<CmsGraphqlQueriesQueryData, CmsGraphqlQueriesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CmsGraphqlQueriesQueryData, CmsGraphqlQueriesQueryVariables>(CmsGraphqlQueriesQueryDocument, options);
       }
-export function useCmsGraphqlQueriesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsGraphqlQueriesQueryQuery, CmsGraphqlQueriesQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CmsGraphqlQueriesQueryQuery, CmsGraphqlQueriesQueryQueryVariables>(CmsGraphqlQueriesQueryDocument, baseOptions);
+export function useCmsGraphqlQueriesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsGraphqlQueriesQueryData, CmsGraphqlQueriesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CmsGraphqlQueriesQueryData, CmsGraphqlQueriesQueryVariables>(CmsGraphqlQueriesQueryDocument, options);
         }
-export type CmsGraphqlQueriesQueryQueryHookResult = ReturnType<typeof useCmsGraphqlQueriesQueryQuery>;
+export type CmsGraphqlQueriesQueryHookResult = ReturnType<typeof useCmsGraphqlQueriesQuery>;
 export type CmsGraphqlQueriesQueryLazyQueryHookResult = ReturnType<typeof useCmsGraphqlQueriesQueryLazyQuery>;
-export type CmsGraphqlQueriesQueryQueryResult = Apollo.QueryResult<CmsGraphqlQueriesQueryQuery, CmsGraphqlQueriesQueryQueryVariables>;
+export type CmsGraphqlQueriesQueryDataResult = Apollo.QueryResult<CmsGraphqlQueriesQueryData, CmsGraphqlQueriesQueryVariables>;

--- a/app/javascript/CmsAdmin/CmsLayoutsAdmin/CmsLayoutsAdminTable.tsx
+++ b/app/javascript/CmsAdmin/CmsLayoutsAdmin/CmsLayoutsAdminTable.tsx
@@ -9,10 +9,10 @@ import { useConfirm } from '../../ModalDialogs/Confirm';
 import { useDeleteMutation } from '../../MutationUtils';
 import usePageTitle from '../../usePageTitle';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { useCmsLayoutsAdminQueryQuery } from './queries.generated';
+import { useCmsLayoutsAdminQuery } from './queries.generated';
 
 function CmsLayoutsAdminTable() {
-  const { data, loading, error } = useCmsLayoutsAdminQueryQuery();
+  const { data, loading, error } = useCmsLayoutsAdminQuery();
   const confirm = useConfirm();
   const deleteLayoutMutate = useDeleteMutation(DeleteLayout, {
     query: CmsLayoutsAdminQuery,

--- a/app/javascript/CmsAdmin/CmsLayoutsAdmin/EditCmsLayout.tsx
+++ b/app/javascript/CmsAdmin/CmsLayoutsAdmin/EditCmsLayout.tsx
@@ -8,12 +8,12 @@ import CmsLayoutForm from './CmsLayoutForm';
 import ErrorDisplay from '../../ErrorDisplay';
 import useAsyncFunction from '../../useAsyncFunction';
 import usePageTitle from '../../usePageTitle';
-import { useCmsLayoutsAdminQueryQuery } from './queries.generated';
+import { useCmsLayoutsAdminQuery } from './queries.generated';
 import { LoadSingleValueFromCollectionWrapper } from '../../GraphqlLoadingWrappers';
 import { useUpdateLayoutMutation } from './mutations.generated';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useCmsLayoutsAdminQueryQuery,
+  useCmsLayoutsAdminQuery,
   (data, id) => data.cmsLayouts.find((layout) => id === layout.id.toString()),
   function EditCmsLayout({ value: initialLayout }) {
     const history = useHistory();

--- a/app/javascript/CmsAdmin/CmsLayoutsAdmin/ViewCmsLayoutSource.tsx
+++ b/app/javascript/CmsAdmin/CmsLayoutsAdmin/ViewCmsLayoutSource.tsx
@@ -1,10 +1,10 @@
 import CmsLayoutForm from './CmsLayoutForm';
 import usePageTitle from '../../usePageTitle';
 import { LoadSingleValueFromCollectionWrapper } from '../../GraphqlLoadingWrappers';
-import { useCmsLayoutsAdminQueryQuery } from './queries.generated';
+import { useCmsLayoutsAdminQuery } from './queries.generated';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useCmsLayoutsAdminQueryQuery,
+  useCmsLayoutsAdminQuery,
   (data, id) => data.cmsLayouts.find((layout) => layout.id.toString() === id),
   function ViewCmsLayoutSource({ value }) {
     usePageTitle(`View “${value.name}” Source`);

--- a/app/javascript/CmsAdmin/CmsLayoutsAdmin/mutations.generated.ts
+++ b/app/javascript/CmsAdmin/CmsLayoutsAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { CmsLayoutFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { CmsLayoutFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateLayoutMutationVariables = Types.Exact<{
   cmsLayout: Types.CmsLayoutInput;
 }>;
 
 
-export type CreateLayoutMutation = (
+export type CreateLayoutMutationData = (
   { __typename: 'Mutation' }
   & { createCmsLayout?: Types.Maybe<(
     { __typename: 'CreateCmsLayoutPayload' }
@@ -28,7 +29,7 @@ export type UpdateLayoutMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateLayoutMutation = (
+export type UpdateLayoutMutationData = (
   { __typename: 'Mutation' }
   & { updateCmsLayout?: Types.Maybe<(
     { __typename: 'UpdateCmsLayoutPayload' }
@@ -45,7 +46,7 @@ export type DeleteLayoutMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteLayoutMutation = (
+export type DeleteLayoutMutationData = (
   { __typename: 'Mutation' }
   & { deleteCmsLayout?: Types.Maybe<(
     { __typename: 'DeleteCmsLayoutPayload' }
@@ -64,7 +65,7 @@ export const CreateLayoutDocument = gql`
   }
 }
     ${CmsLayoutFieldsFragmentDoc}`;
-export type CreateLayoutMutationFn = Apollo.MutationFunction<CreateLayoutMutation, CreateLayoutMutationVariables>;
+export type CreateLayoutMutationFn = Apollo.MutationFunction<CreateLayoutMutationData, CreateLayoutMutationVariables>;
 
 /**
  * __useCreateLayoutMutation__
@@ -83,12 +84,13 @@ export type CreateLayoutMutationFn = Apollo.MutationFunction<CreateLayoutMutatio
  *   },
  * });
  */
-export function useCreateLayoutMutation(baseOptions?: Apollo.MutationHookOptions<CreateLayoutMutation, CreateLayoutMutationVariables>) {
-        return Apollo.useMutation<CreateLayoutMutation, CreateLayoutMutationVariables>(CreateLayoutDocument, baseOptions);
+export function useCreateLayoutMutation(baseOptions?: Apollo.MutationHookOptions<CreateLayoutMutationData, CreateLayoutMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateLayoutMutationData, CreateLayoutMutationVariables>(CreateLayoutDocument, options);
       }
 export type CreateLayoutMutationHookResult = ReturnType<typeof useCreateLayoutMutation>;
-export type CreateLayoutMutationResult = Apollo.MutationResult<CreateLayoutMutation>;
-export type CreateLayoutMutationOptions = Apollo.BaseMutationOptions<CreateLayoutMutation, CreateLayoutMutationVariables>;
+export type CreateLayoutMutationResult = Apollo.MutationResult<CreateLayoutMutationData>;
+export type CreateLayoutMutationOptions = Apollo.BaseMutationOptions<CreateLayoutMutationData, CreateLayoutMutationVariables>;
 export const UpdateLayoutDocument = gql`
     mutation UpdateLayout($id: Int!, $cmsLayout: CmsLayoutInput!) {
   updateCmsLayout(input: {id: $id, cms_layout: $cmsLayout}) {
@@ -99,7 +101,7 @@ export const UpdateLayoutDocument = gql`
   }
 }
     ${CmsLayoutFieldsFragmentDoc}`;
-export type UpdateLayoutMutationFn = Apollo.MutationFunction<UpdateLayoutMutation, UpdateLayoutMutationVariables>;
+export type UpdateLayoutMutationFn = Apollo.MutationFunction<UpdateLayoutMutationData, UpdateLayoutMutationVariables>;
 
 /**
  * __useUpdateLayoutMutation__
@@ -119,12 +121,13 @@ export type UpdateLayoutMutationFn = Apollo.MutationFunction<UpdateLayoutMutatio
  *   },
  * });
  */
-export function useUpdateLayoutMutation(baseOptions?: Apollo.MutationHookOptions<UpdateLayoutMutation, UpdateLayoutMutationVariables>) {
-        return Apollo.useMutation<UpdateLayoutMutation, UpdateLayoutMutationVariables>(UpdateLayoutDocument, baseOptions);
+export function useUpdateLayoutMutation(baseOptions?: Apollo.MutationHookOptions<UpdateLayoutMutationData, UpdateLayoutMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateLayoutMutationData, UpdateLayoutMutationVariables>(UpdateLayoutDocument, options);
       }
 export type UpdateLayoutMutationHookResult = ReturnType<typeof useUpdateLayoutMutation>;
-export type UpdateLayoutMutationResult = Apollo.MutationResult<UpdateLayoutMutation>;
-export type UpdateLayoutMutationOptions = Apollo.BaseMutationOptions<UpdateLayoutMutation, UpdateLayoutMutationVariables>;
+export type UpdateLayoutMutationResult = Apollo.MutationResult<UpdateLayoutMutationData>;
+export type UpdateLayoutMutationOptions = Apollo.BaseMutationOptions<UpdateLayoutMutationData, UpdateLayoutMutationVariables>;
 export const DeleteLayoutDocument = gql`
     mutation DeleteLayout($id: Int!) {
   deleteCmsLayout(input: {id: $id}) {
@@ -132,7 +135,7 @@ export const DeleteLayoutDocument = gql`
   }
 }
     `;
-export type DeleteLayoutMutationFn = Apollo.MutationFunction<DeleteLayoutMutation, DeleteLayoutMutationVariables>;
+export type DeleteLayoutMutationFn = Apollo.MutationFunction<DeleteLayoutMutationData, DeleteLayoutMutationVariables>;
 
 /**
  * __useDeleteLayoutMutation__
@@ -151,9 +154,10 @@ export type DeleteLayoutMutationFn = Apollo.MutationFunction<DeleteLayoutMutatio
  *   },
  * });
  */
-export function useDeleteLayoutMutation(baseOptions?: Apollo.MutationHookOptions<DeleteLayoutMutation, DeleteLayoutMutationVariables>) {
-        return Apollo.useMutation<DeleteLayoutMutation, DeleteLayoutMutationVariables>(DeleteLayoutDocument, baseOptions);
+export function useDeleteLayoutMutation(baseOptions?: Apollo.MutationHookOptions<DeleteLayoutMutationData, DeleteLayoutMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteLayoutMutationData, DeleteLayoutMutationVariables>(DeleteLayoutDocument, options);
       }
 export type DeleteLayoutMutationHookResult = ReturnType<typeof useDeleteLayoutMutation>;
-export type DeleteLayoutMutationResult = Apollo.MutationResult<DeleteLayoutMutation>;
-export type DeleteLayoutMutationOptions = Apollo.BaseMutationOptions<DeleteLayoutMutation, DeleteLayoutMutationVariables>;
+export type DeleteLayoutMutationResult = Apollo.MutationResult<DeleteLayoutMutationData>;
+export type DeleteLayoutMutationOptions = Apollo.BaseMutationOptions<DeleteLayoutMutationData, DeleteLayoutMutationVariables>;

--- a/app/javascript/CmsAdmin/CmsLayoutsAdmin/queries.generated.ts
+++ b/app/javascript/CmsAdmin/CmsLayoutsAdmin/queries.generated.ts
@@ -3,15 +3,16 @@ import * as Types from '../../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CmsLayoutFieldsFragment = (
   { __typename: 'CmsLayout' }
   & Pick<Types.CmsLayout, 'id' | 'name' | 'content' | 'navbar_classes' | 'admin_notes' | 'current_ability_can_update' | 'current_ability_can_delete'>
 );
 
-export type CmsLayoutsAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CmsLayoutsAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CmsLayoutsAdminQueryQuery = (
+export type CmsLayoutsAdminQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -54,26 +55,28 @@ export const CmsLayoutsAdminQueryDocument = gql`
     ${CmsLayoutFieldsFragmentDoc}`;
 
 /**
- * __useCmsLayoutsAdminQueryQuery__
+ * __useCmsLayoutsAdminQuery__
  *
- * To run a query within a React component, call `useCmsLayoutsAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCmsLayoutsAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCmsLayoutsAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCmsLayoutsAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCmsLayoutsAdminQueryQuery({
+ * const { data, loading, error } = useCmsLayoutsAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCmsLayoutsAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<CmsLayoutsAdminQueryQuery, CmsLayoutsAdminQueryQueryVariables>) {
-        return Apollo.useQuery<CmsLayoutsAdminQueryQuery, CmsLayoutsAdminQueryQueryVariables>(CmsLayoutsAdminQueryDocument, baseOptions);
+export function useCmsLayoutsAdminQuery(baseOptions?: Apollo.QueryHookOptions<CmsLayoutsAdminQueryData, CmsLayoutsAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CmsLayoutsAdminQueryData, CmsLayoutsAdminQueryVariables>(CmsLayoutsAdminQueryDocument, options);
       }
-export function useCmsLayoutsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsLayoutsAdminQueryQuery, CmsLayoutsAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CmsLayoutsAdminQueryQuery, CmsLayoutsAdminQueryQueryVariables>(CmsLayoutsAdminQueryDocument, baseOptions);
+export function useCmsLayoutsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsLayoutsAdminQueryData, CmsLayoutsAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CmsLayoutsAdminQueryData, CmsLayoutsAdminQueryVariables>(CmsLayoutsAdminQueryDocument, options);
         }
-export type CmsLayoutsAdminQueryQueryHookResult = ReturnType<typeof useCmsLayoutsAdminQueryQuery>;
+export type CmsLayoutsAdminQueryHookResult = ReturnType<typeof useCmsLayoutsAdminQuery>;
 export type CmsLayoutsAdminQueryLazyQueryHookResult = ReturnType<typeof useCmsLayoutsAdminQueryLazyQuery>;
-export type CmsLayoutsAdminQueryQueryResult = Apollo.QueryResult<CmsLayoutsAdminQueryQuery, CmsLayoutsAdminQueryQueryVariables>;
+export type CmsLayoutsAdminQueryDataResult = Apollo.QueryResult<CmsLayoutsAdminQueryData, CmsLayoutsAdminQueryVariables>;

--- a/app/javascript/CmsAdmin/CmsPagesAdmin/CmsPageForm.tsx
+++ b/app/javascript/CmsAdmin/CmsPagesAdmin/CmsPageForm.tsx
@@ -8,7 +8,7 @@ import SelectWithLabel from '../../BuiltInFormControls/SelectWithLabel';
 import { sortByLocaleString } from '../../ValueUtils';
 import useUniqueId from '../../useUniqueId';
 import { CmsLayout, Page } from '../../graphqlTypes.generated';
-import { CmsPagesAdminQueryQuery } from './queries.generated';
+import { CmsPagesAdminQueryData } from './queries.generated';
 import { usePropertySetters } from '../../usePropertySetters';
 
 export type PageFormFields = Pick<
@@ -19,8 +19,8 @@ export type PageFormFields = Pick<
 export type CmsPageFormProps<T extends PageFormFields> = {
   page: T;
   onChange?: React.Dispatch<React.SetStateAction<T>>;
-  cmsParent: CmsPagesAdminQueryQuery['cmsParent'];
-  cmsLayouts: CmsPagesAdminQueryQuery['cmsLayouts'];
+  cmsParent: CmsPagesAdminQueryData['cmsParent'];
+  cmsLayouts: CmsPagesAdminQueryData['cmsLayouts'];
   readOnly?: boolean;
 };
 

--- a/app/javascript/CmsAdmin/CmsPagesAdmin/CmsPagesAdminTable.tsx
+++ b/app/javascript/CmsAdmin/CmsPagesAdmin/CmsPagesAdminTable.tsx
@@ -10,10 +10,10 @@ import { useDeleteMutation } from '../../MutationUtils';
 import useValueUnless from '../../useValueUnless';
 import usePageTitle from '../../usePageTitle';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { useCmsPagesAdminQueryQuery } from './queries.generated';
+import { useCmsPagesAdminQuery } from './queries.generated';
 
 function CmsPagesAdminTable() {
-  const { data, loading, error } = useCmsPagesAdminQueryQuery();
+  const { data, loading, error } = useCmsPagesAdminQuery();
   const confirm = useGraphQLConfirm();
   const deletePageMutate = useDeleteMutation(DeletePage, {
     query: CmsPagesAdminQuery,

--- a/app/javascript/CmsAdmin/CmsPagesAdmin/EditCmsPage.tsx
+++ b/app/javascript/CmsAdmin/CmsPagesAdmin/EditCmsPage.tsx
@@ -9,11 +9,11 @@ import ErrorDisplay from '../../ErrorDisplay';
 import useAsyncFunction from '../../useAsyncFunction';
 import usePageTitle from '../../usePageTitle';
 import { LoadSingleValueFromCollectionWrapper } from '../../GraphqlLoadingWrappers';
-import { useCmsPagesAdminQueryQuery } from './queries.generated';
+import { useCmsPagesAdminQuery } from './queries.generated';
 import { useUpdatePageMutation } from './mutations.generated';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useCmsPagesAdminQueryQuery,
+  useCmsPagesAdminQuery,
   (data, id) => data.cmsPages.find((p) => id === p.id.toString()),
   function EditCmsPageForm({ value: initialPage, data: { cmsLayouts, cmsParent } }) {
     const history = useHistory();

--- a/app/javascript/CmsAdmin/CmsPagesAdmin/NewCmsPage.tsx
+++ b/app/javascript/CmsAdmin/CmsPagesAdmin/NewCmsPage.tsx
@@ -12,11 +12,11 @@ import useAsyncFunction from '../../useAsyncFunction';
 import { useCreateMutation } from '../../MutationUtils';
 import usePageTitle from '../../usePageTitle';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { useCmsPagesAdminQueryQuery } from './queries.generated';
+import { useCmsPagesAdminQuery } from './queries.generated';
 
 function NewCmsPage() {
   const history = useHistory();
-  const { data, loading, error } = useCmsPagesAdminQueryQuery();
+  const { data, loading, error } = useCmsPagesAdminQuery();
   const [page, setPage] = useState<PageFormFields>({
     hidden_from_search: false,
   });

--- a/app/javascript/CmsAdmin/CmsPagesAdmin/ViewCmsPageSource.tsx
+++ b/app/javascript/CmsAdmin/CmsPagesAdmin/ViewCmsPageSource.tsx
@@ -1,10 +1,10 @@
 import CmsPageForm from './CmsPageForm';
 import usePageTitle from '../../usePageTitle';
 import { LoadSingleValueFromCollectionWrapper } from '../../GraphqlLoadingWrappers';
-import { useCmsPagesAdminQueryQuery } from './queries.generated';
+import { useCmsPagesAdminQuery } from './queries.generated';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useCmsPagesAdminQueryQuery,
+  useCmsPagesAdminQuery,
   (data, id) => data.cmsPages.find((p) => id === p.id.toString()),
   function ViewCmsPageSource({ value: page, data }) {
     usePageTitle(`View “${page.name}” Source`);

--- a/app/javascript/CmsAdmin/CmsPagesAdmin/mutations.generated.ts
+++ b/app/javascript/CmsAdmin/CmsPagesAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { CmsPageFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { CmsPageFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreatePageMutationVariables = Types.Exact<{
   page: Types.PageInput;
 }>;
 
 
-export type CreatePageMutation = (
+export type CreatePageMutationData = (
   { __typename: 'Mutation' }
   & { createPage?: Types.Maybe<(
     { __typename: 'CreatePagePayload' }
@@ -28,7 +29,7 @@ export type UpdatePageMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdatePageMutation = (
+export type UpdatePageMutationData = (
   { __typename: 'Mutation' }
   & { updatePage?: Types.Maybe<(
     { __typename: 'UpdatePagePayload' }
@@ -45,7 +46,7 @@ export type DeletePageMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeletePageMutation = (
+export type DeletePageMutationData = (
   { __typename: 'Mutation' }
   & { deletePage?: Types.Maybe<(
     { __typename: 'DeletePagePayload' }
@@ -64,7 +65,7 @@ export const CreatePageDocument = gql`
   }
 }
     ${CmsPageFieldsFragmentDoc}`;
-export type CreatePageMutationFn = Apollo.MutationFunction<CreatePageMutation, CreatePageMutationVariables>;
+export type CreatePageMutationFn = Apollo.MutationFunction<CreatePageMutationData, CreatePageMutationVariables>;
 
 /**
  * __useCreatePageMutation__
@@ -83,12 +84,13 @@ export type CreatePageMutationFn = Apollo.MutationFunction<CreatePageMutation, C
  *   },
  * });
  */
-export function useCreatePageMutation(baseOptions?: Apollo.MutationHookOptions<CreatePageMutation, CreatePageMutationVariables>) {
-        return Apollo.useMutation<CreatePageMutation, CreatePageMutationVariables>(CreatePageDocument, baseOptions);
+export function useCreatePageMutation(baseOptions?: Apollo.MutationHookOptions<CreatePageMutationData, CreatePageMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreatePageMutationData, CreatePageMutationVariables>(CreatePageDocument, options);
       }
 export type CreatePageMutationHookResult = ReturnType<typeof useCreatePageMutation>;
-export type CreatePageMutationResult = Apollo.MutationResult<CreatePageMutation>;
-export type CreatePageMutationOptions = Apollo.BaseMutationOptions<CreatePageMutation, CreatePageMutationVariables>;
+export type CreatePageMutationResult = Apollo.MutationResult<CreatePageMutationData>;
+export type CreatePageMutationOptions = Apollo.BaseMutationOptions<CreatePageMutationData, CreatePageMutationVariables>;
 export const UpdatePageDocument = gql`
     mutation UpdatePage($id: Int!, $page: PageInput!) {
   updatePage(input: {id: $id, page: $page}) {
@@ -99,7 +101,7 @@ export const UpdatePageDocument = gql`
   }
 }
     ${CmsPageFieldsFragmentDoc}`;
-export type UpdatePageMutationFn = Apollo.MutationFunction<UpdatePageMutation, UpdatePageMutationVariables>;
+export type UpdatePageMutationFn = Apollo.MutationFunction<UpdatePageMutationData, UpdatePageMutationVariables>;
 
 /**
  * __useUpdatePageMutation__
@@ -119,12 +121,13 @@ export type UpdatePageMutationFn = Apollo.MutationFunction<UpdatePageMutation, U
  *   },
  * });
  */
-export function useUpdatePageMutation(baseOptions?: Apollo.MutationHookOptions<UpdatePageMutation, UpdatePageMutationVariables>) {
-        return Apollo.useMutation<UpdatePageMutation, UpdatePageMutationVariables>(UpdatePageDocument, baseOptions);
+export function useUpdatePageMutation(baseOptions?: Apollo.MutationHookOptions<UpdatePageMutationData, UpdatePageMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdatePageMutationData, UpdatePageMutationVariables>(UpdatePageDocument, options);
       }
 export type UpdatePageMutationHookResult = ReturnType<typeof useUpdatePageMutation>;
-export type UpdatePageMutationResult = Apollo.MutationResult<UpdatePageMutation>;
-export type UpdatePageMutationOptions = Apollo.BaseMutationOptions<UpdatePageMutation, UpdatePageMutationVariables>;
+export type UpdatePageMutationResult = Apollo.MutationResult<UpdatePageMutationData>;
+export type UpdatePageMutationOptions = Apollo.BaseMutationOptions<UpdatePageMutationData, UpdatePageMutationVariables>;
 export const DeletePageDocument = gql`
     mutation DeletePage($id: Int!) {
   deletePage(input: {id: $id}) {
@@ -132,7 +135,7 @@ export const DeletePageDocument = gql`
   }
 }
     `;
-export type DeletePageMutationFn = Apollo.MutationFunction<DeletePageMutation, DeletePageMutationVariables>;
+export type DeletePageMutationFn = Apollo.MutationFunction<DeletePageMutationData, DeletePageMutationVariables>;
 
 /**
  * __useDeletePageMutation__
@@ -151,9 +154,10 @@ export type DeletePageMutationFn = Apollo.MutationFunction<DeletePageMutation, D
  *   },
  * });
  */
-export function useDeletePageMutation(baseOptions?: Apollo.MutationHookOptions<DeletePageMutation, DeletePageMutationVariables>) {
-        return Apollo.useMutation<DeletePageMutation, DeletePageMutationVariables>(DeletePageDocument, baseOptions);
+export function useDeletePageMutation(baseOptions?: Apollo.MutationHookOptions<DeletePageMutationData, DeletePageMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeletePageMutationData, DeletePageMutationVariables>(DeletePageDocument, options);
       }
 export type DeletePageMutationHookResult = ReturnType<typeof useDeletePageMutation>;
-export type DeletePageMutationResult = Apollo.MutationResult<DeletePageMutation>;
-export type DeletePageMutationOptions = Apollo.BaseMutationOptions<DeletePageMutation, DeletePageMutationVariables>;
+export type DeletePageMutationResult = Apollo.MutationResult<DeletePageMutationData>;
+export type DeletePageMutationOptions = Apollo.BaseMutationOptions<DeletePageMutationData, DeletePageMutationVariables>;

--- a/app/javascript/CmsAdmin/CmsPagesAdmin/queries.generated.ts
+++ b/app/javascript/CmsAdmin/CmsPagesAdmin/queries.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '../../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CmsPageAdminLayoutFieldsFragment = (
   { __typename: 'CmsLayout' }
   & Pick<Types.CmsLayout, 'id' | 'name'>
@@ -18,10 +19,10 @@ export type CmsPageFieldsFragment = (
   )> }
 );
 
-export type CmsPagesAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CmsPagesAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CmsPagesAdminQueryQuery = (
+export type CmsPagesAdminQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -117,26 +118,28 @@ export const CmsPagesAdminQueryDocument = gql`
 ${CmsPageAdminLayoutFieldsFragmentDoc}`;
 
 /**
- * __useCmsPagesAdminQueryQuery__
+ * __useCmsPagesAdminQuery__
  *
- * To run a query within a React component, call `useCmsPagesAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCmsPagesAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCmsPagesAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCmsPagesAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCmsPagesAdminQueryQuery({
+ * const { data, loading, error } = useCmsPagesAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCmsPagesAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<CmsPagesAdminQueryQuery, CmsPagesAdminQueryQueryVariables>) {
-        return Apollo.useQuery<CmsPagesAdminQueryQuery, CmsPagesAdminQueryQueryVariables>(CmsPagesAdminQueryDocument, baseOptions);
+export function useCmsPagesAdminQuery(baseOptions?: Apollo.QueryHookOptions<CmsPagesAdminQueryData, CmsPagesAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CmsPagesAdminQueryData, CmsPagesAdminQueryVariables>(CmsPagesAdminQueryDocument, options);
       }
-export function useCmsPagesAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsPagesAdminQueryQuery, CmsPagesAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CmsPagesAdminQueryQuery, CmsPagesAdminQueryQueryVariables>(CmsPagesAdminQueryDocument, baseOptions);
+export function useCmsPagesAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsPagesAdminQueryData, CmsPagesAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CmsPagesAdminQueryData, CmsPagesAdminQueryVariables>(CmsPagesAdminQueryDocument, options);
         }
-export type CmsPagesAdminQueryQueryHookResult = ReturnType<typeof useCmsPagesAdminQueryQuery>;
+export type CmsPagesAdminQueryHookResult = ReturnType<typeof useCmsPagesAdminQuery>;
 export type CmsPagesAdminQueryLazyQueryHookResult = ReturnType<typeof useCmsPagesAdminQueryLazyQuery>;
-export type CmsPagesAdminQueryQueryResult = Apollo.QueryResult<CmsPagesAdminQueryQuery, CmsPagesAdminQueryQueryVariables>;
+export type CmsPagesAdminQueryDataResult = Apollo.QueryResult<CmsPagesAdminQueryData, CmsPagesAdminQueryVariables>;

--- a/app/javascript/CmsAdmin/CmsPartialsAdmin/CmsPartialsAdminTable.tsx
+++ b/app/javascript/CmsAdmin/CmsPartialsAdmin/CmsPartialsAdminTable.tsx
@@ -9,10 +9,10 @@ import { useConfirm } from '../../ModalDialogs/Confirm';
 import { useDeleteMutation } from '../../MutationUtils';
 import usePageTitle from '../../usePageTitle';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { useCmsPartialsAdminQueryQuery } from './queries.generated';
+import { useCmsPartialsAdminQuery } from './queries.generated';
 
 function CmsPartialsAdminTable() {
-  const { data, loading, error } = useCmsPartialsAdminQueryQuery();
+  const { data, loading, error } = useCmsPartialsAdminQuery();
   const confirm = useConfirm();
   const deletePartialMutate = useDeleteMutation(DeletePartial, {
     query: CmsPartialsAdminQuery,

--- a/app/javascript/CmsAdmin/CmsPartialsAdmin/EditCmsPartial.tsx
+++ b/app/javascript/CmsAdmin/CmsPartialsAdmin/EditCmsPartial.tsx
@@ -9,11 +9,11 @@ import ErrorDisplay from '../../ErrorDisplay';
 import useAsyncFunction from '../../useAsyncFunction';
 import usePageTitle from '../../usePageTitle';
 import { LoadSingleValueFromCollectionWrapper } from '../../GraphqlLoadingWrappers';
-import { useCmsPartialsAdminQueryQuery } from './queries.generated';
+import { useCmsPartialsAdminQuery } from './queries.generated';
 import { useUpdatePartialMutation } from './mutations.generated';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useCmsPartialsAdminQueryQuery,
+  useCmsPartialsAdminQuery,
   (data, id) => data.cmsPartials.find((p) => id === p.id.toString()),
   function EditCmsPartialForm({ value: initialPartial }) {
     const history = useHistory();

--- a/app/javascript/CmsAdmin/CmsPartialsAdmin/ViewCmsPartialSource.tsx
+++ b/app/javascript/CmsAdmin/CmsPartialsAdmin/ViewCmsPartialSource.tsx
@@ -1,10 +1,10 @@
 import CmsPartialForm from './CmsPartialForm';
 import usePageTitle from '../../usePageTitle';
 import { LoadSingleValueFromCollectionWrapper } from '../../GraphqlLoadingWrappers';
-import { useCmsPartialsAdminQueryQuery } from './queries.generated';
+import { useCmsPartialsAdminQuery } from './queries.generated';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useCmsPartialsAdminQueryQuery,
+  useCmsPartialsAdminQuery,
   (data, id) => data.cmsPartials.find((p) => id === p.id.toString()),
 
   function ViewCmsPartialSource({ value: partial }) {

--- a/app/javascript/CmsAdmin/CmsPartialsAdmin/mutations.generated.ts
+++ b/app/javascript/CmsAdmin/CmsPartialsAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { CmsPartialFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { CmsPartialFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreatePartialMutationVariables = Types.Exact<{
   cmsPartial: Types.CmsPartialInput;
 }>;
 
 
-export type CreatePartialMutation = (
+export type CreatePartialMutationData = (
   { __typename: 'Mutation' }
   & { createCmsPartial?: Types.Maybe<(
     { __typename: 'CreateCmsPartialPayload' }
@@ -28,7 +29,7 @@ export type UpdatePartialMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdatePartialMutation = (
+export type UpdatePartialMutationData = (
   { __typename: 'Mutation' }
   & { updateCmsPartial?: Types.Maybe<(
     { __typename: 'UpdateCmsPartialPayload' }
@@ -45,7 +46,7 @@ export type DeletePartialMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeletePartialMutation = (
+export type DeletePartialMutationData = (
   { __typename: 'Mutation' }
   & { deleteCmsPartial?: Types.Maybe<(
     { __typename: 'DeleteCmsPartialPayload' }
@@ -64,7 +65,7 @@ export const CreatePartialDocument = gql`
   }
 }
     ${CmsPartialFieldsFragmentDoc}`;
-export type CreatePartialMutationFn = Apollo.MutationFunction<CreatePartialMutation, CreatePartialMutationVariables>;
+export type CreatePartialMutationFn = Apollo.MutationFunction<CreatePartialMutationData, CreatePartialMutationVariables>;
 
 /**
  * __useCreatePartialMutation__
@@ -83,12 +84,13 @@ export type CreatePartialMutationFn = Apollo.MutationFunction<CreatePartialMutat
  *   },
  * });
  */
-export function useCreatePartialMutation(baseOptions?: Apollo.MutationHookOptions<CreatePartialMutation, CreatePartialMutationVariables>) {
-        return Apollo.useMutation<CreatePartialMutation, CreatePartialMutationVariables>(CreatePartialDocument, baseOptions);
+export function useCreatePartialMutation(baseOptions?: Apollo.MutationHookOptions<CreatePartialMutationData, CreatePartialMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreatePartialMutationData, CreatePartialMutationVariables>(CreatePartialDocument, options);
       }
 export type CreatePartialMutationHookResult = ReturnType<typeof useCreatePartialMutation>;
-export type CreatePartialMutationResult = Apollo.MutationResult<CreatePartialMutation>;
-export type CreatePartialMutationOptions = Apollo.BaseMutationOptions<CreatePartialMutation, CreatePartialMutationVariables>;
+export type CreatePartialMutationResult = Apollo.MutationResult<CreatePartialMutationData>;
+export type CreatePartialMutationOptions = Apollo.BaseMutationOptions<CreatePartialMutationData, CreatePartialMutationVariables>;
 export const UpdatePartialDocument = gql`
     mutation UpdatePartial($id: Int!, $cmsPartial: CmsPartialInput!) {
   updateCmsPartial(input: {id: $id, cms_partial: $cmsPartial}) {
@@ -99,7 +101,7 @@ export const UpdatePartialDocument = gql`
   }
 }
     ${CmsPartialFieldsFragmentDoc}`;
-export type UpdatePartialMutationFn = Apollo.MutationFunction<UpdatePartialMutation, UpdatePartialMutationVariables>;
+export type UpdatePartialMutationFn = Apollo.MutationFunction<UpdatePartialMutationData, UpdatePartialMutationVariables>;
 
 /**
  * __useUpdatePartialMutation__
@@ -119,12 +121,13 @@ export type UpdatePartialMutationFn = Apollo.MutationFunction<UpdatePartialMutat
  *   },
  * });
  */
-export function useUpdatePartialMutation(baseOptions?: Apollo.MutationHookOptions<UpdatePartialMutation, UpdatePartialMutationVariables>) {
-        return Apollo.useMutation<UpdatePartialMutation, UpdatePartialMutationVariables>(UpdatePartialDocument, baseOptions);
+export function useUpdatePartialMutation(baseOptions?: Apollo.MutationHookOptions<UpdatePartialMutationData, UpdatePartialMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdatePartialMutationData, UpdatePartialMutationVariables>(UpdatePartialDocument, options);
       }
 export type UpdatePartialMutationHookResult = ReturnType<typeof useUpdatePartialMutation>;
-export type UpdatePartialMutationResult = Apollo.MutationResult<UpdatePartialMutation>;
-export type UpdatePartialMutationOptions = Apollo.BaseMutationOptions<UpdatePartialMutation, UpdatePartialMutationVariables>;
+export type UpdatePartialMutationResult = Apollo.MutationResult<UpdatePartialMutationData>;
+export type UpdatePartialMutationOptions = Apollo.BaseMutationOptions<UpdatePartialMutationData, UpdatePartialMutationVariables>;
 export const DeletePartialDocument = gql`
     mutation DeletePartial($id: Int!) {
   deleteCmsPartial(input: {id: $id}) {
@@ -132,7 +135,7 @@ export const DeletePartialDocument = gql`
   }
 }
     `;
-export type DeletePartialMutationFn = Apollo.MutationFunction<DeletePartialMutation, DeletePartialMutationVariables>;
+export type DeletePartialMutationFn = Apollo.MutationFunction<DeletePartialMutationData, DeletePartialMutationVariables>;
 
 /**
  * __useDeletePartialMutation__
@@ -151,9 +154,10 @@ export type DeletePartialMutationFn = Apollo.MutationFunction<DeletePartialMutat
  *   },
  * });
  */
-export function useDeletePartialMutation(baseOptions?: Apollo.MutationHookOptions<DeletePartialMutation, DeletePartialMutationVariables>) {
-        return Apollo.useMutation<DeletePartialMutation, DeletePartialMutationVariables>(DeletePartialDocument, baseOptions);
+export function useDeletePartialMutation(baseOptions?: Apollo.MutationHookOptions<DeletePartialMutationData, DeletePartialMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeletePartialMutationData, DeletePartialMutationVariables>(DeletePartialDocument, options);
       }
 export type DeletePartialMutationHookResult = ReturnType<typeof useDeletePartialMutation>;
-export type DeletePartialMutationResult = Apollo.MutationResult<DeletePartialMutation>;
-export type DeletePartialMutationOptions = Apollo.BaseMutationOptions<DeletePartialMutation, DeletePartialMutationVariables>;
+export type DeletePartialMutationResult = Apollo.MutationResult<DeletePartialMutationData>;
+export type DeletePartialMutationOptions = Apollo.BaseMutationOptions<DeletePartialMutationData, DeletePartialMutationVariables>;

--- a/app/javascript/CmsAdmin/CmsPartialsAdmin/queries.generated.ts
+++ b/app/javascript/CmsAdmin/CmsPartialsAdmin/queries.generated.ts
@@ -3,15 +3,16 @@ import * as Types from '../../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CmsPartialFieldsFragment = (
   { __typename: 'CmsPartial' }
   & Pick<Types.CmsPartial, 'id' | 'name' | 'content' | 'admin_notes' | 'current_ability_can_update' | 'current_ability_can_delete'>
 );
 
-export type CmsPartialsAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CmsPartialsAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CmsPartialsAdminQueryQuery = (
+export type CmsPartialsAdminQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -53,26 +54,28 @@ export const CmsPartialsAdminQueryDocument = gql`
     ${CmsPartialFieldsFragmentDoc}`;
 
 /**
- * __useCmsPartialsAdminQueryQuery__
+ * __useCmsPartialsAdminQuery__
  *
- * To run a query within a React component, call `useCmsPartialsAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCmsPartialsAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCmsPartialsAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCmsPartialsAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCmsPartialsAdminQueryQuery({
+ * const { data, loading, error } = useCmsPartialsAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCmsPartialsAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<CmsPartialsAdminQueryQuery, CmsPartialsAdminQueryQueryVariables>) {
-        return Apollo.useQuery<CmsPartialsAdminQueryQuery, CmsPartialsAdminQueryQueryVariables>(CmsPartialsAdminQueryDocument, baseOptions);
+export function useCmsPartialsAdminQuery(baseOptions?: Apollo.QueryHookOptions<CmsPartialsAdminQueryData, CmsPartialsAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CmsPartialsAdminQueryData, CmsPartialsAdminQueryVariables>(CmsPartialsAdminQueryDocument, options);
       }
-export function useCmsPartialsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsPartialsAdminQueryQuery, CmsPartialsAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CmsPartialsAdminQueryQuery, CmsPartialsAdminQueryQueryVariables>(CmsPartialsAdminQueryDocument, baseOptions);
+export function useCmsPartialsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsPartialsAdminQueryData, CmsPartialsAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CmsPartialsAdminQueryData, CmsPartialsAdminQueryVariables>(CmsPartialsAdminQueryDocument, options);
         }
-export type CmsPartialsAdminQueryQueryHookResult = ReturnType<typeof useCmsPartialsAdminQueryQuery>;
+export type CmsPartialsAdminQueryHookResult = ReturnType<typeof useCmsPartialsAdminQuery>;
 export type CmsPartialsAdminQueryLazyQueryHookResult = ReturnType<typeof useCmsPartialsAdminQueryLazyQuery>;
-export type CmsPartialsAdminQueryQueryResult = Apollo.QueryResult<CmsPartialsAdminQueryQuery, CmsPartialsAdminQueryQueryVariables>;
+export type CmsPartialsAdminQueryDataResult = Apollo.QueryResult<CmsPartialsAdminQueryData, CmsPartialsAdminQueryVariables>;

--- a/app/javascript/CmsAdmin/CmsVariablesAdmin/AddVariableRow.tsx
+++ b/app/javascript/CmsAdmin/CmsVariablesAdmin/AddVariableRow.tsx
@@ -4,9 +4,9 @@ import { ApolloError, useApolloClient } from '@apollo/client';
 import ErrorDisplay from '../../ErrorDisplay';
 import updateCmsVariable from './updateCmsVariable';
 import useAsyncFunction from '../../useAsyncFunction';
-import { CmsVariablesQueryQuery, useSetCmsVariableMutationMutation } from './queries.generated';
+import { CmsVariablesQueryData, useSetCmsVariableMutation } from './queries.generated';
 
-export type AddingVariable = Omit<CmsVariablesQueryQuery['cmsVariables'][0], 'id'> & {
+export type AddingVariable = Omit<CmsVariablesQueryData['cmsVariables'][0], 'id'> & {
   generatedId: number;
 };
 
@@ -18,7 +18,7 @@ export type AddVariableRowProps = {
 };
 
 function AddVariableRow({ variable, onChange, onSave, onCancel }: AddVariableRowProps) {
-  const [setCmsVariableMutate] = useSetCmsVariableMutationMutation();
+  const [setCmsVariableMutate] = useSetCmsVariableMutation();
   const [setCmsVariable, setError, setInProgress] = useAsyncFunction(setCmsVariableMutate);
   const apolloClient = useApolloClient();
 

--- a/app/javascript/CmsAdmin/CmsVariablesAdmin/ExistingVariableRow.tsx
+++ b/app/javascript/CmsAdmin/CmsVariablesAdmin/ExistingVariableRow.tsx
@@ -6,14 +6,14 @@ import ErrorDisplay from '../../ErrorDisplay';
 import { CmsVariablesQuery, DeleteCmsVariableMutation } from './queries';
 import useAsyncFunction from '../../useAsyncFunction';
 import { useDeleteMutation } from '../../MutationUtils';
-import { CmsVariablesQueryQuery, useSetCmsVariableMutationMutation } from './queries.generated';
+import { CmsVariablesQueryData, useSetCmsVariableMutation } from './queries.generated';
 
 export type ExistingVariableRowProps = {
-  variable: CmsVariablesQueryQuery['cmsVariables'][0];
+  variable: CmsVariablesQueryData['cmsVariables'][0];
 };
 
 function ExistingVariableRow({ variable }: ExistingVariableRowProps) {
-  const [setVariableMutate] = useSetCmsVariableMutationMutation();
+  const [setVariableMutate] = useSetCmsVariableMutation();
   const [setVariable, setVariableError, , clearSetVariableError] = useAsyncFunction(
     setVariableMutate,
   );

--- a/app/javascript/CmsAdmin/CmsVariablesAdmin/index.tsx
+++ b/app/javascript/CmsAdmin/CmsVariablesAdmin/index.tsx
@@ -6,10 +6,10 @@ import usePageTitle from '../../usePageTitle';
 import ErrorDisplay from '../../ErrorDisplay';
 import { sortByLocaleString } from '../../ValueUtils';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { useCmsVariablesQueryQuery } from './queries.generated';
+import { useCmsVariablesQuery } from './queries.generated';
 
 function CmsVariablesAdmin() {
-  const { data, loading, error } = useCmsVariablesQueryQuery();
+  const { data, loading, error } = useCmsVariablesQuery();
   const [addingVariables, setAddingVariables] = useState<AddingVariable[]>([]);
 
   const addVariable = useCallback(

--- a/app/javascript/CmsAdmin/CmsVariablesAdmin/queries.generated.ts
+++ b/app/javascript/CmsAdmin/CmsVariablesAdmin/queries.generated.ts
@@ -3,15 +3,16 @@ import * as Types from '../../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CmsVariableFieldsFragment = (
   { __typename: 'CmsVariable' }
   & Pick<Types.CmsVariable, 'id' | 'key' | 'value_json' | 'current_ability_can_update' | 'current_ability_can_delete'>
 );
 
-export type CmsVariablesQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CmsVariablesQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CmsVariablesQueryQuery = (
+export type CmsVariablesQueryData = (
   { __typename: 'Query' }
   & { cmsVariables: Array<(
     { __typename: 'CmsVariable' }
@@ -23,13 +24,13 @@ export type CmsVariablesQueryQuery = (
   ) }
 );
 
-export type SetCmsVariableMutationMutationVariables = Types.Exact<{
+export type SetCmsVariableMutationVariables = Types.Exact<{
   key: Types.Scalars['String'];
   value_json: Types.Scalars['String'];
 }>;
 
 
-export type SetCmsVariableMutationMutation = (
+export type SetCmsVariableMutationData = (
   { __typename: 'Mutation' }
   & { setCmsVariable?: Types.Maybe<(
     { __typename: 'SetCmsVariablePayload' }
@@ -41,12 +42,12 @@ export type SetCmsVariableMutationMutation = (
   )> }
 );
 
-export type DeleteCmsVariableMutationMutationVariables = Types.Exact<{
+export type DeleteCmsVariableMutationVariables = Types.Exact<{
   key: Types.Scalars['String'];
 }>;
 
 
-export type DeleteCmsVariableMutationMutation = (
+export type DeleteCmsVariableMutationData = (
   { __typename: 'Mutation' }
   & { deleteCmsVariable?: Types.Maybe<(
     { __typename: 'DeleteCmsVariablePayload' }
@@ -80,29 +81,31 @@ export const CmsVariablesQueryDocument = gql`
     ${CmsVariableFieldsFragmentDoc}`;
 
 /**
- * __useCmsVariablesQueryQuery__
+ * __useCmsVariablesQuery__
  *
- * To run a query within a React component, call `useCmsVariablesQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCmsVariablesQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCmsVariablesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCmsVariablesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCmsVariablesQueryQuery({
+ * const { data, loading, error } = useCmsVariablesQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCmsVariablesQueryQuery(baseOptions?: Apollo.QueryHookOptions<CmsVariablesQueryQuery, CmsVariablesQueryQueryVariables>) {
-        return Apollo.useQuery<CmsVariablesQueryQuery, CmsVariablesQueryQueryVariables>(CmsVariablesQueryDocument, baseOptions);
+export function useCmsVariablesQuery(baseOptions?: Apollo.QueryHookOptions<CmsVariablesQueryData, CmsVariablesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CmsVariablesQueryData, CmsVariablesQueryVariables>(CmsVariablesQueryDocument, options);
       }
-export function useCmsVariablesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsVariablesQueryQuery, CmsVariablesQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CmsVariablesQueryQuery, CmsVariablesQueryQueryVariables>(CmsVariablesQueryDocument, baseOptions);
+export function useCmsVariablesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsVariablesQueryData, CmsVariablesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CmsVariablesQueryData, CmsVariablesQueryVariables>(CmsVariablesQueryDocument, options);
         }
-export type CmsVariablesQueryQueryHookResult = ReturnType<typeof useCmsVariablesQueryQuery>;
+export type CmsVariablesQueryHookResult = ReturnType<typeof useCmsVariablesQuery>;
 export type CmsVariablesQueryLazyQueryHookResult = ReturnType<typeof useCmsVariablesQueryLazyQuery>;
-export type CmsVariablesQueryQueryResult = Apollo.QueryResult<CmsVariablesQueryQuery, CmsVariablesQueryQueryVariables>;
+export type CmsVariablesQueryDataResult = Apollo.QueryResult<CmsVariablesQueryData, CmsVariablesQueryVariables>;
 export const SetCmsVariableMutationDocument = gql`
     mutation SetCmsVariableMutation($key: String!, $value_json: String!) {
   setCmsVariable(input: {cms_variable: {key: $key, value_json: $value_json}}) {
@@ -113,32 +116,33 @@ export const SetCmsVariableMutationDocument = gql`
   }
 }
     ${CmsVariableFieldsFragmentDoc}`;
-export type SetCmsVariableMutationMutationFn = Apollo.MutationFunction<SetCmsVariableMutationMutation, SetCmsVariableMutationMutationVariables>;
+export type SetCmsVariableMutationMutationFn = Apollo.MutationFunction<SetCmsVariableMutationData, SetCmsVariableMutationVariables>;
 
 /**
- * __useSetCmsVariableMutationMutation__
+ * __useSetCmsVariableMutation__
  *
- * To run a mutation, you first call `useSetCmsVariableMutationMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useSetCmsVariableMutationMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useSetCmsVariableMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useSetCmsVariableMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [setCmsVariableMutationMutation, { data, loading, error }] = useSetCmsVariableMutationMutation({
+ * const [setCmsVariableMutation, { data, loading, error }] = useSetCmsVariableMutation({
  *   variables: {
  *      key: // value for 'key'
  *      value_json: // value for 'value_json'
  *   },
  * });
  */
-export function useSetCmsVariableMutationMutation(baseOptions?: Apollo.MutationHookOptions<SetCmsVariableMutationMutation, SetCmsVariableMutationMutationVariables>) {
-        return Apollo.useMutation<SetCmsVariableMutationMutation, SetCmsVariableMutationMutationVariables>(SetCmsVariableMutationDocument, baseOptions);
+export function useSetCmsVariableMutation(baseOptions?: Apollo.MutationHookOptions<SetCmsVariableMutationData, SetCmsVariableMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SetCmsVariableMutationData, SetCmsVariableMutationVariables>(SetCmsVariableMutationDocument, options);
       }
-export type SetCmsVariableMutationMutationHookResult = ReturnType<typeof useSetCmsVariableMutationMutation>;
-export type SetCmsVariableMutationMutationResult = Apollo.MutationResult<SetCmsVariableMutationMutation>;
-export type SetCmsVariableMutationMutationOptions = Apollo.BaseMutationOptions<SetCmsVariableMutationMutation, SetCmsVariableMutationMutationVariables>;
+export type SetCmsVariableMutationHookResult = ReturnType<typeof useSetCmsVariableMutation>;
+export type SetCmsVariableMutationMutationResult = Apollo.MutationResult<SetCmsVariableMutationData>;
+export type SetCmsVariableMutationMutationOptions = Apollo.BaseMutationOptions<SetCmsVariableMutationData, SetCmsVariableMutationVariables>;
 export const DeleteCmsVariableMutationDocument = gql`
     mutation DeleteCmsVariableMutation($key: String!) {
   deleteCmsVariable(input: {key: $key}) {
@@ -149,28 +153,29 @@ export const DeleteCmsVariableMutationDocument = gql`
   }
 }
     ${CmsVariableFieldsFragmentDoc}`;
-export type DeleteCmsVariableMutationMutationFn = Apollo.MutationFunction<DeleteCmsVariableMutationMutation, DeleteCmsVariableMutationMutationVariables>;
+export type DeleteCmsVariableMutationMutationFn = Apollo.MutationFunction<DeleteCmsVariableMutationData, DeleteCmsVariableMutationVariables>;
 
 /**
- * __useDeleteCmsVariableMutationMutation__
+ * __useDeleteCmsVariableMutation__
  *
- * To run a mutation, you first call `useDeleteCmsVariableMutationMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useDeleteCmsVariableMutationMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useDeleteCmsVariableMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteCmsVariableMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [deleteCmsVariableMutationMutation, { data, loading, error }] = useDeleteCmsVariableMutationMutation({
+ * const [deleteCmsVariableMutation, { data, loading, error }] = useDeleteCmsVariableMutation({
  *   variables: {
  *      key: // value for 'key'
  *   },
  * });
  */
-export function useDeleteCmsVariableMutationMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCmsVariableMutationMutation, DeleteCmsVariableMutationMutationVariables>) {
-        return Apollo.useMutation<DeleteCmsVariableMutationMutation, DeleteCmsVariableMutationMutationVariables>(DeleteCmsVariableMutationDocument, baseOptions);
+export function useDeleteCmsVariableMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCmsVariableMutationData, DeleteCmsVariableMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteCmsVariableMutationData, DeleteCmsVariableMutationVariables>(DeleteCmsVariableMutationDocument, options);
       }
-export type DeleteCmsVariableMutationMutationHookResult = ReturnType<typeof useDeleteCmsVariableMutationMutation>;
-export type DeleteCmsVariableMutationMutationResult = Apollo.MutationResult<DeleteCmsVariableMutationMutation>;
-export type DeleteCmsVariableMutationMutationOptions = Apollo.BaseMutationOptions<DeleteCmsVariableMutationMutation, DeleteCmsVariableMutationMutationVariables>;
+export type DeleteCmsVariableMutationHookResult = ReturnType<typeof useDeleteCmsVariableMutation>;
+export type DeleteCmsVariableMutationMutationResult = Apollo.MutationResult<DeleteCmsVariableMutationData>;
+export type DeleteCmsVariableMutationMutationOptions = Apollo.BaseMutationOptions<DeleteCmsVariableMutationData, DeleteCmsVariableMutationVariables>;

--- a/app/javascript/CmsAdmin/CmsVariablesAdmin/updateCmsVariable.ts
+++ b/app/javascript/CmsAdmin/CmsVariablesAdmin/updateCmsVariable.ts
@@ -1,12 +1,12 @@
 import { ApolloCache, MutationResult } from '@apollo/client';
 import { CmsVariablesQuery } from './queries';
-import { CmsVariablesQueryQuery, SetCmsVariableMutationMutation } from './queries.generated';
+import { CmsVariablesQueryData, SetCmsVariableMutationData } from './queries.generated';
 
 export default function updateCmsVariable(
   cache: ApolloCache<any>,
-  result: MutationResult<SetCmsVariableMutationMutation>,
+  result: MutationResult<SetCmsVariableMutationData>,
 ) {
-  const data = cache.readQuery<CmsVariablesQueryQuery>({ query: CmsVariablesQuery });
+  const data = cache.readQuery<CmsVariablesQueryData>({ query: CmsVariablesQuery });
   const cmsVariable = result.data?.setCmsVariable?.cms_variable;
   if (!data || !cmsVariable) {
     return;

--- a/app/javascript/CmsAdmin/NavigationItemsAdmin/Client.ts
+++ b/app/javascript/CmsAdmin/NavigationItemsAdmin/Client.ts
@@ -2,20 +2,20 @@ import { ApolloClient, FetchResult } from '@apollo/client';
 import { NavigationItemsAdminQuery } from './queries';
 import {
   AdminNavigationItemFieldsFragment,
-  NavigationItemsAdminQueryQuery,
+  NavigationItemsAdminQueryData,
 } from './queries.generated';
 import {
   CreateNavigationItemDocument,
-  CreateNavigationItemMutation,
+  CreateNavigationItemMutationData,
   CreateNavigationItemMutationVariables,
   DeleteNavigationItemDocument,
-  DeleteNavigationItemMutation,
+  DeleteNavigationItemMutationData,
   DeleteNavigationItemMutationVariables,
   SortNavigationItemsDocument,
-  SortNavigationItemsMutation,
+  SortNavigationItemsMutationData,
   SortNavigationItemsMutationVariables,
   UpdateNavigationItemDocument,
-  UpdateNavigationItemMutation,
+  UpdateNavigationItemMutationData,
   UpdateNavigationItemMutationVariables,
 } from './mutations.generated';
 import { CmsNavigationItemInput } from '../../graphqlTypes.generated';
@@ -119,7 +119,7 @@ class Client {
         operation = 'update';
         mutate = () =>
           this.apolloClient.mutate<
-            UpdateNavigationItemMutation,
+            UpdateNavigationItemMutationData,
             UpdateNavigationItemMutationVariables
           >({
             mutation: UpdateNavigationItemDocument,
@@ -129,20 +129,20 @@ class Client {
         operation = 'create';
         mutate = () =>
           this.apolloClient.mutate<
-            CreateNavigationItemMutation,
+            CreateNavigationItemMutationData,
             CreateNavigationItemMutationVariables
           >({
             mutation: CreateNavigationItemDocument,
             variables: { navigationItem: navigationItemInput },
             update: (cache, { data: resultData }) => {
-              const data = cache.readQuery<NavigationItemsAdminQueryQuery>({
+              const data = cache.readQuery<NavigationItemsAdminQueryData>({
                 query: NavigationItemsAdminQuery,
               });
               const newNavigationItem = resultData?.createCmsNavigationItem?.cms_navigation_item;
               if (!data || !newNavigationItem) {
                 return;
               }
-              cache.writeQuery<NavigationItemsAdminQueryQuery>({
+              cache.writeQuery<NavigationItemsAdminQueryData>({
                 query: NavigationItemsAdminQuery,
                 data: {
                   ...data,
@@ -172,13 +172,13 @@ class Client {
 
     try {
       const response = await this.apolloClient.mutate<
-        DeleteNavigationItemMutation,
+        DeleteNavigationItemMutationData,
         DeleteNavigationItemMutationVariables
       >({
         mutation: DeleteNavigationItemDocument,
         variables: { id: navigationItem.id },
         update: (cache) => {
-          const data = cache.readQuery<NavigationItemsAdminQueryQuery>({
+          const data = cache.readQuery<NavigationItemsAdminQueryData>({
             query: NavigationItemsAdminQuery,
           });
           if (!data) {
@@ -217,13 +217,13 @@ class Client {
     this.requestsInProgress.sortingNavigationItems = true;
     try {
       const response = await this.apolloClient.mutate<
-        SortNavigationItemsMutation,
+        SortNavigationItemsMutationData,
         SortNavigationItemsMutationVariables
       >({
         mutation: SortNavigationItemsDocument,
         variables: { sortItems },
         update: (cache) => {
-          const data = cache.readQuery<NavigationItemsAdminQueryQuery>({
+          const data = cache.readQuery<NavigationItemsAdminQueryData>({
             query: NavigationItemsAdminQuery,
           });
           if (!data) {

--- a/app/javascript/CmsAdmin/NavigationItemsAdmin/mutations.generated.ts
+++ b/app/javascript/CmsAdmin/NavigationItemsAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { AdminNavigationItemFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { AdminNavigationItemFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateNavigationItemMutationVariables = Types.Exact<{
   navigationItem: Types.CmsNavigationItemInput;
 }>;
 
 
-export type CreateNavigationItemMutation = (
+export type CreateNavigationItemMutationData = (
   { __typename: 'Mutation' }
   & { createCmsNavigationItem?: Types.Maybe<(
     { __typename: 'CreateCmsNavigationItemPayload' }
@@ -28,7 +29,7 @@ export type UpdateNavigationItemMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateNavigationItemMutation = (
+export type UpdateNavigationItemMutationData = (
   { __typename: 'Mutation' }
   & { updateCmsNavigationItem?: Types.Maybe<(
     { __typename: 'UpdateCmsNavigationItemPayload' }
@@ -45,7 +46,7 @@ export type DeleteNavigationItemMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteNavigationItemMutation = (
+export type DeleteNavigationItemMutationData = (
   { __typename: 'Mutation' }
   & { deleteCmsNavigationItem?: Types.Maybe<(
     { __typename: 'DeleteCmsNavigationItemPayload' }
@@ -61,7 +62,7 @@ export type SortNavigationItemsMutationVariables = Types.Exact<{
 }>;
 
 
-export type SortNavigationItemsMutation = (
+export type SortNavigationItemsMutationData = (
   { __typename: 'Mutation' }
   & { sortCmsNavigationItems?: Types.Maybe<(
     { __typename: 'SortCmsNavigationItemsPayload' }
@@ -80,7 +81,7 @@ export const CreateNavigationItemDocument = gql`
   }
 }
     ${AdminNavigationItemFieldsFragmentDoc}`;
-export type CreateNavigationItemMutationFn = Apollo.MutationFunction<CreateNavigationItemMutation, CreateNavigationItemMutationVariables>;
+export type CreateNavigationItemMutationFn = Apollo.MutationFunction<CreateNavigationItemMutationData, CreateNavigationItemMutationVariables>;
 
 /**
  * __useCreateNavigationItemMutation__
@@ -99,12 +100,13 @@ export type CreateNavigationItemMutationFn = Apollo.MutationFunction<CreateNavig
  *   },
  * });
  */
-export function useCreateNavigationItemMutation(baseOptions?: Apollo.MutationHookOptions<CreateNavigationItemMutation, CreateNavigationItemMutationVariables>) {
-        return Apollo.useMutation<CreateNavigationItemMutation, CreateNavigationItemMutationVariables>(CreateNavigationItemDocument, baseOptions);
+export function useCreateNavigationItemMutation(baseOptions?: Apollo.MutationHookOptions<CreateNavigationItemMutationData, CreateNavigationItemMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateNavigationItemMutationData, CreateNavigationItemMutationVariables>(CreateNavigationItemDocument, options);
       }
 export type CreateNavigationItemMutationHookResult = ReturnType<typeof useCreateNavigationItemMutation>;
-export type CreateNavigationItemMutationResult = Apollo.MutationResult<CreateNavigationItemMutation>;
-export type CreateNavigationItemMutationOptions = Apollo.BaseMutationOptions<CreateNavigationItemMutation, CreateNavigationItemMutationVariables>;
+export type CreateNavigationItemMutationResult = Apollo.MutationResult<CreateNavigationItemMutationData>;
+export type CreateNavigationItemMutationOptions = Apollo.BaseMutationOptions<CreateNavigationItemMutationData, CreateNavigationItemMutationVariables>;
 export const UpdateNavigationItemDocument = gql`
     mutation UpdateNavigationItem($id: Int!, $navigationItem: CmsNavigationItemInput!) {
   updateCmsNavigationItem(input: {id: $id, cms_navigation_item: $navigationItem}) {
@@ -115,7 +117,7 @@ export const UpdateNavigationItemDocument = gql`
   }
 }
     ${AdminNavigationItemFieldsFragmentDoc}`;
-export type UpdateNavigationItemMutationFn = Apollo.MutationFunction<UpdateNavigationItemMutation, UpdateNavigationItemMutationVariables>;
+export type UpdateNavigationItemMutationFn = Apollo.MutationFunction<UpdateNavigationItemMutationData, UpdateNavigationItemMutationVariables>;
 
 /**
  * __useUpdateNavigationItemMutation__
@@ -135,12 +137,13 @@ export type UpdateNavigationItemMutationFn = Apollo.MutationFunction<UpdateNavig
  *   },
  * });
  */
-export function useUpdateNavigationItemMutation(baseOptions?: Apollo.MutationHookOptions<UpdateNavigationItemMutation, UpdateNavigationItemMutationVariables>) {
-        return Apollo.useMutation<UpdateNavigationItemMutation, UpdateNavigationItemMutationVariables>(UpdateNavigationItemDocument, baseOptions);
+export function useUpdateNavigationItemMutation(baseOptions?: Apollo.MutationHookOptions<UpdateNavigationItemMutationData, UpdateNavigationItemMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateNavigationItemMutationData, UpdateNavigationItemMutationVariables>(UpdateNavigationItemDocument, options);
       }
 export type UpdateNavigationItemMutationHookResult = ReturnType<typeof useUpdateNavigationItemMutation>;
-export type UpdateNavigationItemMutationResult = Apollo.MutationResult<UpdateNavigationItemMutation>;
-export type UpdateNavigationItemMutationOptions = Apollo.BaseMutationOptions<UpdateNavigationItemMutation, UpdateNavigationItemMutationVariables>;
+export type UpdateNavigationItemMutationResult = Apollo.MutationResult<UpdateNavigationItemMutationData>;
+export type UpdateNavigationItemMutationOptions = Apollo.BaseMutationOptions<UpdateNavigationItemMutationData, UpdateNavigationItemMutationVariables>;
 export const DeleteNavigationItemDocument = gql`
     mutation DeleteNavigationItem($id: Int!) {
   deleteCmsNavigationItem(input: {id: $id}) {
@@ -150,7 +153,7 @@ export const DeleteNavigationItemDocument = gql`
   }
 }
     `;
-export type DeleteNavigationItemMutationFn = Apollo.MutationFunction<DeleteNavigationItemMutation, DeleteNavigationItemMutationVariables>;
+export type DeleteNavigationItemMutationFn = Apollo.MutationFunction<DeleteNavigationItemMutationData, DeleteNavigationItemMutationVariables>;
 
 /**
  * __useDeleteNavigationItemMutation__
@@ -169,12 +172,13 @@ export type DeleteNavigationItemMutationFn = Apollo.MutationFunction<DeleteNavig
  *   },
  * });
  */
-export function useDeleteNavigationItemMutation(baseOptions?: Apollo.MutationHookOptions<DeleteNavigationItemMutation, DeleteNavigationItemMutationVariables>) {
-        return Apollo.useMutation<DeleteNavigationItemMutation, DeleteNavigationItemMutationVariables>(DeleteNavigationItemDocument, baseOptions);
+export function useDeleteNavigationItemMutation(baseOptions?: Apollo.MutationHookOptions<DeleteNavigationItemMutationData, DeleteNavigationItemMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteNavigationItemMutationData, DeleteNavigationItemMutationVariables>(DeleteNavigationItemDocument, options);
       }
 export type DeleteNavigationItemMutationHookResult = ReturnType<typeof useDeleteNavigationItemMutation>;
-export type DeleteNavigationItemMutationResult = Apollo.MutationResult<DeleteNavigationItemMutation>;
-export type DeleteNavigationItemMutationOptions = Apollo.BaseMutationOptions<DeleteNavigationItemMutation, DeleteNavigationItemMutationVariables>;
+export type DeleteNavigationItemMutationResult = Apollo.MutationResult<DeleteNavigationItemMutationData>;
+export type DeleteNavigationItemMutationOptions = Apollo.BaseMutationOptions<DeleteNavigationItemMutationData, DeleteNavigationItemMutationVariables>;
 export const SortNavigationItemsDocument = gql`
     mutation SortNavigationItems($sortItems: [UpdateCmsNavigationItemInput!]!) {
   sortCmsNavigationItems(input: {sort_items: $sortItems}) {
@@ -182,7 +186,7 @@ export const SortNavigationItemsDocument = gql`
   }
 }
     `;
-export type SortNavigationItemsMutationFn = Apollo.MutationFunction<SortNavigationItemsMutation, SortNavigationItemsMutationVariables>;
+export type SortNavigationItemsMutationFn = Apollo.MutationFunction<SortNavigationItemsMutationData, SortNavigationItemsMutationVariables>;
 
 /**
  * __useSortNavigationItemsMutation__
@@ -201,9 +205,10 @@ export type SortNavigationItemsMutationFn = Apollo.MutationFunction<SortNavigati
  *   },
  * });
  */
-export function useSortNavigationItemsMutation(baseOptions?: Apollo.MutationHookOptions<SortNavigationItemsMutation, SortNavigationItemsMutationVariables>) {
-        return Apollo.useMutation<SortNavigationItemsMutation, SortNavigationItemsMutationVariables>(SortNavigationItemsDocument, baseOptions);
+export function useSortNavigationItemsMutation(baseOptions?: Apollo.MutationHookOptions<SortNavigationItemsMutationData, SortNavigationItemsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SortNavigationItemsMutationData, SortNavigationItemsMutationVariables>(SortNavigationItemsDocument, options);
       }
 export type SortNavigationItemsMutationHookResult = ReturnType<typeof useSortNavigationItemsMutation>;
-export type SortNavigationItemsMutationResult = Apollo.MutationResult<SortNavigationItemsMutation>;
-export type SortNavigationItemsMutationOptions = Apollo.BaseMutationOptions<SortNavigationItemsMutation, SortNavigationItemsMutationVariables>;
+export type SortNavigationItemsMutationResult = Apollo.MutationResult<SortNavigationItemsMutationData>;
+export type SortNavigationItemsMutationOptions = Apollo.BaseMutationOptions<SortNavigationItemsMutationData, SortNavigationItemsMutationVariables>;

--- a/app/javascript/CmsAdmin/NavigationItemsAdmin/queries.generated.ts
+++ b/app/javascript/CmsAdmin/NavigationItemsAdmin/queries.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '../../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type AdminNavigationItemFieldsFragment = (
   { __typename: 'CmsNavigationItem' }
   & Pick<Types.CmsNavigationItem, 'id' | 'position' | 'title'>
@@ -15,10 +16,10 @@ export type AdminNavigationItemFieldsFragment = (
   )> }
 );
 
-export type NavigationItemsAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type NavigationItemsAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type NavigationItemsAdminQueryQuery = (
+export type NavigationItemsAdminQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -64,26 +65,28 @@ export const NavigationItemsAdminQueryDocument = gql`
     ${AdminNavigationItemFieldsFragmentDoc}`;
 
 /**
- * __useNavigationItemsAdminQueryQuery__
+ * __useNavigationItemsAdminQuery__
  *
- * To run a query within a React component, call `useNavigationItemsAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useNavigationItemsAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useNavigationItemsAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNavigationItemsAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useNavigationItemsAdminQueryQuery({
+ * const { data, loading, error } = useNavigationItemsAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useNavigationItemsAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<NavigationItemsAdminQueryQuery, NavigationItemsAdminQueryQueryVariables>) {
-        return Apollo.useQuery<NavigationItemsAdminQueryQuery, NavigationItemsAdminQueryQueryVariables>(NavigationItemsAdminQueryDocument, baseOptions);
+export function useNavigationItemsAdminQuery(baseOptions?: Apollo.QueryHookOptions<NavigationItemsAdminQueryData, NavigationItemsAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<NavigationItemsAdminQueryData, NavigationItemsAdminQueryVariables>(NavigationItemsAdminQueryDocument, options);
       }
-export function useNavigationItemsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NavigationItemsAdminQueryQuery, NavigationItemsAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<NavigationItemsAdminQueryQuery, NavigationItemsAdminQueryQueryVariables>(NavigationItemsAdminQueryDocument, baseOptions);
+export function useNavigationItemsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NavigationItemsAdminQueryData, NavigationItemsAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<NavigationItemsAdminQueryData, NavigationItemsAdminQueryVariables>(NavigationItemsAdminQueryDocument, options);
         }
-export type NavigationItemsAdminQueryQueryHookResult = ReturnType<typeof useNavigationItemsAdminQueryQuery>;
+export type NavigationItemsAdminQueryHookResult = ReturnType<typeof useNavigationItemsAdminQuery>;
 export type NavigationItemsAdminQueryLazyQueryHookResult = ReturnType<typeof useNavigationItemsAdminQueryLazyQuery>;
-export type NavigationItemsAdminQueryQueryResult = Apollo.QueryResult<NavigationItemsAdminQueryQuery, NavigationItemsAdminQueryQueryVariables>;
+export type NavigationItemsAdminQueryDataResult = Apollo.QueryResult<NavigationItemsAdminQueryData, NavigationItemsAdminQueryVariables>;

--- a/app/javascript/CmsAdmin/index.tsx
+++ b/app/javascript/CmsAdmin/index.tsx
@@ -14,7 +14,7 @@ import RootSiteAdmin from '../RootSiteAdmin';
 import LoadingIndicator from '../LoadingIndicator';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
 import MenuIcon from '../NavigationBar/MenuIcon';
-import { useCmsAdminBaseQueryQuery } from './queries.generated';
+import { useCmsAdminBaseQuery } from './queries.generated';
 
 type CmsAdminNavTabProps = {
   path: string;
@@ -35,7 +35,7 @@ function CmsAdminNavTab({ path, children, icon }: CmsAdminNavTabProps) {
 
 function CmsAdmin() {
   const authorizationWarning = useAuthorizationRequired('can_manage_any_cms_content');
-  const { data, loading, error } = useCmsAdminBaseQueryQuery();
+  const { data, loading, error } = useCmsAdminBaseQuery();
 
   if (loading) {
     return <LoadingIndicator />;

--- a/app/javascript/CmsAdmin/queries.generated.ts
+++ b/app/javascript/CmsAdmin/queries.generated.ts
@@ -3,10 +3,11 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type CmsAdminBaseQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+const defaultOptions =  {}
+export type CmsAdminBaseQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CmsAdminBaseQueryQuery = (
+export type CmsAdminBaseQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -30,26 +31,28 @@ export const CmsAdminBaseQueryDocument = gql`
     `;
 
 /**
- * __useCmsAdminBaseQueryQuery__
+ * __useCmsAdminBaseQuery__
  *
- * To run a query within a React component, call `useCmsAdminBaseQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCmsAdminBaseQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCmsAdminBaseQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCmsAdminBaseQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCmsAdminBaseQueryQuery({
+ * const { data, loading, error } = useCmsAdminBaseQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCmsAdminBaseQueryQuery(baseOptions?: Apollo.QueryHookOptions<CmsAdminBaseQueryQuery, CmsAdminBaseQueryQueryVariables>) {
-        return Apollo.useQuery<CmsAdminBaseQueryQuery, CmsAdminBaseQueryQueryVariables>(CmsAdminBaseQueryDocument, baseOptions);
+export function useCmsAdminBaseQuery(baseOptions?: Apollo.QueryHookOptions<CmsAdminBaseQueryData, CmsAdminBaseQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CmsAdminBaseQueryData, CmsAdminBaseQueryVariables>(CmsAdminBaseQueryDocument, options);
       }
-export function useCmsAdminBaseQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsAdminBaseQueryQuery, CmsAdminBaseQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CmsAdminBaseQueryQuery, CmsAdminBaseQueryQueryVariables>(CmsAdminBaseQueryDocument, baseOptions);
+export function useCmsAdminBaseQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsAdminBaseQueryData, CmsAdminBaseQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CmsAdminBaseQueryData, CmsAdminBaseQueryVariables>(CmsAdminBaseQueryDocument, options);
         }
-export type CmsAdminBaseQueryQueryHookResult = ReturnType<typeof useCmsAdminBaseQueryQuery>;
+export type CmsAdminBaseQueryHookResult = ReturnType<typeof useCmsAdminBaseQuery>;
 export type CmsAdminBaseQueryLazyQueryHookResult = ReturnType<typeof useCmsAdminBaseQueryLazyQuery>;
-export type CmsAdminBaseQueryQueryResult = Apollo.QueryResult<CmsAdminBaseQueryQuery, CmsAdminBaseQueryQueryVariables>;
+export type CmsAdminBaseQueryDataResult = Apollo.QueryResult<CmsAdminBaseQueryData, CmsAdminBaseQueryVariables>;

--- a/app/javascript/CmsPage/PageAdminDropdown.tsx
+++ b/app/javascript/CmsPage/PageAdminDropdown.tsx
@@ -6,7 +6,7 @@ import { useGraphQLConfirm } from '../ModalDialogs/Confirm';
 import MenuIcon from '../NavigationBar/MenuIcon';
 import { DropdownMenu } from '../UIComponents/DropdownMenu';
 import { useDeletePageMutation } from '../CmsAdmin/CmsPagesAdmin/mutations.generated';
-import { PageAdminDropdownQueryQuery, usePageAdminDropdownQueryQuery } from './queries.generated';
+import { PageAdminDropdownQueryData, usePageAdminDropdownQuery } from './queries.generated';
 
 export type PageAdminDropdownProps = {
   showEdit: boolean;
@@ -15,8 +15,8 @@ export type PageAdminDropdownProps = {
 };
 
 function getEffectiveLayout(
-  cmsPage: PageAdminDropdownQueryQuery['cmsPage'],
-  cmsParent: PageAdminDropdownQueryQuery['cmsParent'],
+  cmsPage: PageAdminDropdownQueryData['cmsPage'],
+  cmsParent: PageAdminDropdownQueryData['cmsParent'],
 ) {
   const specificLayout = cmsPage.cms_layout;
   if (specificLayout) {
@@ -34,7 +34,7 @@ function PageAdminDropdown({ showEdit, showDelete, pageId }: PageAdminDropdownPr
   const history = useHistory();
   const confirm = useGraphQLConfirm();
   const [deletePage] = useDeletePageMutation();
-  const { data, loading, error } = usePageAdminDropdownQueryQuery({ variables: { id: pageId } });
+  const { data, loading, error } = usePageAdminDropdownQuery({ variables: { id: pageId } });
 
   const deleteConfirmed = useCallback(async () => {
     await deletePage({ variables: { id: pageId } });

--- a/app/javascript/CmsPage/index.tsx
+++ b/app/javascript/CmsPage/index.tsx
@@ -8,7 +8,7 @@ import usePageTitle from '../usePageTitle';
 import { lazyWithBundleHashCheck } from '../checkBundleHash';
 import FourOhFourPage from '../FourOhFourPage';
 import parseCmsContent from '../parseCmsContent';
-import { useCmsPageQueryQuery } from './queries.generated';
+import { useCmsPageQuery } from './queries.generated';
 import { useToast } from '../UIComponents/ToastContext';
 
 const PageAdminDropdown = lazyWithBundleHashCheck(
@@ -23,7 +23,7 @@ export type CmsPageProps = {
 function CmsPage({ slug, rootPage }: CmsPageProps) {
   const history = useHistory();
   const location = useLocation();
-  const { data, loading, error } = useCmsPageQueryQuery({ variables: { slug, rootPage } });
+  const { data, loading, error } = useCmsPageQuery({ variables: { slug, rootPage } });
   const content = useMemo(() => {
     if (loading || error || !data) {
       return null;

--- a/app/javascript/CmsPage/queries.generated.ts
+++ b/app/javascript/CmsPage/queries.generated.ts
@@ -3,13 +3,14 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type CmsPageQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type CmsPageQueryVariables = Types.Exact<{
   slug?: Types.Maybe<Types.Scalars['String']>;
   rootPage?: Types.Maybe<Types.Scalars['Boolean']>;
 }>;
 
 
-export type CmsPageQueryQuery = (
+export type CmsPageQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -26,12 +27,12 @@ export type CmsPageQueryQuery = (
   ) }
 );
 
-export type PageAdminDropdownQueryQueryVariables = Types.Exact<{
+export type PageAdminDropdownQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type PageAdminDropdownQueryQuery = (
+export type PageAdminDropdownQueryData = (
   { __typename: 'Query' }
   & { cmsParent: (
     { __typename: 'Convention' }
@@ -87,31 +88,33 @@ export const CmsPageQueryDocument = gql`
     `;
 
 /**
- * __useCmsPageQueryQuery__
+ * __useCmsPageQuery__
  *
- * To run a query within a React component, call `useCmsPageQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCmsPageQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCmsPageQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCmsPageQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCmsPageQueryQuery({
+ * const { data, loading, error } = useCmsPageQuery({
  *   variables: {
  *      slug: // value for 'slug'
  *      rootPage: // value for 'rootPage'
  *   },
  * });
  */
-export function useCmsPageQueryQuery(baseOptions?: Apollo.QueryHookOptions<CmsPageQueryQuery, CmsPageQueryQueryVariables>) {
-        return Apollo.useQuery<CmsPageQueryQuery, CmsPageQueryQueryVariables>(CmsPageQueryDocument, baseOptions);
+export function useCmsPageQuery(baseOptions?: Apollo.QueryHookOptions<CmsPageQueryData, CmsPageQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CmsPageQueryData, CmsPageQueryVariables>(CmsPageQueryDocument, options);
       }
-export function useCmsPageQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsPageQueryQuery, CmsPageQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CmsPageQueryQuery, CmsPageQueryQueryVariables>(CmsPageQueryDocument, baseOptions);
+export function useCmsPageQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CmsPageQueryData, CmsPageQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CmsPageQueryData, CmsPageQueryVariables>(CmsPageQueryDocument, options);
         }
-export type CmsPageQueryQueryHookResult = ReturnType<typeof useCmsPageQueryQuery>;
+export type CmsPageQueryHookResult = ReturnType<typeof useCmsPageQuery>;
 export type CmsPageQueryLazyQueryHookResult = ReturnType<typeof useCmsPageQueryLazyQuery>;
-export type CmsPageQueryQueryResult = Apollo.QueryResult<CmsPageQueryQuery, CmsPageQueryQueryVariables>;
+export type CmsPageQueryDataResult = Apollo.QueryResult<CmsPageQueryData, CmsPageQueryVariables>;
 export const PageAdminDropdownQueryDocument = gql`
     query PageAdminDropdownQuery($id: Int!) {
   cmsParent {
@@ -145,27 +148,29 @@ export const PageAdminDropdownQueryDocument = gql`
     `;
 
 /**
- * __usePageAdminDropdownQueryQuery__
+ * __usePageAdminDropdownQuery__
  *
- * To run a query within a React component, call `usePageAdminDropdownQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `usePageAdminDropdownQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `usePageAdminDropdownQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePageAdminDropdownQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = usePageAdminDropdownQueryQuery({
+ * const { data, loading, error } = usePageAdminDropdownQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function usePageAdminDropdownQueryQuery(baseOptions: Apollo.QueryHookOptions<PageAdminDropdownQueryQuery, PageAdminDropdownQueryQueryVariables>) {
-        return Apollo.useQuery<PageAdminDropdownQueryQuery, PageAdminDropdownQueryQueryVariables>(PageAdminDropdownQueryDocument, baseOptions);
+export function usePageAdminDropdownQuery(baseOptions: Apollo.QueryHookOptions<PageAdminDropdownQueryData, PageAdminDropdownQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PageAdminDropdownQueryData, PageAdminDropdownQueryVariables>(PageAdminDropdownQueryDocument, options);
       }
-export function usePageAdminDropdownQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PageAdminDropdownQueryQuery, PageAdminDropdownQueryQueryVariables>) {
-          return Apollo.useLazyQuery<PageAdminDropdownQueryQuery, PageAdminDropdownQueryQueryVariables>(PageAdminDropdownQueryDocument, baseOptions);
+export function usePageAdminDropdownQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PageAdminDropdownQueryData, PageAdminDropdownQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PageAdminDropdownQueryData, PageAdminDropdownQueryVariables>(PageAdminDropdownQueryDocument, options);
         }
-export type PageAdminDropdownQueryQueryHookResult = ReturnType<typeof usePageAdminDropdownQueryQuery>;
+export type PageAdminDropdownQueryHookResult = ReturnType<typeof usePageAdminDropdownQuery>;
 export type PageAdminDropdownQueryLazyQueryHookResult = ReturnType<typeof usePageAdminDropdownQueryLazyQuery>;
-export type PageAdminDropdownQueryQueryResult = Apollo.QueryResult<PageAdminDropdownQueryQuery, PageAdminDropdownQueryQueryVariables>;
+export type PageAdminDropdownQueryDataResult = Apollo.QueryResult<PageAdminDropdownQueryData, PageAdminDropdownQueryVariables>;

--- a/app/javascript/ConventionAdmin/ConventionForm.tsx
+++ b/app/javascript/ConventionAdmin/ConventionForm.tsx
@@ -10,11 +10,11 @@ import useAsyncFunction from '../useAsyncFunction';
 import ErrorDisplay from '../ErrorDisplay';
 import { EditingScheduledValue } from '../BuiltInFormControls/ScheduledValueEditor';
 import ConventionFormEmailSection from './ConventionFormEmailSection';
-import { ConventionAdminConventionQueryQuery } from './queries.generated';
+import { ConventionAdminConventionQueryData } from './queries.generated';
 import { MaximumEventSignupsValue } from './MaximumEventSignupsPreview';
 
 export type ConventionFormConvention = Omit<
-  ConventionAdminConventionQueryQuery['convention'],
+  ConventionAdminConventionQueryData['convention'],
   'maximum_event_signups'
 > & {
   maximum_event_signups: EditingScheduledValue<MaximumEventSignupsValue>;
@@ -23,9 +23,9 @@ export type ConventionFormConvention = Omit<
 export type ConventionFormProps = {
   initialConvention: ConventionFormConvention;
   saveConvention: (convention: ConventionFormConvention) => Promise<void>;
-  cmsLayouts: ConventionAdminConventionQueryQuery['convention']['cms_layouts'];
-  pages: ConventionAdminConventionQueryQuery['convention']['pages'];
-  rootSite: ConventionAdminConventionQueryQuery['rootSite'];
+  cmsLayouts: ConventionAdminConventionQueryData['convention']['cms_layouts'];
+  pages: ConventionAdminConventionQueryData['convention']['pages'];
+  rootSite: ConventionAdminConventionQueryData['rootSite'];
 };
 
 function ConventionForm({

--- a/app/javascript/ConventionAdmin/ConventionFormBillingSection.tsx
+++ b/app/javascript/ConventionAdmin/ConventionFormBillingSection.tsx
@@ -16,8 +16,8 @@ import ErrorDisplay from '../ErrorDisplay';
 import LoadingIndicator from '../LoadingIndicator';
 import {
   StripeAccountOnboardingLinkQueryDocument,
-  StripeAccountOnboardingLinkQueryQuery,
-  StripeAccountOnboardingLinkQueryQueryVariables,
+  StripeAccountOnboardingLinkQueryData,
+  StripeAccountOnboardingLinkQueryVariables,
 } from './queries.generated';
 
 export type ConventionFormBillingSectionProps = {
@@ -60,8 +60,8 @@ function ConventionFormBillingSection({
 
   const obtainOnboardingLinkAndRedirect = useCallback(async () => {
     const result = await apolloClient.query<
-      StripeAccountOnboardingLinkQueryQuery,
-      StripeAccountOnboardingLinkQueryQueryVariables
+      StripeAccountOnboardingLinkQueryData,
+      StripeAccountOnboardingLinkQueryVariables
     >({
       query: StripeAccountOnboardingLinkQueryDocument,
       variables: { baseUrl: window.location.href.toString() },

--- a/app/javascript/ConventionAdmin/ConventionFormEmailSection.tsx
+++ b/app/javascript/ConventionAdmin/ConventionFormEmailSection.tsx
@@ -4,7 +4,7 @@ import BootstrapFormInput from '../BuiltInFormControls/BootstrapFormInput';
 import SelectWithLabel from '../BuiltInFormControls/SelectWithLabel';
 import MultipleChoiceInput from '../BuiltInFormControls/MultipleChoiceInput';
 import type { ConventionFormConvention } from './ConventionForm';
-import { ConventionAdminConventionQueryQuery } from './queries.generated';
+import { ConventionAdminConventionQueryData } from './queries.generated';
 import { usePropertySetters } from '../usePropertySetters';
 import { EmailMode } from '../graphqlTypes.generated';
 
@@ -12,7 +12,7 @@ export type ConventionFormEmailSectionProps = {
   convention: ConventionFormConvention;
   setConvention: React.Dispatch<React.SetStateAction<ConventionFormConvention>>;
   disabled: boolean;
-  staffPositions: ConventionAdminConventionQueryQuery['convention']['staff_positions'];
+  staffPositions: ConventionAdminConventionQueryData['convention']['staff_positions'];
 };
 
 function ConventionFormEmailSection({

--- a/app/javascript/ConventionAdmin/ConventionFormHeader.tsx
+++ b/app/javascript/ConventionAdmin/ConventionFormHeader.tsx
@@ -10,7 +10,7 @@ import pluralizeWithCount from '../pluralizeWithCount';
 import { timezoneNameForConvention } from '../TimeUtils';
 import { ShowSchedule } from '../graphqlTypes.generated';
 import { EditingScheduledValue } from '../BuiltInFormControls/ScheduledValueEditor';
-import { ConventionAdminConventionQueryQuery } from './queries.generated';
+import { ConventionAdminConventionQueryData } from './queries.generated';
 
 function describeEventVisibility(visibility: ShowSchedule | null | undefined) {
   switch (visibility) {
@@ -94,7 +94,7 @@ function describeConventionTiming(
 
 export type ConventionFormHeaderProps = {
   convention: Pick<
-    ConventionAdminConventionQueryQuery['convention'],
+    ConventionAdminConventionQueryData['convention'],
     | 'id'
     | 'name'
     | 'starts_at'

--- a/app/javascript/ConventionAdmin/ConventionFormWebsiteSection.tsx
+++ b/app/javascript/ConventionAdmin/ConventionFormWebsiteSection.tsx
@@ -5,7 +5,7 @@ import SelectWithLabel from '../BuiltInFormControls/SelectWithLabel';
 import LiquidInput from '../BuiltInFormControls/LiquidInput';
 import BooleanInput from '../BuiltInFormControls/BooleanInput';
 import type { ConventionFormConvention } from './ConventionForm';
-import { ConventionAdminConventionQueryQuery } from './queries.generated';
+import { ConventionAdminConventionQueryData } from './queries.generated';
 import { usePropertySetters } from '../usePropertySetters';
 
 // Since our selects come right above a CodeMirror, we need to override the z-index on the
@@ -18,9 +18,9 @@ export type ConventionFormWebsiteSectionProps = {
   convention: ConventionFormConvention;
   setConvention: React.Dispatch<React.SetStateAction<ConventionFormConvention>>;
   disabled: boolean;
-  rootSite: ConventionAdminConventionQueryQuery['rootSite'];
-  cmsLayouts: ConventionAdminConventionQueryQuery['convention']['cms_layouts'];
-  pages: ConventionAdminConventionQueryQuery['convention']['pages'];
+  rootSite: ConventionAdminConventionQueryData['rootSite'];
+  cmsLayouts: ConventionAdminConventionQueryData['convention']['cms_layouts'];
+  pages: ConventionAdminConventionQueryData['convention']['pages'];
 };
 
 function ConventionFormWebsiteSection({

--- a/app/javascript/ConventionAdmin/index.tsx
+++ b/app/javascript/ConventionAdmin/index.tsx
@@ -10,7 +10,7 @@ import ConventionFormHeader from './ConventionFormHeader';
 import usePageTitle from '../usePageTitle';
 import PageLoadingIndicator from '../PageLoadingIndicator';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
-import { useConventionAdminConventionQueryQuery } from './queries.generated';
+import { useConventionAdminConventionQuery } from './queries.generated';
 import { useUpdateConventionMutation } from './mutations.generated';
 import { ConventionInput } from '../graphqlTypes.generated';
 import { EditingScheduledValue } from '../BuiltInFormControls/ScheduledValueEditor';
@@ -18,7 +18,7 @@ import { MaximumEventSignupsValue } from './MaximumEventSignupsPreview';
 
 function ConventionAdmin() {
   const history = useHistory();
-  const { data, loading, error } = useConventionAdminConventionQueryQuery();
+  const { data, loading, error } = useConventionAdminConventionQuery();
   const [updateMutate] = useUpdateConventionMutation();
   const [mutate, mutationError] = useAsyncFunction(updateMutate);
   const apolloClient = useApolloClient();

--- a/app/javascript/ConventionAdmin/mutations.generated.ts
+++ b/app/javascript/ConventionAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { ConventionAdminConventionFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { ConventionAdminConventionFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type UpdateConventionMutationVariables = Types.Exact<{
   input: Types.UpdateConventionInput;
 }>;
 
 
-export type UpdateConventionMutation = (
+export type UpdateConventionMutationData = (
   { __typename: 'Mutation' }
   & { updateConvention?: Types.Maybe<(
     { __typename: 'UpdateConventionPayload' }
@@ -27,7 +28,7 @@ export type CreateConventionStripeAccountMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateConventionStripeAccountMutation = (
+export type CreateConventionStripeAccountMutationData = (
   { __typename: 'Mutation' }
   & { createConventionStripeAccount?: Types.Maybe<(
     { __typename: 'CreateConventionStripeAccountPayload' }
@@ -49,7 +50,7 @@ export const UpdateConventionDocument = gql`
   }
 }
     ${ConventionAdminConventionFieldsFragmentDoc}`;
-export type UpdateConventionMutationFn = Apollo.MutationFunction<UpdateConventionMutation, UpdateConventionMutationVariables>;
+export type UpdateConventionMutationFn = Apollo.MutationFunction<UpdateConventionMutationData, UpdateConventionMutationVariables>;
 
 /**
  * __useUpdateConventionMutation__
@@ -68,12 +69,13 @@ export type UpdateConventionMutationFn = Apollo.MutationFunction<UpdateConventio
  *   },
  * });
  */
-export function useUpdateConventionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateConventionMutation, UpdateConventionMutationVariables>) {
-        return Apollo.useMutation<UpdateConventionMutation, UpdateConventionMutationVariables>(UpdateConventionDocument, baseOptions);
+export function useUpdateConventionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateConventionMutationData, UpdateConventionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateConventionMutationData, UpdateConventionMutationVariables>(UpdateConventionDocument, options);
       }
 export type UpdateConventionMutationHookResult = ReturnType<typeof useUpdateConventionMutation>;
-export type UpdateConventionMutationResult = Apollo.MutationResult<UpdateConventionMutation>;
-export type UpdateConventionMutationOptions = Apollo.BaseMutationOptions<UpdateConventionMutation, UpdateConventionMutationVariables>;
+export type UpdateConventionMutationResult = Apollo.MutationResult<UpdateConventionMutationData>;
+export type UpdateConventionMutationOptions = Apollo.BaseMutationOptions<UpdateConventionMutationData, UpdateConventionMutationVariables>;
 export const CreateConventionStripeAccountDocument = gql`
     mutation CreateConventionStripeAccount($baseUrl: String!) {
   createConventionStripeAccount(input: {}) {
@@ -84,7 +86,7 @@ export const CreateConventionStripeAccountDocument = gql`
   }
 }
     `;
-export type CreateConventionStripeAccountMutationFn = Apollo.MutationFunction<CreateConventionStripeAccountMutation, CreateConventionStripeAccountMutationVariables>;
+export type CreateConventionStripeAccountMutationFn = Apollo.MutationFunction<CreateConventionStripeAccountMutationData, CreateConventionStripeAccountMutationVariables>;
 
 /**
  * __useCreateConventionStripeAccountMutation__
@@ -103,9 +105,10 @@ export type CreateConventionStripeAccountMutationFn = Apollo.MutationFunction<Cr
  *   },
  * });
  */
-export function useCreateConventionStripeAccountMutation(baseOptions?: Apollo.MutationHookOptions<CreateConventionStripeAccountMutation, CreateConventionStripeAccountMutationVariables>) {
-        return Apollo.useMutation<CreateConventionStripeAccountMutation, CreateConventionStripeAccountMutationVariables>(CreateConventionStripeAccountDocument, baseOptions);
+export function useCreateConventionStripeAccountMutation(baseOptions?: Apollo.MutationHookOptions<CreateConventionStripeAccountMutationData, CreateConventionStripeAccountMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateConventionStripeAccountMutationData, CreateConventionStripeAccountMutationVariables>(CreateConventionStripeAccountDocument, options);
       }
 export type CreateConventionStripeAccountMutationHookResult = ReturnType<typeof useCreateConventionStripeAccountMutation>;
-export type CreateConventionStripeAccountMutationResult = Apollo.MutationResult<CreateConventionStripeAccountMutation>;
-export type CreateConventionStripeAccountMutationOptions = Apollo.BaseMutationOptions<CreateConventionStripeAccountMutation, CreateConventionStripeAccountMutationVariables>;
+export type CreateConventionStripeAccountMutationResult = Apollo.MutationResult<CreateConventionStripeAccountMutationData>;
+export type CreateConventionStripeAccountMutationOptions = Apollo.BaseMutationOptions<CreateConventionStripeAccountMutationData, CreateConventionStripeAccountMutationVariables>;

--- a/app/javascript/ConventionAdmin/queries.generated.ts
+++ b/app/javascript/ConventionAdmin/queries.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type ConventionAdminConventionFieldsFragment = (
   { __typename: 'Convention' }
   & Pick<Types.Convention, 'id' | 'accepting_proposals' | 'starts_at' | 'ends_at' | 'canceled' | 'name' | 'domain' | 'email_from' | 'email_mode' | 'event_mailing_list_domain' | 'location' | 'language' | 'timezone_name' | 'timezone_mode' | 'show_schedule' | 'show_event_list' | 'hidden' | 'maximum_tickets' | 'ticket_name' | 'clickwrap_agreement' | 'ticket_mode' | 'site_mode' | 'signup_mode' | 'signup_requests_open' | 'stripe_account_ready_to_charge'>
@@ -36,10 +37,10 @@ export type ConventionAdminConventionFieldsFragment = (
   )> }
 );
 
-export type ConventionAdminConventionQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type ConventionAdminConventionQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type ConventionAdminConventionQueryQuery = (
+export type ConventionAdminConventionQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -51,12 +52,12 @@ export type ConventionAdminConventionQueryQuery = (
   ) }
 );
 
-export type StripeAccountOnboardingLinkQueryQueryVariables = Types.Exact<{
+export type StripeAccountOnboardingLinkQueryVariables = Types.Exact<{
   baseUrl: Types.Scalars['String'];
 }>;
 
 
-export type StripeAccountOnboardingLinkQueryQuery = (
+export type StripeAccountOnboardingLinkQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -148,29 +149,31 @@ export const ConventionAdminConventionQueryDocument = gql`
     ${ConventionAdminConventionFieldsFragmentDoc}`;
 
 /**
- * __useConventionAdminConventionQueryQuery__
+ * __useConventionAdminConventionQuery__
  *
- * To run a query within a React component, call `useConventionAdminConventionQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useConventionAdminConventionQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useConventionAdminConventionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useConventionAdminConventionQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useConventionAdminConventionQueryQuery({
+ * const { data, loading, error } = useConventionAdminConventionQuery({
  *   variables: {
  *   },
  * });
  */
-export function useConventionAdminConventionQueryQuery(baseOptions?: Apollo.QueryHookOptions<ConventionAdminConventionQueryQuery, ConventionAdminConventionQueryQueryVariables>) {
-        return Apollo.useQuery<ConventionAdminConventionQueryQuery, ConventionAdminConventionQueryQueryVariables>(ConventionAdminConventionQueryDocument, baseOptions);
+export function useConventionAdminConventionQuery(baseOptions?: Apollo.QueryHookOptions<ConventionAdminConventionQueryData, ConventionAdminConventionQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ConventionAdminConventionQueryData, ConventionAdminConventionQueryVariables>(ConventionAdminConventionQueryDocument, options);
       }
-export function useConventionAdminConventionQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ConventionAdminConventionQueryQuery, ConventionAdminConventionQueryQueryVariables>) {
-          return Apollo.useLazyQuery<ConventionAdminConventionQueryQuery, ConventionAdminConventionQueryQueryVariables>(ConventionAdminConventionQueryDocument, baseOptions);
+export function useConventionAdminConventionQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ConventionAdminConventionQueryData, ConventionAdminConventionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ConventionAdminConventionQueryData, ConventionAdminConventionQueryVariables>(ConventionAdminConventionQueryDocument, options);
         }
-export type ConventionAdminConventionQueryQueryHookResult = ReturnType<typeof useConventionAdminConventionQueryQuery>;
+export type ConventionAdminConventionQueryHookResult = ReturnType<typeof useConventionAdminConventionQuery>;
 export type ConventionAdminConventionQueryLazyQueryHookResult = ReturnType<typeof useConventionAdminConventionQueryLazyQuery>;
-export type ConventionAdminConventionQueryQueryResult = Apollo.QueryResult<ConventionAdminConventionQueryQuery, ConventionAdminConventionQueryQueryVariables>;
+export type ConventionAdminConventionQueryDataResult = Apollo.QueryResult<ConventionAdminConventionQueryData, ConventionAdminConventionQueryVariables>;
 export const StripeAccountOnboardingLinkQueryDocument = gql`
     query StripeAccountOnboardingLinkQuery($baseUrl: String!) {
   convention: assertConvention {
@@ -184,27 +187,29 @@ export const StripeAccountOnboardingLinkQueryDocument = gql`
     `;
 
 /**
- * __useStripeAccountOnboardingLinkQueryQuery__
+ * __useStripeAccountOnboardingLinkQuery__
  *
- * To run a query within a React component, call `useStripeAccountOnboardingLinkQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useStripeAccountOnboardingLinkQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useStripeAccountOnboardingLinkQuery` and pass it any options that fit your needs.
+ * When your component renders, `useStripeAccountOnboardingLinkQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useStripeAccountOnboardingLinkQueryQuery({
+ * const { data, loading, error } = useStripeAccountOnboardingLinkQuery({
  *   variables: {
  *      baseUrl: // value for 'baseUrl'
  *   },
  * });
  */
-export function useStripeAccountOnboardingLinkQueryQuery(baseOptions: Apollo.QueryHookOptions<StripeAccountOnboardingLinkQueryQuery, StripeAccountOnboardingLinkQueryQueryVariables>) {
-        return Apollo.useQuery<StripeAccountOnboardingLinkQueryQuery, StripeAccountOnboardingLinkQueryQueryVariables>(StripeAccountOnboardingLinkQueryDocument, baseOptions);
+export function useStripeAccountOnboardingLinkQuery(baseOptions: Apollo.QueryHookOptions<StripeAccountOnboardingLinkQueryData, StripeAccountOnboardingLinkQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<StripeAccountOnboardingLinkQueryData, StripeAccountOnboardingLinkQueryVariables>(StripeAccountOnboardingLinkQueryDocument, options);
       }
-export function useStripeAccountOnboardingLinkQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<StripeAccountOnboardingLinkQueryQuery, StripeAccountOnboardingLinkQueryQueryVariables>) {
-          return Apollo.useLazyQuery<StripeAccountOnboardingLinkQueryQuery, StripeAccountOnboardingLinkQueryQueryVariables>(StripeAccountOnboardingLinkQueryDocument, baseOptions);
+export function useStripeAccountOnboardingLinkQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<StripeAccountOnboardingLinkQueryData, StripeAccountOnboardingLinkQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<StripeAccountOnboardingLinkQueryData, StripeAccountOnboardingLinkQueryVariables>(StripeAccountOnboardingLinkQueryDocument, options);
         }
-export type StripeAccountOnboardingLinkQueryQueryHookResult = ReturnType<typeof useStripeAccountOnboardingLinkQueryQuery>;
+export type StripeAccountOnboardingLinkQueryHookResult = ReturnType<typeof useStripeAccountOnboardingLinkQuery>;
 export type StripeAccountOnboardingLinkQueryLazyQueryHookResult = ReturnType<typeof useStripeAccountOnboardingLinkQueryLazyQuery>;
-export type StripeAccountOnboardingLinkQueryQueryResult = Apollo.QueryResult<StripeAccountOnboardingLinkQueryQuery, StripeAccountOnboardingLinkQueryQueryVariables>;
+export type StripeAccountOnboardingLinkQueryDataResult = Apollo.QueryResult<StripeAccountOnboardingLinkQueryData, StripeAccountOnboardingLinkQueryVariables>;

--- a/app/javascript/DepartmentAdmin/DepartmentAdminIndex.tsx
+++ b/app/javascript/DepartmentAdmin/DepartmentAdminIndex.tsx
@@ -8,11 +8,9 @@ import usePageTitle from '../usePageTitle';
 import { useGraphQLConfirm } from '../ModalDialogs/Confirm';
 import { useDeleteMutation } from '../MutationUtils';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useDepartmentAdminQueryQuery } from './queries.generated';
+import { useDepartmentAdminQuery } from './queries.generated';
 
-export default LoadQueryWrapper(useDepartmentAdminQueryQuery, function DepartmentAdminIndex({
-  data,
-}) {
+export default LoadQueryWrapper(useDepartmentAdminQuery, function DepartmentAdminIndex({ data }) {
   const confirm = useGraphQLConfirm();
   const deleteDepartment = useDeleteMutation(DeleteDepartment, {
     query: DepartmentAdminQuery,

--- a/app/javascript/DepartmentAdmin/EditDepartment.tsx
+++ b/app/javascript/DepartmentAdmin/EditDepartment.tsx
@@ -5,11 +5,11 @@ import usePageTitle from '../usePageTitle';
 import buildDepartmentInput from './buildDepartmentInput';
 import DepartmentForm from './DepartmentForm';
 import { LoadSingleValueFromCollectionWrapper } from '../GraphqlLoadingWrappers';
-import { useDepartmentAdminQueryQuery } from './queries.generated';
+import { useDepartmentAdminQuery } from './queries.generated';
 import { useUpdateDepartmentMutation } from './mutations.generated';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useDepartmentAdminQueryQuery,
+  useDepartmentAdminQuery,
   (data, id) => data.convention.departments.find((d) => d.id.toString() === id),
   function EditDepartment({ value: initialDepartment }) {
     const [updateDepartment] = useUpdateDepartmentMutation();

--- a/app/javascript/DepartmentAdmin/mutations.generated.ts
+++ b/app/javascript/DepartmentAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { AdminDepartmentFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { AdminDepartmentFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateDepartmentMutationVariables = Types.Exact<{
   department: Types.DepartmentInput;
 }>;
 
 
-export type CreateDepartmentMutation = (
+export type CreateDepartmentMutationData = (
   { __typename: 'Mutation' }
   & { createDepartment?: Types.Maybe<(
     { __typename: 'CreateDepartmentPayload' }
@@ -28,7 +29,7 @@ export type UpdateDepartmentMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateDepartmentMutation = (
+export type UpdateDepartmentMutationData = (
   { __typename: 'Mutation' }
   & { updateDepartment?: Types.Maybe<(
     { __typename: 'UpdateDepartmentPayload' }
@@ -45,7 +46,7 @@ export type DeleteDepartmentMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteDepartmentMutation = (
+export type DeleteDepartmentMutationData = (
   { __typename: 'Mutation' }
   & { deleteDepartment?: Types.Maybe<(
     { __typename: 'DeleteDepartmentPayload' }
@@ -64,7 +65,7 @@ export const CreateDepartmentDocument = gql`
   }
 }
     ${AdminDepartmentFieldsFragmentDoc}`;
-export type CreateDepartmentMutationFn = Apollo.MutationFunction<CreateDepartmentMutation, CreateDepartmentMutationVariables>;
+export type CreateDepartmentMutationFn = Apollo.MutationFunction<CreateDepartmentMutationData, CreateDepartmentMutationVariables>;
 
 /**
  * __useCreateDepartmentMutation__
@@ -83,12 +84,13 @@ export type CreateDepartmentMutationFn = Apollo.MutationFunction<CreateDepartmen
  *   },
  * });
  */
-export function useCreateDepartmentMutation(baseOptions?: Apollo.MutationHookOptions<CreateDepartmentMutation, CreateDepartmentMutationVariables>) {
-        return Apollo.useMutation<CreateDepartmentMutation, CreateDepartmentMutationVariables>(CreateDepartmentDocument, baseOptions);
+export function useCreateDepartmentMutation(baseOptions?: Apollo.MutationHookOptions<CreateDepartmentMutationData, CreateDepartmentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateDepartmentMutationData, CreateDepartmentMutationVariables>(CreateDepartmentDocument, options);
       }
 export type CreateDepartmentMutationHookResult = ReturnType<typeof useCreateDepartmentMutation>;
-export type CreateDepartmentMutationResult = Apollo.MutationResult<CreateDepartmentMutation>;
-export type CreateDepartmentMutationOptions = Apollo.BaseMutationOptions<CreateDepartmentMutation, CreateDepartmentMutationVariables>;
+export type CreateDepartmentMutationResult = Apollo.MutationResult<CreateDepartmentMutationData>;
+export type CreateDepartmentMutationOptions = Apollo.BaseMutationOptions<CreateDepartmentMutationData, CreateDepartmentMutationVariables>;
 export const UpdateDepartmentDocument = gql`
     mutation UpdateDepartment($id: Int!, $department: DepartmentInput!) {
   updateDepartment(input: {id: $id, department: $department}) {
@@ -99,7 +101,7 @@ export const UpdateDepartmentDocument = gql`
   }
 }
     ${AdminDepartmentFieldsFragmentDoc}`;
-export type UpdateDepartmentMutationFn = Apollo.MutationFunction<UpdateDepartmentMutation, UpdateDepartmentMutationVariables>;
+export type UpdateDepartmentMutationFn = Apollo.MutationFunction<UpdateDepartmentMutationData, UpdateDepartmentMutationVariables>;
 
 /**
  * __useUpdateDepartmentMutation__
@@ -119,12 +121,13 @@ export type UpdateDepartmentMutationFn = Apollo.MutationFunction<UpdateDepartmen
  *   },
  * });
  */
-export function useUpdateDepartmentMutation(baseOptions?: Apollo.MutationHookOptions<UpdateDepartmentMutation, UpdateDepartmentMutationVariables>) {
-        return Apollo.useMutation<UpdateDepartmentMutation, UpdateDepartmentMutationVariables>(UpdateDepartmentDocument, baseOptions);
+export function useUpdateDepartmentMutation(baseOptions?: Apollo.MutationHookOptions<UpdateDepartmentMutationData, UpdateDepartmentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateDepartmentMutationData, UpdateDepartmentMutationVariables>(UpdateDepartmentDocument, options);
       }
 export type UpdateDepartmentMutationHookResult = ReturnType<typeof useUpdateDepartmentMutation>;
-export type UpdateDepartmentMutationResult = Apollo.MutationResult<UpdateDepartmentMutation>;
-export type UpdateDepartmentMutationOptions = Apollo.BaseMutationOptions<UpdateDepartmentMutation, UpdateDepartmentMutationVariables>;
+export type UpdateDepartmentMutationResult = Apollo.MutationResult<UpdateDepartmentMutationData>;
+export type UpdateDepartmentMutationOptions = Apollo.BaseMutationOptions<UpdateDepartmentMutationData, UpdateDepartmentMutationVariables>;
 export const DeleteDepartmentDocument = gql`
     mutation DeleteDepartment($id: Int!) {
   deleteDepartment(input: {id: $id}) {
@@ -132,7 +135,7 @@ export const DeleteDepartmentDocument = gql`
   }
 }
     `;
-export type DeleteDepartmentMutationFn = Apollo.MutationFunction<DeleteDepartmentMutation, DeleteDepartmentMutationVariables>;
+export type DeleteDepartmentMutationFn = Apollo.MutationFunction<DeleteDepartmentMutationData, DeleteDepartmentMutationVariables>;
 
 /**
  * __useDeleteDepartmentMutation__
@@ -151,9 +154,10 @@ export type DeleteDepartmentMutationFn = Apollo.MutationFunction<DeleteDepartmen
  *   },
  * });
  */
-export function useDeleteDepartmentMutation(baseOptions?: Apollo.MutationHookOptions<DeleteDepartmentMutation, DeleteDepartmentMutationVariables>) {
-        return Apollo.useMutation<DeleteDepartmentMutation, DeleteDepartmentMutationVariables>(DeleteDepartmentDocument, baseOptions);
+export function useDeleteDepartmentMutation(baseOptions?: Apollo.MutationHookOptions<DeleteDepartmentMutationData, DeleteDepartmentMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteDepartmentMutationData, DeleteDepartmentMutationVariables>(DeleteDepartmentDocument, options);
       }
 export type DeleteDepartmentMutationHookResult = ReturnType<typeof useDeleteDepartmentMutation>;
-export type DeleteDepartmentMutationResult = Apollo.MutationResult<DeleteDepartmentMutation>;
-export type DeleteDepartmentMutationOptions = Apollo.BaseMutationOptions<DeleteDepartmentMutation, DeleteDepartmentMutationVariables>;
+export type DeleteDepartmentMutationResult = Apollo.MutationResult<DeleteDepartmentMutationData>;
+export type DeleteDepartmentMutationOptions = Apollo.BaseMutationOptions<DeleteDepartmentMutationData, DeleteDepartmentMutationVariables>;

--- a/app/javascript/DepartmentAdmin/queries.generated.ts
+++ b/app/javascript/DepartmentAdmin/queries.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type AdminDepartmentFieldsFragment = (
   { __typename: 'Department' }
   & Pick<Types.Department, 'id' | 'name' | 'proposal_description'>
@@ -12,10 +13,10 @@ export type AdminDepartmentFieldsFragment = (
   )> }
 );
 
-export type DepartmentAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type DepartmentAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type DepartmentAdminQueryQuery = (
+export type DepartmentAdminQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -58,26 +59,28 @@ export const DepartmentAdminQueryDocument = gql`
     ${AdminDepartmentFieldsFragmentDoc}`;
 
 /**
- * __useDepartmentAdminQueryQuery__
+ * __useDepartmentAdminQuery__
  *
- * To run a query within a React component, call `useDepartmentAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useDepartmentAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useDepartmentAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDepartmentAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useDepartmentAdminQueryQuery({
+ * const { data, loading, error } = useDepartmentAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useDepartmentAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<DepartmentAdminQueryQuery, DepartmentAdminQueryQueryVariables>) {
-        return Apollo.useQuery<DepartmentAdminQueryQuery, DepartmentAdminQueryQueryVariables>(DepartmentAdminQueryDocument, baseOptions);
+export function useDepartmentAdminQuery(baseOptions?: Apollo.QueryHookOptions<DepartmentAdminQueryData, DepartmentAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<DepartmentAdminQueryData, DepartmentAdminQueryVariables>(DepartmentAdminQueryDocument, options);
       }
-export function useDepartmentAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DepartmentAdminQueryQuery, DepartmentAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<DepartmentAdminQueryQuery, DepartmentAdminQueryQueryVariables>(DepartmentAdminQueryDocument, baseOptions);
+export function useDepartmentAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DepartmentAdminQueryData, DepartmentAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<DepartmentAdminQueryData, DepartmentAdminQueryVariables>(DepartmentAdminQueryDocument, options);
         }
-export type DepartmentAdminQueryQueryHookResult = ReturnType<typeof useDepartmentAdminQueryQuery>;
+export type DepartmentAdminQueryHookResult = ReturnType<typeof useDepartmentAdminQuery>;
 export type DepartmentAdminQueryLazyQueryHookResult = ReturnType<typeof useDepartmentAdminQueryLazyQuery>;
-export type DepartmentAdminQueryQueryResult = Apollo.QueryResult<DepartmentAdminQueryQuery, DepartmentAdminQueryQueryVariables>;
+export type DepartmentAdminQueryDataResult = Apollo.QueryResult<DepartmentAdminQueryData, DepartmentAdminQueryVariables>;

--- a/app/javascript/EventAdmin/DroppedEventAdmin.tsx
+++ b/app/javascript/EventAdmin/DroppedEventAdmin.tsx
@@ -2,11 +2,11 @@ import ErrorDisplay from '../ErrorDisplay';
 import { useConfirm } from '../ModalDialogs/Confirm';
 import usePageTitle from '../usePageTitle';
 import PageLoadingIndicator from '../PageLoadingIndicator';
-import { useEventAdminEventsQueryQuery } from './queries.generated';
+import { useEventAdminEventsQuery } from './queries.generated';
 import { useRestoreDroppedEventMutation } from './mutations.generated';
 
 function DroppedEventAdmin() {
-  const { data, loading, error } = useEventAdminEventsQueryQuery();
+  const { data, loading, error } = useEventAdminEventsQuery();
   const [restoreDroppedEvent] = useRestoreDroppedEventMutation();
   const confirm = useConfirm();
 

--- a/app/javascript/EventAdmin/EditRunModal.tsx
+++ b/app/javascript/EventAdmin/EditRunModal.tsx
@@ -12,7 +12,7 @@ import {
   useUpdateRunMutation,
 } from './mutations.generated';
 import {
-  EventAdminEventsQueryQuery,
+  EventAdminEventsQueryData,
   EventFieldsFragment,
   RunFieldsFragment,
 } from './queries.generated';
@@ -76,7 +76,7 @@ function EditRunModal({
         },
       },
       update: (store, { data }) => {
-        const eventsData = store.readQuery<EventAdminEventsQueryQuery>({
+        const eventsData = store.readQuery<EventAdminEventsQueryData>({
           query: EventAdminEventsQuery,
         });
         const newRun = data?.createRun?.run;
@@ -119,7 +119,7 @@ function EditRunModal({
         },
       },
       update: (store) => {
-        const eventsData = store.readQuery<EventAdminEventsQueryQuery>({
+        const eventsData = store.readQuery<EventAdminEventsQueryData>({
           query: EventAdminEventsQuery,
         });
         if (!eventsData) {

--- a/app/javascript/EventAdmin/EventAdminEditEvent.tsx
+++ b/app/javascript/EventAdmin/EventAdminEditEvent.tsx
@@ -16,8 +16,8 @@ import PageLoadingIndicator from '../PageLoadingIndicator';
 import deserializeFormResponse, { WithFormResponse } from '../Models/deserializeFormResponse';
 import {
   EventAdminEventsQueryDocument,
-  EventAdminEventsQueryQuery,
-  useEventAdminEventsQueryQuery,
+  EventAdminEventsQueryData,
+  useEventAdminEventsQuery,
 } from './queries.generated';
 import {
   useDropEventMutation,
@@ -27,8 +27,8 @@ import {
 } from './mutations.generated';
 
 type EventAdminEditEventFormProps = {
-  data: EventAdminEventsQueryQuery;
-  initialEvent: WithFormResponse<EventAdminEventsQueryQuery['events'][0]>;
+  data: EventAdminEventsQueryData;
+  initialEvent: WithFormResponse<EventAdminEventsQueryData['events'][0]>;
 };
 
 function EventAdminEditEventForm({ data, initialEvent }: EventAdminEditEventFormProps) {
@@ -39,7 +39,7 @@ function EventAdminEditEventForm({ data, initialEvent }: EventAdminEditEventForm
     updateMutate: useUpdateMaximumEventProvidedTicketsOverrideMutation()[0],
     deleteMutate: useDeleteMaximumEventProvidedTicketsOverrideMutation()[0],
     createUpdater: (store, updatedEventId, override) => {
-      const storeData = store.readQuery<EventAdminEventsQueryQuery>({
+      const storeData = store.readQuery<EventAdminEventsQueryData>({
         query: EventAdminEventsQueryDocument,
       });
       store.writeQuery({
@@ -63,7 +63,7 @@ function EventAdminEditEventForm({ data, initialEvent }: EventAdminEditEventForm
       });
     },
     deleteUpdater: (store, overrideId) => {
-      const storeData = store.readQuery<EventAdminEventsQueryQuery>({
+      const storeData = store.readQuery<EventAdminEventsQueryData>({
         query: EventAdminEventsQueryDocument,
       });
       store.writeQuery({
@@ -161,7 +161,7 @@ function EventAdminEditEventForm({ data, initialEvent }: EventAdminEditEventForm
 }
 
 function EventAdminEditEvent() {
-  const { data, loading, error } = useEventAdminEventsQueryQuery();
+  const { data, loading, error } = useEventAdminEventsQuery();
   const { id: eventId } = useParams<{ id: string }>();
   const serializedEvent = useMemo(
     () => (data ? data.events.find((e) => e.id.toString() === eventId) : undefined),

--- a/app/javascript/EventAdmin/EventAdminRunsTable.tsx
+++ b/app/javascript/EventAdmin/EventAdminRunsTable.tsx
@@ -9,14 +9,14 @@ import useValueUnless from '../useValueUnless';
 import buildEventCategoryUrl from './buildEventCategoryUrl';
 import useEventAdminCategory from './useEventAdminCategory';
 import PageLoadingIndicator from '../PageLoadingIndicator';
-import { useEventAdminEventsQueryQuery } from './queries.generated';
+import { useEventAdminEventsQuery } from './queries.generated';
 
 export type EventAdminRunsTableProps = {
   eventCategoryId: number;
 };
 
 function EventAdminRunsTable({ eventCategoryId }: EventAdminRunsTableProps) {
-  const { data, loading, error } = useEventAdminEventsQueryQuery();
+  const { data, loading, error } = useEventAdminEventsQuery();
 
   const [eventCategory, sortedEvents] = useEventAdminCategory(
     data,

--- a/app/javascript/EventAdmin/NewEvent.tsx
+++ b/app/javascript/EventAdmin/NewEvent.tsx
@@ -12,11 +12,11 @@ import useEventFormWithCategorySelection, {
 import useCreateEvent from './useCreateEvent';
 import usePageTitle from '../usePageTitle';
 import PageLoadingIndicator from '../PageLoadingIndicator';
-import { useEventAdminEventsQueryQuery, EventAdminEventsQueryQuery } from './queries.generated';
+import { useEventAdminEventsQuery, EventAdminEventsQueryData } from './queries.generated';
 import { buildEventInput } from './InputBuilders';
 
 type NewEventFormProps = {
-  data: EventAdminEventsQueryQuery;
+  data: EventAdminEventsQueryData;
 };
 
 type NewEventFormResponseAttrs = {
@@ -26,7 +26,7 @@ type NewEventFormResponseAttrs = {
 };
 
 type EventCategoryType = NonNullable<
-  EventAdminEventsQueryQuery['convention']
+  EventAdminEventsQueryData['convention']
 >['event_categories'][0];
 
 type NewEventFormEvent = {
@@ -146,7 +146,7 @@ function NewEventForm({ data }: NewEventFormProps) {
 }
 
 function NewEvent() {
-  const { data, loading, error } = useEventAdminEventsQueryQuery();
+  const { data, loading, error } = useEventAdminEventsQuery();
 
   usePageTitle('New event');
 

--- a/app/javascript/EventAdmin/ProspectiveRunSchedule.tsx
+++ b/app/javascript/EventAdmin/ProspectiveRunSchedule.tsx
@@ -30,11 +30,11 @@ import {
 } from '../EventsApp/ScheduleGrid/ScheduleLayout/ScheduleLayoutBlock';
 import { ScheduleGridConfig } from '../EventsApp/ScheduleGrid/ScheduleGridConfig';
 import {
-  useEventAdminEventsQueryQuery,
+  useEventAdminEventsQuery,
   EventFieldsFragment,
   RunFieldsFragment,
 } from './queries.generated';
-import { ScheduleGridEventFragmentFragment } from '../EventsApp/ScheduleGrid/queries.generated';
+import { ScheduleGridEventFragment } from '../EventsApp/ScheduleGrid/queries.generated';
 import { ScheduleRun } from '../EventsApp/ScheduleGrid/Schedule';
 import { notEmpty } from '../ValueUtils';
 
@@ -167,7 +167,7 @@ export type ProspectiveRunScheduleProps = {
 
 function ProspectiveRunSchedule({ day, runs, event }: ProspectiveRunScheduleProps) {
   const { timezoneName } = useContext(AppRootContext);
-  const { data, loading, error } = useEventAdminEventsQueryQuery();
+  const { data, loading, error } = useEventAdminEventsQuery();
 
   const conventionTimespan = useMemo(
     () => (error || loading ? null : timespanFromConvention(data!.convention!)),
@@ -195,7 +195,7 @@ function ProspectiveRunSchedule({ day, runs, event }: ProspectiveRunScheduleProp
     [runs, event.id],
   );
 
-  const eventsForSchedule: ScheduleGridEventFragmentFragment[] | undefined = useMemo(() => {
+  const eventsForSchedule: ScheduleGridEventFragment[] | undefined = useMemo(() => {
     if (error || loading || !data) {
       return undefined;
     }

--- a/app/javascript/EventAdmin/RecurringEventAdmin.tsx
+++ b/app/javascript/EventAdmin/RecurringEventAdmin.tsx
@@ -9,14 +9,14 @@ import useEventAdminCategory from './useEventAdminCategory';
 import buildEventCategoryUrl from './buildEventCategoryUrl';
 import useValueUnless from '../useValueUnless';
 import PageLoadingIndicator from '../PageLoadingIndicator';
-import { useEventAdminEventsQueryQuery } from './queries.generated';
+import { useEventAdminEventsQuery } from './queries.generated';
 
 export type RecurringEventAdminProps = {
   eventCategoryId: number;
 };
 
 function RecurringEventAdmin({ eventCategoryId }: RecurringEventAdminProps) {
-  const { data, loading, error } = useEventAdminEventsQueryQuery();
+  const { data, loading, error } = useEventAdminEventsQuery();
   const [eventCategory, sortedEvents] = useEventAdminCategory(
     data,
     loading,

--- a/app/javascript/EventAdmin/ScheduleMultipleRunsModal.tsx
+++ b/app/javascript/EventAdmin/ScheduleMultipleRunsModal.tsx
@@ -23,7 +23,7 @@ import { useCreateMultipleRunsMutation } from './mutations.generated';
 import { FuzzyTime } from '../FormPresenter/TimeblockTypes';
 import {
   ConventionFieldsFragment,
-  EventAdminEventsQueryQuery,
+  EventAdminEventsQueryData,
   EventFieldsFragment,
   RoomFieldsFragment,
 } from './queries.generated';
@@ -141,7 +141,7 @@ function ScheduleMultipleRunsModal({
         input: { event_id: event.id, runs },
       },
       update: (store, { data }) => {
-        const eventsData = store.readQuery<EventAdminEventsQueryQuery>({
+        const eventsData = store.readQuery<EventAdminEventsQueryData>({
           query: EventAdminEventsQuery,
         });
         const newRuns = data?.createMultipleRuns?.runs;

--- a/app/javascript/EventAdmin/SingleRunEventAdminList.tsx
+++ b/app/javascript/EventAdmin/SingleRunEventAdminList.tsx
@@ -14,7 +14,7 @@ import buildEventCategoryUrl from './buildEventCategoryUrl';
 import PageLoadingIndicator from '../PageLoadingIndicator';
 import AppRootContext from '../AppRootContext';
 import { timezoneNameForConvention } from '../TimeUtils';
-import { useEventAdminEventsQueryQuery } from './queries.generated';
+import { useEventAdminEventsQuery } from './queries.generated';
 import { useDropEventMutation } from './mutations.generated';
 import { useFormatRunTimespan } from '../EventsApp/runTimeFormatting';
 
@@ -25,7 +25,7 @@ export type SingleRunEventAdminListProps = {
 function SingleRunEventAdminList({ eventCategoryId }: SingleRunEventAdminListProps) {
   const { t } = useTranslation();
   const { timezoneName } = useContext(AppRootContext);
-  const { data, loading, error } = useEventAdminEventsQueryQuery();
+  const { data, loading, error } = useEventAdminEventsQuery();
   const [eventCategory, sortedEvents] = useEventAdminCategory(
     data,
     loading,

--- a/app/javascript/EventAdmin/getFormForEventCategory.ts
+++ b/app/javascript/EventAdmin/getFormForEventCategory.ts
@@ -1,8 +1,8 @@
-import { EventPageQueryQuery } from '../EventsApp/EventPage/queries.generated';
+import { EventPageQueryData } from '../EventsApp/EventPage/queries.generated';
 import { FormType, EventCategory } from '../graphqlTypes.generated';
 import { CommonFormFieldsFragment } from '../Models/commonFormFragments.generated';
 
-const BLANK_FORM: NonNullable<EventPageQueryQuery['event']['form']> = {
+const BLANK_FORM: NonNullable<EventPageQueryData['event']['form']> = {
   __typename: 'Form',
   id: 0,
   title: '',

--- a/app/javascript/EventAdmin/index.tsx
+++ b/app/javascript/EventAdmin/index.tsx
@@ -14,7 +14,7 @@ import buildEventCategoryUrl from './buildEventCategoryUrl';
 import SingleRunEventAdminList from './SingleRunEventAdminList';
 import PageLoadingIndicator from '../PageLoadingIndicator';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
-import { useEventAdminEventsQueryQuery } from './queries.generated';
+import { useEventAdminEventsQuery } from './queries.generated';
 import { useIntercodePopperWithAutoClosing } from '../UIComponents/PopperUtils';
 
 const eventCategoryIdRegexp = '[0-9a-z\\-]+';
@@ -27,7 +27,7 @@ const adminComponentsBySchedulingUi = {
 
 function EventAdmin() {
   const authorizationWarning = useAuthorizationRequired('can_manage_runs');
-  const { data, loading, error } = useEventAdminEventsQueryQuery();
+  const { data, loading, error } = useEventAdminEventsQuery();
   const location = useLocation();
 
   const eventCategories = useMemo(

--- a/app/javascript/EventAdmin/mutations.generated.ts
+++ b/app/javascript/EventAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { EventFieldsFragment, RunFieldsFragment, MaximumEventProvidedTicketsOver
 import { gql } from '@apollo/client';
 import { EventFieldsFragmentDoc, RunFieldsFragmentDoc, MaximumEventProvidedTicketsOverrideFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateEventMutationVariables = Types.Exact<{
   input: Types.CreateEventInput;
 }>;
 
 
-export type CreateEventMutation = (
+export type CreateEventMutationData = (
   { __typename: 'Mutation' }
   & { createEvent?: Types.Maybe<(
     { __typename: 'CreateEventPayload' }
@@ -27,7 +28,7 @@ export type CreateFillerEventMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateFillerEventMutation = (
+export type CreateFillerEventMutationData = (
   { __typename: 'Mutation' }
   & { createFillerEvent?: Types.Maybe<(
     { __typename: 'CreateFillerEventPayload' }
@@ -44,7 +45,7 @@ export type DropEventMutationVariables = Types.Exact<{
 }>;
 
 
-export type DropEventMutation = (
+export type DropEventMutationData = (
   { __typename: 'Mutation' }
   & { dropEvent?: Types.Maybe<(
     { __typename: 'DropEventPayload' }
@@ -60,7 +61,7 @@ export type RestoreDroppedEventMutationVariables = Types.Exact<{
 }>;
 
 
-export type RestoreDroppedEventMutation = (
+export type RestoreDroppedEventMutationData = (
   { __typename: 'Mutation' }
   & { restoreDroppedEvent?: Types.Maybe<(
     { __typename: 'RestoreDroppedEventPayload' }
@@ -76,7 +77,7 @@ export type UpdateEventMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateEventMutation = (
+export type UpdateEventMutationData = (
   { __typename: 'Mutation' }
   & { updateEvent?: Types.Maybe<(
     { __typename: 'UpdateEventPayload' }
@@ -93,7 +94,7 @@ export type CreateRunMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateRunMutation = (
+export type CreateRunMutationData = (
   { __typename: 'Mutation' }
   & { createRun?: Types.Maybe<(
     { __typename: 'CreateRunPayload' }
@@ -110,7 +111,7 @@ export type CreateMultipleRunsMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateMultipleRunsMutation = (
+export type CreateMultipleRunsMutationData = (
   { __typename: 'Mutation' }
   & { createMultipleRuns?: Types.Maybe<(
     { __typename: 'CreateMultipleRunsPayload' }
@@ -127,7 +128,7 @@ export type UpdateRunMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateRunMutation = (
+export type UpdateRunMutationData = (
   { __typename: 'Mutation' }
   & { updateRun?: Types.Maybe<(
     { __typename: 'UpdateRunPayload' }
@@ -144,7 +145,7 @@ export type DeleteRunMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteRunMutation = (
+export type DeleteRunMutationData = (
   { __typename: 'Mutation' }
   & { deleteRun?: Types.Maybe<(
     { __typename: 'DeleteRunPayload' }
@@ -161,7 +162,7 @@ export type CreateMaximumEventProvidedTicketsOverrideMutationVariables = Types.E
 }>;
 
 
-export type CreateMaximumEventProvidedTicketsOverrideMutation = (
+export type CreateMaximumEventProvidedTicketsOverrideMutationData = (
   { __typename: 'Mutation' }
   & { createMaximumEventProvidedTicketsOverride?: Types.Maybe<(
     { __typename: 'CreateMaximumEventProvidedTicketsOverridePayload' }
@@ -178,7 +179,7 @@ export type DeleteMaximumEventProvidedTicketsOverrideMutationVariables = Types.E
 }>;
 
 
-export type DeleteMaximumEventProvidedTicketsOverrideMutation = (
+export type DeleteMaximumEventProvidedTicketsOverrideMutationData = (
   { __typename: 'Mutation' }
   & { deleteMaximumEventProvidedTicketsOverride?: Types.Maybe<(
     { __typename: 'DeleteMaximumEventProvidedTicketsOverridePayload' }
@@ -195,7 +196,7 @@ export type UpdateMaximumEventProvidedTicketsOverrideMutationVariables = Types.E
 }>;
 
 
-export type UpdateMaximumEventProvidedTicketsOverrideMutation = (
+export type UpdateMaximumEventProvidedTicketsOverrideMutationData = (
   { __typename: 'Mutation' }
   & { updateMaximumEventProvidedTicketsOverride?: Types.Maybe<(
     { __typename: 'UpdateMaximumEventProvidedTicketsOverridePayload' }
@@ -213,7 +214,7 @@ export type UpdateEventAdminNotesMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateEventAdminNotesMutation = (
+export type UpdateEventAdminNotesMutationData = (
   { __typename: 'Mutation' }
   & { updateEventAdminNotes?: Types.Maybe<(
     { __typename: 'UpdateEventAdminNotesPayload' }
@@ -236,7 +237,7 @@ export const CreateEventDocument = gql`
   }
 }
     ${EventFieldsFragmentDoc}`;
-export type CreateEventMutationFn = Apollo.MutationFunction<CreateEventMutation, CreateEventMutationVariables>;
+export type CreateEventMutationFn = Apollo.MutationFunction<CreateEventMutationData, CreateEventMutationVariables>;
 
 /**
  * __useCreateEventMutation__
@@ -255,12 +256,13 @@ export type CreateEventMutationFn = Apollo.MutationFunction<CreateEventMutation,
  *   },
  * });
  */
-export function useCreateEventMutation(baseOptions?: Apollo.MutationHookOptions<CreateEventMutation, CreateEventMutationVariables>) {
-        return Apollo.useMutation<CreateEventMutation, CreateEventMutationVariables>(CreateEventDocument, baseOptions);
+export function useCreateEventMutation(baseOptions?: Apollo.MutationHookOptions<CreateEventMutationData, CreateEventMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateEventMutationData, CreateEventMutationVariables>(CreateEventDocument, options);
       }
 export type CreateEventMutationHookResult = ReturnType<typeof useCreateEventMutation>;
-export type CreateEventMutationResult = Apollo.MutationResult<CreateEventMutation>;
-export type CreateEventMutationOptions = Apollo.BaseMutationOptions<CreateEventMutation, CreateEventMutationVariables>;
+export type CreateEventMutationResult = Apollo.MutationResult<CreateEventMutationData>;
+export type CreateEventMutationOptions = Apollo.BaseMutationOptions<CreateEventMutationData, CreateEventMutationVariables>;
 export const CreateFillerEventDocument = gql`
     mutation CreateFillerEvent($input: CreateFillerEventInput!) {
   createFillerEvent(input: $input) {
@@ -271,7 +273,7 @@ export const CreateFillerEventDocument = gql`
   }
 }
     ${EventFieldsFragmentDoc}`;
-export type CreateFillerEventMutationFn = Apollo.MutationFunction<CreateFillerEventMutation, CreateFillerEventMutationVariables>;
+export type CreateFillerEventMutationFn = Apollo.MutationFunction<CreateFillerEventMutationData, CreateFillerEventMutationVariables>;
 
 /**
  * __useCreateFillerEventMutation__
@@ -290,12 +292,13 @@ export type CreateFillerEventMutationFn = Apollo.MutationFunction<CreateFillerEv
  *   },
  * });
  */
-export function useCreateFillerEventMutation(baseOptions?: Apollo.MutationHookOptions<CreateFillerEventMutation, CreateFillerEventMutationVariables>) {
-        return Apollo.useMutation<CreateFillerEventMutation, CreateFillerEventMutationVariables>(CreateFillerEventDocument, baseOptions);
+export function useCreateFillerEventMutation(baseOptions?: Apollo.MutationHookOptions<CreateFillerEventMutationData, CreateFillerEventMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateFillerEventMutationData, CreateFillerEventMutationVariables>(CreateFillerEventDocument, options);
       }
 export type CreateFillerEventMutationHookResult = ReturnType<typeof useCreateFillerEventMutation>;
-export type CreateFillerEventMutationResult = Apollo.MutationResult<CreateFillerEventMutation>;
-export type CreateFillerEventMutationOptions = Apollo.BaseMutationOptions<CreateFillerEventMutation, CreateFillerEventMutationVariables>;
+export type CreateFillerEventMutationResult = Apollo.MutationResult<CreateFillerEventMutationData>;
+export type CreateFillerEventMutationOptions = Apollo.BaseMutationOptions<CreateFillerEventMutationData, CreateFillerEventMutationVariables>;
 export const DropEventDocument = gql`
     mutation DropEvent($input: DropEventInput!) {
   dropEvent(input: $input) {
@@ -306,7 +309,7 @@ export const DropEventDocument = gql`
   }
 }
     `;
-export type DropEventMutationFn = Apollo.MutationFunction<DropEventMutation, DropEventMutationVariables>;
+export type DropEventMutationFn = Apollo.MutationFunction<DropEventMutationData, DropEventMutationVariables>;
 
 /**
  * __useDropEventMutation__
@@ -325,12 +328,13 @@ export type DropEventMutationFn = Apollo.MutationFunction<DropEventMutation, Dro
  *   },
  * });
  */
-export function useDropEventMutation(baseOptions?: Apollo.MutationHookOptions<DropEventMutation, DropEventMutationVariables>) {
-        return Apollo.useMutation<DropEventMutation, DropEventMutationVariables>(DropEventDocument, baseOptions);
+export function useDropEventMutation(baseOptions?: Apollo.MutationHookOptions<DropEventMutationData, DropEventMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DropEventMutationData, DropEventMutationVariables>(DropEventDocument, options);
       }
 export type DropEventMutationHookResult = ReturnType<typeof useDropEventMutation>;
-export type DropEventMutationResult = Apollo.MutationResult<DropEventMutation>;
-export type DropEventMutationOptions = Apollo.BaseMutationOptions<DropEventMutation, DropEventMutationVariables>;
+export type DropEventMutationResult = Apollo.MutationResult<DropEventMutationData>;
+export type DropEventMutationOptions = Apollo.BaseMutationOptions<DropEventMutationData, DropEventMutationVariables>;
 export const RestoreDroppedEventDocument = gql`
     mutation RestoreDroppedEvent($input: RestoreDroppedEventInput!) {
   restoreDroppedEvent(input: $input) {
@@ -341,7 +345,7 @@ export const RestoreDroppedEventDocument = gql`
   }
 }
     `;
-export type RestoreDroppedEventMutationFn = Apollo.MutationFunction<RestoreDroppedEventMutation, RestoreDroppedEventMutationVariables>;
+export type RestoreDroppedEventMutationFn = Apollo.MutationFunction<RestoreDroppedEventMutationData, RestoreDroppedEventMutationVariables>;
 
 /**
  * __useRestoreDroppedEventMutation__
@@ -360,12 +364,13 @@ export type RestoreDroppedEventMutationFn = Apollo.MutationFunction<RestoreDropp
  *   },
  * });
  */
-export function useRestoreDroppedEventMutation(baseOptions?: Apollo.MutationHookOptions<RestoreDroppedEventMutation, RestoreDroppedEventMutationVariables>) {
-        return Apollo.useMutation<RestoreDroppedEventMutation, RestoreDroppedEventMutationVariables>(RestoreDroppedEventDocument, baseOptions);
+export function useRestoreDroppedEventMutation(baseOptions?: Apollo.MutationHookOptions<RestoreDroppedEventMutationData, RestoreDroppedEventMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RestoreDroppedEventMutationData, RestoreDroppedEventMutationVariables>(RestoreDroppedEventDocument, options);
       }
 export type RestoreDroppedEventMutationHookResult = ReturnType<typeof useRestoreDroppedEventMutation>;
-export type RestoreDroppedEventMutationResult = Apollo.MutationResult<RestoreDroppedEventMutation>;
-export type RestoreDroppedEventMutationOptions = Apollo.BaseMutationOptions<RestoreDroppedEventMutation, RestoreDroppedEventMutationVariables>;
+export type RestoreDroppedEventMutationResult = Apollo.MutationResult<RestoreDroppedEventMutationData>;
+export type RestoreDroppedEventMutationOptions = Apollo.BaseMutationOptions<RestoreDroppedEventMutationData, RestoreDroppedEventMutationVariables>;
 export const UpdateEventDocument = gql`
     mutation UpdateEvent($input: UpdateEventInput!) {
   updateEvent(input: $input) {
@@ -376,7 +381,7 @@ export const UpdateEventDocument = gql`
   }
 }
     ${EventFieldsFragmentDoc}`;
-export type UpdateEventMutationFn = Apollo.MutationFunction<UpdateEventMutation, UpdateEventMutationVariables>;
+export type UpdateEventMutationFn = Apollo.MutationFunction<UpdateEventMutationData, UpdateEventMutationVariables>;
 
 /**
  * __useUpdateEventMutation__
@@ -395,12 +400,13 @@ export type UpdateEventMutationFn = Apollo.MutationFunction<UpdateEventMutation,
  *   },
  * });
  */
-export function useUpdateEventMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventMutation, UpdateEventMutationVariables>) {
-        return Apollo.useMutation<UpdateEventMutation, UpdateEventMutationVariables>(UpdateEventDocument, baseOptions);
+export function useUpdateEventMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventMutationData, UpdateEventMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateEventMutationData, UpdateEventMutationVariables>(UpdateEventDocument, options);
       }
 export type UpdateEventMutationHookResult = ReturnType<typeof useUpdateEventMutation>;
-export type UpdateEventMutationResult = Apollo.MutationResult<UpdateEventMutation>;
-export type UpdateEventMutationOptions = Apollo.BaseMutationOptions<UpdateEventMutation, UpdateEventMutationVariables>;
+export type UpdateEventMutationResult = Apollo.MutationResult<UpdateEventMutationData>;
+export type UpdateEventMutationOptions = Apollo.BaseMutationOptions<UpdateEventMutationData, UpdateEventMutationVariables>;
 export const CreateRunDocument = gql`
     mutation CreateRun($input: CreateRunInput!) {
   createRun(input: $input) {
@@ -411,7 +417,7 @@ export const CreateRunDocument = gql`
   }
 }
     ${RunFieldsFragmentDoc}`;
-export type CreateRunMutationFn = Apollo.MutationFunction<CreateRunMutation, CreateRunMutationVariables>;
+export type CreateRunMutationFn = Apollo.MutationFunction<CreateRunMutationData, CreateRunMutationVariables>;
 
 /**
  * __useCreateRunMutation__
@@ -430,12 +436,13 @@ export type CreateRunMutationFn = Apollo.MutationFunction<CreateRunMutation, Cre
  *   },
  * });
  */
-export function useCreateRunMutation(baseOptions?: Apollo.MutationHookOptions<CreateRunMutation, CreateRunMutationVariables>) {
-        return Apollo.useMutation<CreateRunMutation, CreateRunMutationVariables>(CreateRunDocument, baseOptions);
+export function useCreateRunMutation(baseOptions?: Apollo.MutationHookOptions<CreateRunMutationData, CreateRunMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateRunMutationData, CreateRunMutationVariables>(CreateRunDocument, options);
       }
 export type CreateRunMutationHookResult = ReturnType<typeof useCreateRunMutation>;
-export type CreateRunMutationResult = Apollo.MutationResult<CreateRunMutation>;
-export type CreateRunMutationOptions = Apollo.BaseMutationOptions<CreateRunMutation, CreateRunMutationVariables>;
+export type CreateRunMutationResult = Apollo.MutationResult<CreateRunMutationData>;
+export type CreateRunMutationOptions = Apollo.BaseMutationOptions<CreateRunMutationData, CreateRunMutationVariables>;
 export const CreateMultipleRunsDocument = gql`
     mutation CreateMultipleRuns($input: CreateMultipleRunsInput!) {
   createMultipleRuns(input: $input) {
@@ -446,7 +453,7 @@ export const CreateMultipleRunsDocument = gql`
   }
 }
     ${RunFieldsFragmentDoc}`;
-export type CreateMultipleRunsMutationFn = Apollo.MutationFunction<CreateMultipleRunsMutation, CreateMultipleRunsMutationVariables>;
+export type CreateMultipleRunsMutationFn = Apollo.MutationFunction<CreateMultipleRunsMutationData, CreateMultipleRunsMutationVariables>;
 
 /**
  * __useCreateMultipleRunsMutation__
@@ -465,12 +472,13 @@ export type CreateMultipleRunsMutationFn = Apollo.MutationFunction<CreateMultipl
  *   },
  * });
  */
-export function useCreateMultipleRunsMutation(baseOptions?: Apollo.MutationHookOptions<CreateMultipleRunsMutation, CreateMultipleRunsMutationVariables>) {
-        return Apollo.useMutation<CreateMultipleRunsMutation, CreateMultipleRunsMutationVariables>(CreateMultipleRunsDocument, baseOptions);
+export function useCreateMultipleRunsMutation(baseOptions?: Apollo.MutationHookOptions<CreateMultipleRunsMutationData, CreateMultipleRunsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateMultipleRunsMutationData, CreateMultipleRunsMutationVariables>(CreateMultipleRunsDocument, options);
       }
 export type CreateMultipleRunsMutationHookResult = ReturnType<typeof useCreateMultipleRunsMutation>;
-export type CreateMultipleRunsMutationResult = Apollo.MutationResult<CreateMultipleRunsMutation>;
-export type CreateMultipleRunsMutationOptions = Apollo.BaseMutationOptions<CreateMultipleRunsMutation, CreateMultipleRunsMutationVariables>;
+export type CreateMultipleRunsMutationResult = Apollo.MutationResult<CreateMultipleRunsMutationData>;
+export type CreateMultipleRunsMutationOptions = Apollo.BaseMutationOptions<CreateMultipleRunsMutationData, CreateMultipleRunsMutationVariables>;
 export const UpdateRunDocument = gql`
     mutation UpdateRun($input: UpdateRunInput!) {
   updateRun(input: $input) {
@@ -481,7 +489,7 @@ export const UpdateRunDocument = gql`
   }
 }
     ${RunFieldsFragmentDoc}`;
-export type UpdateRunMutationFn = Apollo.MutationFunction<UpdateRunMutation, UpdateRunMutationVariables>;
+export type UpdateRunMutationFn = Apollo.MutationFunction<UpdateRunMutationData, UpdateRunMutationVariables>;
 
 /**
  * __useUpdateRunMutation__
@@ -500,12 +508,13 @@ export type UpdateRunMutationFn = Apollo.MutationFunction<UpdateRunMutation, Upd
  *   },
  * });
  */
-export function useUpdateRunMutation(baseOptions?: Apollo.MutationHookOptions<UpdateRunMutation, UpdateRunMutationVariables>) {
-        return Apollo.useMutation<UpdateRunMutation, UpdateRunMutationVariables>(UpdateRunDocument, baseOptions);
+export function useUpdateRunMutation(baseOptions?: Apollo.MutationHookOptions<UpdateRunMutationData, UpdateRunMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateRunMutationData, UpdateRunMutationVariables>(UpdateRunDocument, options);
       }
 export type UpdateRunMutationHookResult = ReturnType<typeof useUpdateRunMutation>;
-export type UpdateRunMutationResult = Apollo.MutationResult<UpdateRunMutation>;
-export type UpdateRunMutationOptions = Apollo.BaseMutationOptions<UpdateRunMutation, UpdateRunMutationVariables>;
+export type UpdateRunMutationResult = Apollo.MutationResult<UpdateRunMutationData>;
+export type UpdateRunMutationOptions = Apollo.BaseMutationOptions<UpdateRunMutationData, UpdateRunMutationVariables>;
 export const DeleteRunDocument = gql`
     mutation DeleteRun($input: DeleteRunInput!) {
   deleteRun(input: $input) {
@@ -516,7 +525,7 @@ export const DeleteRunDocument = gql`
   }
 }
     ${RunFieldsFragmentDoc}`;
-export type DeleteRunMutationFn = Apollo.MutationFunction<DeleteRunMutation, DeleteRunMutationVariables>;
+export type DeleteRunMutationFn = Apollo.MutationFunction<DeleteRunMutationData, DeleteRunMutationVariables>;
 
 /**
  * __useDeleteRunMutation__
@@ -535,12 +544,13 @@ export type DeleteRunMutationFn = Apollo.MutationFunction<DeleteRunMutation, Del
  *   },
  * });
  */
-export function useDeleteRunMutation(baseOptions?: Apollo.MutationHookOptions<DeleteRunMutation, DeleteRunMutationVariables>) {
-        return Apollo.useMutation<DeleteRunMutation, DeleteRunMutationVariables>(DeleteRunDocument, baseOptions);
+export function useDeleteRunMutation(baseOptions?: Apollo.MutationHookOptions<DeleteRunMutationData, DeleteRunMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteRunMutationData, DeleteRunMutationVariables>(DeleteRunDocument, options);
       }
 export type DeleteRunMutationHookResult = ReturnType<typeof useDeleteRunMutation>;
-export type DeleteRunMutationResult = Apollo.MutationResult<DeleteRunMutation>;
-export type DeleteRunMutationOptions = Apollo.BaseMutationOptions<DeleteRunMutation, DeleteRunMutationVariables>;
+export type DeleteRunMutationResult = Apollo.MutationResult<DeleteRunMutationData>;
+export type DeleteRunMutationOptions = Apollo.BaseMutationOptions<DeleteRunMutationData, DeleteRunMutationVariables>;
 export const CreateMaximumEventProvidedTicketsOverrideDocument = gql`
     mutation CreateMaximumEventProvidedTicketsOverride($input: CreateMaximumEventProvidedTicketsOverrideInput!) {
   createMaximumEventProvidedTicketsOverride(input: $input) {
@@ -551,7 +561,7 @@ export const CreateMaximumEventProvidedTicketsOverrideDocument = gql`
   }
 }
     ${MaximumEventProvidedTicketsOverrideFieldsFragmentDoc}`;
-export type CreateMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<CreateMaximumEventProvidedTicketsOverrideMutation, CreateMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type CreateMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<CreateMaximumEventProvidedTicketsOverrideMutationData, CreateMaximumEventProvidedTicketsOverrideMutationVariables>;
 
 /**
  * __useCreateMaximumEventProvidedTicketsOverrideMutation__
@@ -570,12 +580,13 @@ export type CreateMaximumEventProvidedTicketsOverrideMutationFn = Apollo.Mutatio
  *   },
  * });
  */
-export function useCreateMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<CreateMaximumEventProvidedTicketsOverrideMutation, CreateMaximumEventProvidedTicketsOverrideMutationVariables>) {
-        return Apollo.useMutation<CreateMaximumEventProvidedTicketsOverrideMutation, CreateMaximumEventProvidedTicketsOverrideMutationVariables>(CreateMaximumEventProvidedTicketsOverrideDocument, baseOptions);
+export function useCreateMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<CreateMaximumEventProvidedTicketsOverrideMutationData, CreateMaximumEventProvidedTicketsOverrideMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateMaximumEventProvidedTicketsOverrideMutationData, CreateMaximumEventProvidedTicketsOverrideMutationVariables>(CreateMaximumEventProvidedTicketsOverrideDocument, options);
       }
 export type CreateMaximumEventProvidedTicketsOverrideMutationHookResult = ReturnType<typeof useCreateMaximumEventProvidedTicketsOverrideMutation>;
-export type CreateMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<CreateMaximumEventProvidedTicketsOverrideMutation>;
-export type CreateMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<CreateMaximumEventProvidedTicketsOverrideMutation, CreateMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type CreateMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<CreateMaximumEventProvidedTicketsOverrideMutationData>;
+export type CreateMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<CreateMaximumEventProvidedTicketsOverrideMutationData, CreateMaximumEventProvidedTicketsOverrideMutationVariables>;
 export const DeleteMaximumEventProvidedTicketsOverrideDocument = gql`
     mutation DeleteMaximumEventProvidedTicketsOverride($input: DeleteMaximumEventProvidedTicketsOverrideInput!) {
   deleteMaximumEventProvidedTicketsOverride(input: $input) {
@@ -586,7 +597,7 @@ export const DeleteMaximumEventProvidedTicketsOverrideDocument = gql`
   }
 }
     ${MaximumEventProvidedTicketsOverrideFieldsFragmentDoc}`;
-export type DeleteMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<DeleteMaximumEventProvidedTicketsOverrideMutation, DeleteMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type DeleteMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<DeleteMaximumEventProvidedTicketsOverrideMutationData, DeleteMaximumEventProvidedTicketsOverrideMutationVariables>;
 
 /**
  * __useDeleteMaximumEventProvidedTicketsOverrideMutation__
@@ -605,12 +616,13 @@ export type DeleteMaximumEventProvidedTicketsOverrideMutationFn = Apollo.Mutatio
  *   },
  * });
  */
-export function useDeleteMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<DeleteMaximumEventProvidedTicketsOverrideMutation, DeleteMaximumEventProvidedTicketsOverrideMutationVariables>) {
-        return Apollo.useMutation<DeleteMaximumEventProvidedTicketsOverrideMutation, DeleteMaximumEventProvidedTicketsOverrideMutationVariables>(DeleteMaximumEventProvidedTicketsOverrideDocument, baseOptions);
+export function useDeleteMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<DeleteMaximumEventProvidedTicketsOverrideMutationData, DeleteMaximumEventProvidedTicketsOverrideMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteMaximumEventProvidedTicketsOverrideMutationData, DeleteMaximumEventProvidedTicketsOverrideMutationVariables>(DeleteMaximumEventProvidedTicketsOverrideDocument, options);
       }
 export type DeleteMaximumEventProvidedTicketsOverrideMutationHookResult = ReturnType<typeof useDeleteMaximumEventProvidedTicketsOverrideMutation>;
-export type DeleteMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<DeleteMaximumEventProvidedTicketsOverrideMutation>;
-export type DeleteMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<DeleteMaximumEventProvidedTicketsOverrideMutation, DeleteMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type DeleteMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<DeleteMaximumEventProvidedTicketsOverrideMutationData>;
+export type DeleteMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<DeleteMaximumEventProvidedTicketsOverrideMutationData, DeleteMaximumEventProvidedTicketsOverrideMutationVariables>;
 export const UpdateMaximumEventProvidedTicketsOverrideDocument = gql`
     mutation UpdateMaximumEventProvidedTicketsOverride($input: UpdateMaximumEventProvidedTicketsOverrideInput!) {
   updateMaximumEventProvidedTicketsOverride(input: $input) {
@@ -621,7 +633,7 @@ export const UpdateMaximumEventProvidedTicketsOverrideDocument = gql`
   }
 }
     ${MaximumEventProvidedTicketsOverrideFieldsFragmentDoc}`;
-export type UpdateMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<UpdateMaximumEventProvidedTicketsOverrideMutation, UpdateMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type UpdateMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<UpdateMaximumEventProvidedTicketsOverrideMutationData, UpdateMaximumEventProvidedTicketsOverrideMutationVariables>;
 
 /**
  * __useUpdateMaximumEventProvidedTicketsOverrideMutation__
@@ -640,12 +652,13 @@ export type UpdateMaximumEventProvidedTicketsOverrideMutationFn = Apollo.Mutatio
  *   },
  * });
  */
-export function useUpdateMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<UpdateMaximumEventProvidedTicketsOverrideMutation, UpdateMaximumEventProvidedTicketsOverrideMutationVariables>) {
-        return Apollo.useMutation<UpdateMaximumEventProvidedTicketsOverrideMutation, UpdateMaximumEventProvidedTicketsOverrideMutationVariables>(UpdateMaximumEventProvidedTicketsOverrideDocument, baseOptions);
+export function useUpdateMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<UpdateMaximumEventProvidedTicketsOverrideMutationData, UpdateMaximumEventProvidedTicketsOverrideMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateMaximumEventProvidedTicketsOverrideMutationData, UpdateMaximumEventProvidedTicketsOverrideMutationVariables>(UpdateMaximumEventProvidedTicketsOverrideDocument, options);
       }
 export type UpdateMaximumEventProvidedTicketsOverrideMutationHookResult = ReturnType<typeof useUpdateMaximumEventProvidedTicketsOverrideMutation>;
-export type UpdateMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<UpdateMaximumEventProvidedTicketsOverrideMutation>;
-export type UpdateMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<UpdateMaximumEventProvidedTicketsOverrideMutation, UpdateMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type UpdateMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<UpdateMaximumEventProvidedTicketsOverrideMutationData>;
+export type UpdateMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<UpdateMaximumEventProvidedTicketsOverrideMutationData, UpdateMaximumEventProvidedTicketsOverrideMutationVariables>;
 export const UpdateEventAdminNotesDocument = gql`
     mutation UpdateEventAdminNotes($eventId: Int!, $adminNotes: String!) {
   updateEventAdminNotes(input: {id: $eventId, admin_notes: $adminNotes}) {
@@ -656,7 +669,7 @@ export const UpdateEventAdminNotesDocument = gql`
   }
 }
     ${EventFieldsFragmentDoc}`;
-export type UpdateEventAdminNotesMutationFn = Apollo.MutationFunction<UpdateEventAdminNotesMutation, UpdateEventAdminNotesMutationVariables>;
+export type UpdateEventAdminNotesMutationFn = Apollo.MutationFunction<UpdateEventAdminNotesMutationData, UpdateEventAdminNotesMutationVariables>;
 
 /**
  * __useUpdateEventAdminNotesMutation__
@@ -676,9 +689,10 @@ export type UpdateEventAdminNotesMutationFn = Apollo.MutationFunction<UpdateEven
  *   },
  * });
  */
-export function useUpdateEventAdminNotesMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventAdminNotesMutation, UpdateEventAdminNotesMutationVariables>) {
-        return Apollo.useMutation<UpdateEventAdminNotesMutation, UpdateEventAdminNotesMutationVariables>(UpdateEventAdminNotesDocument, baseOptions);
+export function useUpdateEventAdminNotesMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventAdminNotesMutationData, UpdateEventAdminNotesMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateEventAdminNotesMutationData, UpdateEventAdminNotesMutationVariables>(UpdateEventAdminNotesDocument, options);
       }
 export type UpdateEventAdminNotesMutationHookResult = ReturnType<typeof useUpdateEventAdminNotesMutation>;
-export type UpdateEventAdminNotesMutationResult = Apollo.MutationResult<UpdateEventAdminNotesMutation>;
-export type UpdateEventAdminNotesMutationOptions = Apollo.BaseMutationOptions<UpdateEventAdminNotesMutation, UpdateEventAdminNotesMutationVariables>;
+export type UpdateEventAdminNotesMutationResult = Apollo.MutationResult<UpdateEventAdminNotesMutationData>;
+export type UpdateEventAdminNotesMutationOptions = Apollo.BaseMutationOptions<UpdateEventAdminNotesMutationData, UpdateEventAdminNotesMutationVariables>;

--- a/app/javascript/EventAdmin/queries.generated.ts
+++ b/app/javascript/EventAdmin/queries.generated.ts
@@ -5,6 +5,7 @@ import { CommonFormFieldsFragment, CommonFormSectionFieldsFragment, CommonFormIt
 import { gql } from '@apollo/client';
 import { CommonFormFieldsFragmentDoc, CommonFormSectionFieldsFragmentDoc, CommonFormItemFieldsFragmentDoc } from '../Models/commonFormFragments.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type TicketTypeFieldsFragment = (
   { __typename: 'TicketType' }
   & Pick<Types.TicketType, 'id' | 'description' | 'maximum_event_provided_tickets'>
@@ -101,10 +102,10 @@ export type EventFieldsFragment = (
   )> }
 );
 
-export type EventAdminEventsQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type EventAdminEventsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type EventAdminEventsQueryQuery = (
+export type EventAdminEventsQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -285,26 +286,28 @@ export const EventAdminEventsQueryDocument = gql`
 ${EventFieldsFragmentDoc}`;
 
 /**
- * __useEventAdminEventsQueryQuery__
+ * __useEventAdminEventsQuery__
  *
- * To run a query within a React component, call `useEventAdminEventsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventAdminEventsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventAdminEventsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventAdminEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventAdminEventsQueryQuery({
+ * const { data, loading, error } = useEventAdminEventsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useEventAdminEventsQueryQuery(baseOptions?: Apollo.QueryHookOptions<EventAdminEventsQueryQuery, EventAdminEventsQueryQueryVariables>) {
-        return Apollo.useQuery<EventAdminEventsQueryQuery, EventAdminEventsQueryQueryVariables>(EventAdminEventsQueryDocument, baseOptions);
+export function useEventAdminEventsQuery(baseOptions?: Apollo.QueryHookOptions<EventAdminEventsQueryData, EventAdminEventsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventAdminEventsQueryData, EventAdminEventsQueryVariables>(EventAdminEventsQueryDocument, options);
       }
-export function useEventAdminEventsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventAdminEventsQueryQuery, EventAdminEventsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventAdminEventsQueryQuery, EventAdminEventsQueryQueryVariables>(EventAdminEventsQueryDocument, baseOptions);
+export function useEventAdminEventsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventAdminEventsQueryData, EventAdminEventsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventAdminEventsQueryData, EventAdminEventsQueryVariables>(EventAdminEventsQueryDocument, options);
         }
-export type EventAdminEventsQueryQueryHookResult = ReturnType<typeof useEventAdminEventsQueryQuery>;
+export type EventAdminEventsQueryHookResult = ReturnType<typeof useEventAdminEventsQuery>;
 export type EventAdminEventsQueryLazyQueryHookResult = ReturnType<typeof useEventAdminEventsQueryLazyQuery>;
-export type EventAdminEventsQueryQueryResult = Apollo.QueryResult<EventAdminEventsQueryQuery, EventAdminEventsQueryQueryVariables>;
+export type EventAdminEventsQueryDataResult = Apollo.QueryResult<EventAdminEventsQueryData, EventAdminEventsQueryVariables>;

--- a/app/javascript/EventAdmin/useCreateEvent.ts
+++ b/app/javascript/EventAdmin/useCreateEvent.ts
@@ -4,24 +4,21 @@ import { buildEventInput, buildRunInput } from './InputBuilders';
 import { CreateEvent, CreateFillerEvent } from './mutations';
 import { EventAdminEventsQuery } from './queries';
 import { useCreateMutation } from '../MutationUtils';
+import { EventAdminEventsQueryData, EventAdminEventsQueryVariables } from './queries.generated';
 import {
-  EventAdminEventsQueryQuery,
-  EventAdminEventsQueryQueryVariables,
-} from './queries.generated';
-import {
-  CreateEventMutation,
+  CreateEventMutationData,
   CreateEventMutationVariables,
-  CreateFillerEventMutation,
+  CreateFillerEventMutationData,
   CreateFillerEventMutationVariables,
 } from './mutations.generated';
 import { SchedulingUi } from '../graphqlTypes.generated';
 
 export function useCreateRegularEvent() {
   const mutate = useCreateMutation<
-    EventAdminEventsQueryQuery,
-    EventAdminEventsQueryQueryVariables,
+    EventAdminEventsQueryData,
+    EventAdminEventsQueryVariables,
     CreateEventMutationVariables,
-    CreateEventMutation
+    CreateEventMutationData
   >(CreateEvent, {
     query: EventAdminEventsQuery,
     arrayPath: ['events'],
@@ -43,10 +40,10 @@ export function useCreateRegularEvent() {
 
 export function useCreateSingleRunEvent() {
   const mutate = useCreateMutation<
-    EventAdminEventsQueryQuery,
-    EventAdminEventsQueryQueryVariables,
+    EventAdminEventsQueryData,
+    EventAdminEventsQueryVariables,
     CreateFillerEventMutationVariables,
-    CreateFillerEventMutation
+    CreateFillerEventMutationData
   >(CreateFillerEvent, {
     query: EventAdminEventsQuery,
     arrayPath: ['events'],

--- a/app/javascript/EventAdmin/useEventAdminCategory.ts
+++ b/app/javascript/EventAdmin/useEventAdminCategory.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Event } from '../graphqlTypes.generated';
 import { sortByLocaleString } from '../ValueUtils';
-import { EventAdminEventsQueryQuery } from './queries.generated';
+import { EventAdminEventsQueryData } from './queries.generated';
 
 function getNormalizedEventTitle<EventType extends Pick<Event, 'title'>>(event: EventType) {
   return (event.title ?? '')
@@ -11,7 +11,7 @@ function getNormalizedEventTitle<EventType extends Pick<Event, 'title'>>(event: 
 }
 
 export default function useEventAdminCategory(
-  data: EventAdminEventsQueryQuery | undefined,
+  data: EventAdminEventsQueryData | undefined,
   loading: boolean,
   error: Error | undefined,
   eventCategoryId: number,

--- a/app/javascript/EventAdmin/useUpdateEvent.ts
+++ b/app/javascript/EventAdmin/useUpdateEvent.ts
@@ -7,7 +7,7 @@ import {
   useUpdateEventMutation,
   useUpdateRunMutation,
 } from './mutations.generated';
-import { EventAdminEventsQueryQuery } from './queries.generated';
+import { EventAdminEventsQueryData } from './queries.generated';
 import { EventCategory, SchedulingUi } from '../graphqlTypes.generated';
 
 function useUpdateRegularEvent() {
@@ -68,7 +68,7 @@ function useUpdateSingleRunEvent() {
             },
           },
           update: (store, { data }) => {
-            const eventsData = store.readQuery<EventAdminEventsQueryQuery>({
+            const eventsData = store.readQuery<EventAdminEventsQueryData>({
               query: EventAdminEventsQuery,
             });
             const newRun = data?.createRun?.run;

--- a/app/javascript/EventCategoryAdmin/EditEventCategory.tsx
+++ b/app/javascript/EventCategoryAdmin/EditEventCategory.tsx
@@ -8,11 +8,11 @@ import ErrorDisplay from '../ErrorDisplay';
 import useAsyncFunction from '../useAsyncFunction';
 import usePageTitle from '../usePageTitle';
 import { LoadSingleValueFromCollectionWrapper } from '../GraphqlLoadingWrappers';
-import { useEventCategoryAdminQueryQuery } from './queries.generated';
+import { useEventCategoryAdminQuery } from './queries.generated';
 import { useUpdateEventCategoryMutation } from './mutations.generated';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useEventCategoryAdminQueryQuery,
+  useEventCategoryAdminQuery,
   (data, id) => data.convention.event_categories.find((c) => c.id.toString() === id),
   function EditEventCategoryForm({ value: initialEventCategory, data: { convention } }) {
     const history = useHistory();

--- a/app/javascript/EventCategoryAdmin/EventCategoryIndex.tsx
+++ b/app/javascript/EventCategoryAdmin/EventCategoryIndex.tsx
@@ -3,12 +3,10 @@ import { Link } from 'react-router-dom';
 import EventCategoryRow from './EventCategoryRow';
 import { sortByLocaleString } from '../ValueUtils';
 import usePageTitle from '../usePageTitle';
-import { useEventCategoryAdminQueryQuery } from './queries.generated';
+import { useEventCategoryAdminQuery } from './queries.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 
-export default LoadQueryWrapper(useEventCategoryAdminQueryQuery, function EventCategoryIndex({
-  data,
-}) {
+export default LoadQueryWrapper(useEventCategoryAdminQuery, function EventCategoryIndex({ data }) {
   usePageTitle('Event Categories');
 
   const { event_categories: eventCategories } = data!.convention;

--- a/app/javascript/EventCategoryAdmin/EventCategoryRow.tsx
+++ b/app/javascript/EventCategoryAdmin/EventCategoryRow.tsx
@@ -8,10 +8,10 @@ import pluralizeWithCount from '../pluralizeWithCount';
 import { useConfirm } from '../ModalDialogs/Confirm';
 import { useDeleteMutation } from '../MutationUtils';
 import ButtonWithTooltip from '../UIComponents/ButtonWithTooltip';
-import { EventCategoryAdminQueryQuery } from './queries.generated';
+import { EventCategoryAdminQueryData } from './queries.generated';
 
 export type EventCategoryRowProps = {
-  eventCategory: EventCategoryAdminQueryQuery['convention']['event_categories'][0];
+  eventCategory: EventCategoryAdminQueryData['convention']['event_categories'][0];
 };
 
 function EventCategoryRow({ eventCategory }: EventCategoryRowProps) {

--- a/app/javascript/EventCategoryAdmin/NewEventCategory.tsx
+++ b/app/javascript/EventCategoryAdmin/NewEventCategory.tsx
@@ -11,11 +11,11 @@ import useAsyncFunction from '../useAsyncFunction';
 import { useCreateMutation } from '../MutationUtils';
 import usePageTitle from '../usePageTitle';
 import PageLoadingIndicator from '../PageLoadingIndicator';
-import { useEventCategoryAdminQueryQuery } from './queries.generated';
+import { useEventCategoryAdminQuery } from './queries.generated';
 
 function NewEventCategory() {
   const history = useHistory();
-  const { data, loading, error } = useEventCategoryAdminQueryQuery();
+  const { data, loading, error } = useEventCategoryAdminQuery();
   const [create, createError, createInProgress] = useAsyncFunction(
     useCreateMutation(CreateEventCategory, {
       query: EventCategoryAdminQuery,

--- a/app/javascript/EventCategoryAdmin/mutations.generated.ts
+++ b/app/javascript/EventCategoryAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { EventCategoryFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { EventCategoryFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateEventCategoryMutationVariables = Types.Exact<{
   eventCategory: Types.EventCategoryInput;
 }>;
 
 
-export type CreateEventCategoryMutation = (
+export type CreateEventCategoryMutationData = (
   { __typename: 'Mutation' }
   & { createEventCategory?: Types.Maybe<(
     { __typename: 'CreateEventCategoryPayload' }
@@ -28,7 +29,7 @@ export type UpdateEventCategoryMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateEventCategoryMutation = (
+export type UpdateEventCategoryMutationData = (
   { __typename: 'Mutation' }
   & { updateEventCategory?: Types.Maybe<(
     { __typename: 'UpdateEventCategoryPayload' }
@@ -45,7 +46,7 @@ export type DeleteEventCategoryMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteEventCategoryMutation = (
+export type DeleteEventCategoryMutationData = (
   { __typename: 'Mutation' }
   & { deleteEventCategory?: Types.Maybe<(
     { __typename: 'DeleteEventCategoryPayload' }
@@ -64,7 +65,7 @@ export const CreateEventCategoryDocument = gql`
   }
 }
     ${EventCategoryFieldsFragmentDoc}`;
-export type CreateEventCategoryMutationFn = Apollo.MutationFunction<CreateEventCategoryMutation, CreateEventCategoryMutationVariables>;
+export type CreateEventCategoryMutationFn = Apollo.MutationFunction<CreateEventCategoryMutationData, CreateEventCategoryMutationVariables>;
 
 /**
  * __useCreateEventCategoryMutation__
@@ -83,12 +84,13 @@ export type CreateEventCategoryMutationFn = Apollo.MutationFunction<CreateEventC
  *   },
  * });
  */
-export function useCreateEventCategoryMutation(baseOptions?: Apollo.MutationHookOptions<CreateEventCategoryMutation, CreateEventCategoryMutationVariables>) {
-        return Apollo.useMutation<CreateEventCategoryMutation, CreateEventCategoryMutationVariables>(CreateEventCategoryDocument, baseOptions);
+export function useCreateEventCategoryMutation(baseOptions?: Apollo.MutationHookOptions<CreateEventCategoryMutationData, CreateEventCategoryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateEventCategoryMutationData, CreateEventCategoryMutationVariables>(CreateEventCategoryDocument, options);
       }
 export type CreateEventCategoryMutationHookResult = ReturnType<typeof useCreateEventCategoryMutation>;
-export type CreateEventCategoryMutationResult = Apollo.MutationResult<CreateEventCategoryMutation>;
-export type CreateEventCategoryMutationOptions = Apollo.BaseMutationOptions<CreateEventCategoryMutation, CreateEventCategoryMutationVariables>;
+export type CreateEventCategoryMutationResult = Apollo.MutationResult<CreateEventCategoryMutationData>;
+export type CreateEventCategoryMutationOptions = Apollo.BaseMutationOptions<CreateEventCategoryMutationData, CreateEventCategoryMutationVariables>;
 export const UpdateEventCategoryDocument = gql`
     mutation UpdateEventCategory($id: Int!, $eventCategory: EventCategoryInput!) {
   updateEventCategory(input: {id: $id, event_category: $eventCategory}) {
@@ -99,7 +101,7 @@ export const UpdateEventCategoryDocument = gql`
   }
 }
     ${EventCategoryFieldsFragmentDoc}`;
-export type UpdateEventCategoryMutationFn = Apollo.MutationFunction<UpdateEventCategoryMutation, UpdateEventCategoryMutationVariables>;
+export type UpdateEventCategoryMutationFn = Apollo.MutationFunction<UpdateEventCategoryMutationData, UpdateEventCategoryMutationVariables>;
 
 /**
  * __useUpdateEventCategoryMutation__
@@ -119,12 +121,13 @@ export type UpdateEventCategoryMutationFn = Apollo.MutationFunction<UpdateEventC
  *   },
  * });
  */
-export function useUpdateEventCategoryMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventCategoryMutation, UpdateEventCategoryMutationVariables>) {
-        return Apollo.useMutation<UpdateEventCategoryMutation, UpdateEventCategoryMutationVariables>(UpdateEventCategoryDocument, baseOptions);
+export function useUpdateEventCategoryMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventCategoryMutationData, UpdateEventCategoryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateEventCategoryMutationData, UpdateEventCategoryMutationVariables>(UpdateEventCategoryDocument, options);
       }
 export type UpdateEventCategoryMutationHookResult = ReturnType<typeof useUpdateEventCategoryMutation>;
-export type UpdateEventCategoryMutationResult = Apollo.MutationResult<UpdateEventCategoryMutation>;
-export type UpdateEventCategoryMutationOptions = Apollo.BaseMutationOptions<UpdateEventCategoryMutation, UpdateEventCategoryMutationVariables>;
+export type UpdateEventCategoryMutationResult = Apollo.MutationResult<UpdateEventCategoryMutationData>;
+export type UpdateEventCategoryMutationOptions = Apollo.BaseMutationOptions<UpdateEventCategoryMutationData, UpdateEventCategoryMutationVariables>;
 export const DeleteEventCategoryDocument = gql`
     mutation DeleteEventCategory($id: Int!) {
   deleteEventCategory(input: {id: $id}) {
@@ -132,7 +135,7 @@ export const DeleteEventCategoryDocument = gql`
   }
 }
     `;
-export type DeleteEventCategoryMutationFn = Apollo.MutationFunction<DeleteEventCategoryMutation, DeleteEventCategoryMutationVariables>;
+export type DeleteEventCategoryMutationFn = Apollo.MutationFunction<DeleteEventCategoryMutationData, DeleteEventCategoryMutationVariables>;
 
 /**
  * __useDeleteEventCategoryMutation__
@@ -151,9 +154,10 @@ export type DeleteEventCategoryMutationFn = Apollo.MutationFunction<DeleteEventC
  *   },
  * });
  */
-export function useDeleteEventCategoryMutation(baseOptions?: Apollo.MutationHookOptions<DeleteEventCategoryMutation, DeleteEventCategoryMutationVariables>) {
-        return Apollo.useMutation<DeleteEventCategoryMutation, DeleteEventCategoryMutationVariables>(DeleteEventCategoryDocument, baseOptions);
+export function useDeleteEventCategoryMutation(baseOptions?: Apollo.MutationHookOptions<DeleteEventCategoryMutationData, DeleteEventCategoryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteEventCategoryMutationData, DeleteEventCategoryMutationVariables>(DeleteEventCategoryDocument, options);
       }
 export type DeleteEventCategoryMutationHookResult = ReturnType<typeof useDeleteEventCategoryMutation>;
-export type DeleteEventCategoryMutationResult = Apollo.MutationResult<DeleteEventCategoryMutation>;
-export type DeleteEventCategoryMutationOptions = Apollo.BaseMutationOptions<DeleteEventCategoryMutation, DeleteEventCategoryMutationVariables>;
+export type DeleteEventCategoryMutationResult = Apollo.MutationResult<DeleteEventCategoryMutationData>;
+export type DeleteEventCategoryMutationOptions = Apollo.BaseMutationOptions<DeleteEventCategoryMutationData, DeleteEventCategoryMutationVariables>;

--- a/app/javascript/EventCategoryAdmin/queries.generated.ts
+++ b/app/javascript/EventCategoryAdmin/queries.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type EventCategoryFieldsFragment = (
   { __typename: 'EventCategory' }
   & Pick<Types.EventCategory, 'id' | 'name' | 'team_member_name' | 'proposal_description' | 'scheduling_ui' | 'default_color' | 'signed_up_color' | 'full_color' | 'can_provide_tickets'>
@@ -21,10 +22,10 @@ export type EventCategoryFieldsFragment = (
   )> }
 );
 
-export type EventCategoryAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type EventCategoryAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type EventCategoryAdminQueryQuery = (
+export type EventCategoryAdminQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -98,26 +99,28 @@ export const EventCategoryAdminQueryDocument = gql`
     ${EventCategoryFieldsFragmentDoc}`;
 
 /**
- * __useEventCategoryAdminQueryQuery__
+ * __useEventCategoryAdminQuery__
  *
- * To run a query within a React component, call `useEventCategoryAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventCategoryAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventCategoryAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventCategoryAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventCategoryAdminQueryQuery({
+ * const { data, loading, error } = useEventCategoryAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useEventCategoryAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<EventCategoryAdminQueryQuery, EventCategoryAdminQueryQueryVariables>) {
-        return Apollo.useQuery<EventCategoryAdminQueryQuery, EventCategoryAdminQueryQueryVariables>(EventCategoryAdminQueryDocument, baseOptions);
+export function useEventCategoryAdminQuery(baseOptions?: Apollo.QueryHookOptions<EventCategoryAdminQueryData, EventCategoryAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventCategoryAdminQueryData, EventCategoryAdminQueryVariables>(EventCategoryAdminQueryDocument, options);
       }
-export function useEventCategoryAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventCategoryAdminQueryQuery, EventCategoryAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventCategoryAdminQueryQuery, EventCategoryAdminQueryQueryVariables>(EventCategoryAdminQueryDocument, baseOptions);
+export function useEventCategoryAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventCategoryAdminQueryData, EventCategoryAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventCategoryAdminQueryData, EventCategoryAdminQueryVariables>(EventCategoryAdminQueryDocument, options);
         }
-export type EventCategoryAdminQueryQueryHookResult = ReturnType<typeof useEventCategoryAdminQueryQuery>;
+export type EventCategoryAdminQueryHookResult = ReturnType<typeof useEventCategoryAdminQuery>;
 export type EventCategoryAdminQueryLazyQueryHookResult = ReturnType<typeof useEventCategoryAdminQueryLazyQuery>;
-export type EventCategoryAdminQueryQueryResult = Apollo.QueryResult<EventCategoryAdminQueryQuery, EventCategoryAdminQueryQueryVariables>;
+export type EventCategoryAdminQueryDataResult = Apollo.QueryResult<EventCategoryAdminQueryData, EventCategoryAdminQueryVariables>;

--- a/app/javascript/EventProposals/CreateEventProposalModal.tsx
+++ b/app/javascript/EventProposals/CreateEventProposalModal.tsx
@@ -6,22 +6,25 @@ import { useTranslation } from 'react-i18next';
 import ErrorDisplay from '../ErrorDisplay';
 import SelectWithLabel from '../BuiltInFormControls/SelectWithLabel';
 import { sortByLocaleString } from '../ValueUtils';
-import { ProposeEventButtonQueryQuery } from './queries.generated';
-import { CreateEventProposalMutation, useCreateEventProposalMutation } from './mutations.generated';
+import { ProposeEventButtonQueryData } from './queries.generated';
+import {
+  CreateEventProposalMutationData,
+  useCreateEventProposalMutation,
+} from './mutations.generated';
 
 export type CreateEventProposalModalProps = {
   onCreate: (
     newEventProposal: NonNullable<
-      CreateEventProposalMutation['createEventProposal']
+      CreateEventProposalMutationData['createEventProposal']
     >['event_proposal'],
   ) => void;
   cancel: () => void;
   visible: boolean;
   userEventProposals: NonNullable<
-    NonNullable<ProposeEventButtonQueryQuery['myProfile']>['user']
+    NonNullable<ProposeEventButtonQueryData['myProfile']>['user']
   >['event_proposals'];
-  proposableEventCategories: ProposeEventButtonQueryQuery['convention']['event_categories'];
-  departments: ProposeEventButtonQueryQuery['convention']['departments'];
+  proposableEventCategories: ProposeEventButtonQueryData['convention']['event_categories'];
+  departments: ProposeEventButtonQueryData['convention']['departments'];
 };
 
 function CreateEventProposalModal({

--- a/app/javascript/EventProposals/EditEventProposal.tsx
+++ b/app/javascript/EventProposals/EditEventProposal.tsx
@@ -8,11 +8,11 @@ import { useConfirm } from '../ModalDialogs/Confirm';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 import { useDeleteEventProposalMutation } from './mutations.generated';
-import { useEventProposalQueryQuery } from './queries.generated';
+import { useEventProposalQuery } from './queries.generated';
 
 function useLoadEventProposal() {
   const eventProposalId = Number.parseInt(useParams<{ id: string }>().id, 10);
-  return useEventProposalQueryQuery({ variables: { eventProposalId } });
+  return useEventProposalQuery({ variables: { eventProposalId } });
 }
 
 export default LoadQueryWrapper(useLoadEventProposal, function EditEventProposal({ data }) {

--- a/app/javascript/EventProposals/EventProposalAdminDisplay.tsx
+++ b/app/javascript/EventProposals/EventProposalAdminDisplay.tsx
@@ -10,9 +10,9 @@ import ErrorDisplay from '../ErrorDisplay';
 import usePageTitle from '../usePageTitle';
 import LoadingIndicator from '../LoadingIndicator';
 import {
-  EventProposalAdminNotesQueryQuery,
-  useEventProposalAdminNotesQueryQuery,
-  useEventProposalQueryWithOwnerQuery,
+  EventProposalAdminNotesQueryData,
+  useEventProposalAdminNotesQuery,
+  useEventProposalQueryWithOwner,
 } from './queries.generated';
 import { useUpdateEventProposalAdminNotesMutation } from './mutations.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
@@ -22,7 +22,7 @@ export type EventProposalAdminNotesProps = {
 };
 
 function EventProposalAdminNotes({ eventProposalId }: EventProposalAdminNotesProps) {
-  const { data, loading, error } = useEventProposalAdminNotesQueryQuery({
+  const { data, loading, error } = useEventProposalAdminNotesQuery({
     variables: { eventProposalId },
   });
 
@@ -32,7 +32,7 @@ function EventProposalAdminNotes({ eventProposalId }: EventProposalAdminNotesPro
       updateAdminNotesMutate({
         variables: { eventProposalId, adminNotes },
         update: (cache) => {
-          const queryData = cache.readQuery<EventProposalAdminNotesQueryQuery>({
+          const queryData = cache.readQuery<EventProposalAdminNotesQueryData>({
             query: EventProposalAdminNotesQuery,
             variables: { eventProposalId },
           });
@@ -67,7 +67,7 @@ function EventProposalAdminNotes({ eventProposalId }: EventProposalAdminNotesPro
 
 function useLoadEventProposal() {
   const eventProposalId = Number.parseInt(useParams<{ id: string }>().id, 10);
-  return useEventProposalQueryWithOwnerQuery({ variables: { eventProposalId } });
+  return useEventProposalQueryWithOwner({ variables: { eventProposalId } });
 }
 
 export default LoadQueryWrapper(useLoadEventProposal, function EventProposalAdminDisplay({ data }) {

--- a/app/javascript/EventProposals/EventProposalDisplay.tsx
+++ b/app/javascript/EventProposals/EventProposalDisplay.tsx
@@ -5,7 +5,7 @@ import FormItemDisplay from '../FormPresenter/ItemDisplays/FormItemDisplay';
 import ErrorDisplay from '../ErrorDisplay';
 import Gravatar from '../Gravatar';
 import LoadingIndicator from '../LoadingIndicator';
-import { useEventProposalQueryWithOwnerQuery } from './queries.generated';
+import { useEventProposalQueryWithOwner } from './queries.generated';
 import { getSortedFormItems } from '../Models/Form';
 import { parseTypedFormItemArray } from '../FormAdmin/FormItemUtils';
 import deserializeFormResponse from '../Models/deserializeFormResponse';
@@ -15,7 +15,7 @@ export type EventProposalDisplayProps = {
 };
 
 function EventProposalDisplay({ eventProposalId }: EventProposalDisplayProps) {
-  const { data, loading, error } = useEventProposalQueryWithOwnerQuery({
+  const { data, loading, error } = useEventProposalQueryWithOwner({
     variables: { eventProposalId },
   });
 

--- a/app/javascript/EventProposals/EventProposalForm.tsx
+++ b/app/javascript/EventProposals/EventProposalForm.tsx
@@ -10,7 +10,7 @@ import useAsyncFunction from '../useAsyncFunction';
 import useAutocommitFormResponseOnChange from '../FormPresenter/useAutocommitFormResponseOnChange';
 import PageLoadingIndicator from '../PageLoadingIndicator';
 import deserializeFormResponse, { WithFormResponse } from '../Models/deserializeFormResponse';
-import { useEventProposalQueryQuery, EventProposalQueryQuery } from './queries.generated';
+import { useEventProposalQuery, EventProposalQueryData } from './queries.generated';
 import { ConventionForFormItemDisplay } from '../FormPresenter/ItemDisplays/FormItemDisplay';
 import { CommonFormFieldsFragment } from '../Models/commonFormFragments.generated';
 import {
@@ -32,7 +32,7 @@ function parseResponseErrors(error: ApolloError) {
 
 type EventProposalFormInnerProps = {
   convention: ConventionForFormItemDisplay;
-  initialEventProposal: WithFormResponse<EventProposalQueryQuery['eventProposal']>;
+  initialEventProposal: WithFormResponse<EventProposalQueryData['eventProposal']>;
   form: CommonFormFieldsFragment;
   afterSubmit?: () => void;
   exitButton?: ReactNode;
@@ -159,7 +159,7 @@ export type EventProposalFormProps = {
 };
 
 function EventProposalForm({ eventProposalId, afterSubmit, exitButton }: EventProposalFormProps) {
-  const { data, loading, error } = useEventProposalQueryQuery({ variables: { eventProposalId } });
+  const { data, loading, error } = useEventProposalQuery({ variables: { eventProposalId } });
 
   const initialEventProposal = useMemo(
     () => (loading || error ? undefined : deserializeFormResponse(data!.eventProposal)),

--- a/app/javascript/EventProposals/EventProposalHistory.tsx
+++ b/app/javascript/EventProposals/EventProposalHistory.tsx
@@ -4,7 +4,7 @@ import { useRouteMatch } from 'react-router-dom';
 import ErrorDisplay from '../ErrorDisplay';
 import LoadingIndicator from '../LoadingIndicator';
 import FormResponseChangeHistory from '../FormPresenter/ItemChangeDisplays/FormResponseChangeHistory';
-import { useEventProposalHistoryQueryQuery } from './queries.generated';
+import { useEventProposalHistoryQuery } from './queries.generated';
 
 const EXCLUDE_FIELDS = new Set([
   'minimum_age',
@@ -16,7 +16,7 @@ const EXCLUDE_FIELDS = new Set([
 
 function EventProposalHistory() {
   const match = useRouteMatch<{ id: string }>();
-  const { data, loading, error } = useEventProposalHistoryQueryQuery({
+  const { data, loading, error } = useEventProposalHistoryQuery({
     variables: { id: Number.parseInt(match.params.id, 10) },
   });
 

--- a/app/javascript/EventProposals/EventProposalStatusUpdater.tsx
+++ b/app/javascript/EventProposals/EventProposalStatusUpdater.tsx
@@ -7,7 +7,7 @@ import BooleanInput from '../BuiltInFormControls/BooleanInput';
 import ErrorDisplay from '../ErrorDisplay';
 import MultipleChoiceInput from '../BuiltInFormControls/MultipleChoiceInput';
 import useModal from '../ModalDialogs/useModal';
-import { EventProposalQueryWithOwnerQuery } from './queries.generated';
+import { EventProposalQueryWithOwnerQueryData } from './queries.generated';
 import { useTransitionEventProposalMutation } from './mutations.generated';
 
 const STATUSES = [
@@ -34,7 +34,7 @@ function getStatus(key: string) {
 }
 
 export type EventProposalStatusUpdaterProps = {
-  eventProposal: EventProposalQueryWithOwnerQuery['eventProposal'];
+  eventProposal: EventProposalQueryWithOwnerQueryData['eventProposal'];
 };
 
 function EventProposalStatusUpdater({ eventProposal }: EventProposalStatusUpdaterProps) {

--- a/app/javascript/EventProposals/EventProposalsAdmin.tsx
+++ b/app/javascript/EventProposals/EventProposalsAdmin.tsx
@@ -12,16 +12,13 @@ import EventProposalHistory from './EventProposalHistory';
 import LoadingIndicator from '../LoadingIndicator';
 import RouteActivatedBreadcrumbItem from '../Breadcrumbs/RouteActivatedBreadcrumbItem';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
-import {
-  useEventProposalQueryQuery,
-  useEventProposalQueryWithOwnerQuery,
-} from './queries.generated';
+import { useEventProposalQuery, useEventProposalQueryWithOwner } from './queries.generated';
 
 function SingleProposalBreadcrumbs() {
   const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const eventProposalId = Number.parseInt(params.id, 10);
-  const { data, loading, error } = useEventProposalQueryWithOwnerQuery({
+  const { data, loading, error } = useEventProposalQueryWithOwner({
     variables: { eventProposalId },
   });
 
@@ -61,7 +58,7 @@ function AdminEditEventProposal() {
   const { t } = useTranslation();
   const history = useHistory();
   const eventProposalId = Number.parseInt(useParams<{ id: string }>().id, 10);
-  const { data, loading, error } = useEventProposalQueryQuery({ variables: { eventProposalId } });
+  const { data, loading, error } = useEventProposalQuery({ variables: { eventProposalId } });
 
   usePageTitle(
     useValueUnless(

--- a/app/javascript/EventProposals/EventProposalsAdminTable.tsx
+++ b/app/javascript/EventProposals/EventProposalsAdminTable.tsx
@@ -13,12 +13,9 @@ import TableHeader from '../Tables/TableHeader';
 import usePageTitle from '../usePageTitle';
 import UserConProfileWithGravatarCell from '../Tables/UserConProfileWithGravatarCell';
 import { SingleLineTimestampCell } from '../Tables/TimestampCell';
-import {
-  EventProposalsAdminQueryQuery,
-  useEventProposalsAdminQueryQuery,
-} from './queries.generated';
+import { EventProposalsAdminQueryData, useEventProposalsAdminQuery } from './queries.generated';
 
-type EventProposalType = EventProposalsAdminQueryQuery['convention']['event_proposals_paginated']['entries'][0];
+type EventProposalType = EventProposalsAdminQueryData['convention']['event_proposals_paginated']['entries'][0];
 
 const FILTER_CODECS = buildFieldFilterCodecs({
   status: FilterCodecs.stringArray,
@@ -100,7 +97,7 @@ function ExtraCell({ row: { original } }: CellProps<EventProposalType>) {
 }
 
 const EventCategoryFilter = (props: FilterProps<EventProposalType>) => {
-  const data = useContext(QueryDataContext) as EventProposalsAdminQueryQuery;
+  const data = useContext(QueryDataContext) as EventProposalsAdminQueryData;
   const choices = useMemo(
     () =>
       data
@@ -217,7 +214,7 @@ function EventProposalsAdminTable() {
     getData: ({ data: tableData }) => tableData.convention.event_proposals_paginated.entries,
     getPages: ({ data: tableData }) => tableData.convention.event_proposals_paginated.total_pages,
     getPossibleColumns,
-    useQuery: useEventProposalsAdminQueryQuery,
+    useQuery: useEventProposalsAdminQuery,
     storageKeyPrefix: 'eventProposalsAdmin',
   });
 

--- a/app/javascript/EventProposals/ProposeEventButton.tsx
+++ b/app/javascript/EventProposals/ProposeEventButton.tsx
@@ -7,15 +7,15 @@ import SignInButton from '../Authentication/SignInButton';
 import useUniqueId from '../useUniqueId';
 import useModal from '../ModalDialogs/useModal';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { ProposeEventButtonQueryQuery, useProposeEventButtonQueryQuery } from './queries.generated';
+import { ProposeEventButtonQueryData, useProposeEventButtonQuery } from './queries.generated';
 
 export type ProposeEventButtonProps = {
   className?: string;
   caption: React.ReactNode;
 };
 
-export default LoadQueryWrapper<ProposeEventButtonQueryQuery, ProposeEventButtonProps>(
-  useProposeEventButtonQueryQuery,
+export default LoadQueryWrapper<ProposeEventButtonQueryData, ProposeEventButtonProps>(
+  useProposeEventButtonQuery,
   function ProposeEventButton({ className, caption, data }) {
     const { t } = useTranslation();
     const history = useHistory();

--- a/app/javascript/EventProposals/mutations.generated.ts
+++ b/app/javascript/EventProposals/mutations.generated.ts
@@ -5,13 +5,14 @@ import { EventProposalFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { EventProposalFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateEventProposalMutationVariables = Types.Exact<{
   cloneEventProposalId?: Types.Maybe<Types.Scalars['Int']>;
   eventCategoryId: Types.Scalars['Int'];
 }>;
 
 
-export type CreateEventProposalMutation = (
+export type CreateEventProposalMutationData = (
   { __typename: 'Mutation' }
   & { createEventProposal?: Types.Maybe<(
     { __typename: 'CreateEventProposalPayload' }
@@ -27,7 +28,7 @@ export type UpdateEventProposalMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateEventProposalMutation = (
+export type UpdateEventProposalMutationData = (
   { __typename: 'Mutation' }
   & { updateEventProposal?: Types.Maybe<(
     { __typename: 'UpdateEventProposalPayload' }
@@ -44,7 +45,7 @@ export type DeleteEventProposalMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteEventProposalMutation = (
+export type DeleteEventProposalMutationData = (
   { __typename: 'Mutation' }
   & { deleteEventProposal?: Types.Maybe<(
     { __typename: 'DeleteEventProposalPayload' }
@@ -57,7 +58,7 @@ export type SubmitEventProposalMutationVariables = Types.Exact<{
 }>;
 
 
-export type SubmitEventProposalMutation = (
+export type SubmitEventProposalMutationData = (
   { __typename: 'Mutation' }
   & { submitEventProposal?: Types.Maybe<(
     { __typename: 'SubmitEventProposalPayload' }
@@ -76,7 +77,7 @@ export type TransitionEventProposalMutationVariables = Types.Exact<{
 }>;
 
 
-export type TransitionEventProposalMutation = (
+export type TransitionEventProposalMutationData = (
   { __typename: 'Mutation' }
   & { transitionEventProposal?: Types.Maybe<(
     { __typename: 'TransitionEventProposalPayload' }
@@ -94,7 +95,7 @@ export type UpdateEventProposalAdminNotesMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateEventProposalAdminNotesMutation = (
+export type UpdateEventProposalAdminNotesMutationData = (
   { __typename: 'Mutation' }
   & { updateEventProposalAdminNotes?: Types.Maybe<(
     { __typename: 'UpdateEventProposalAdminNotesPayload' }
@@ -118,7 +119,7 @@ export const CreateEventProposalDocument = gql`
   }
 }
     `;
-export type CreateEventProposalMutationFn = Apollo.MutationFunction<CreateEventProposalMutation, CreateEventProposalMutationVariables>;
+export type CreateEventProposalMutationFn = Apollo.MutationFunction<CreateEventProposalMutationData, CreateEventProposalMutationVariables>;
 
 /**
  * __useCreateEventProposalMutation__
@@ -138,12 +139,13 @@ export type CreateEventProposalMutationFn = Apollo.MutationFunction<CreateEventP
  *   },
  * });
  */
-export function useCreateEventProposalMutation(baseOptions?: Apollo.MutationHookOptions<CreateEventProposalMutation, CreateEventProposalMutationVariables>) {
-        return Apollo.useMutation<CreateEventProposalMutation, CreateEventProposalMutationVariables>(CreateEventProposalDocument, baseOptions);
+export function useCreateEventProposalMutation(baseOptions?: Apollo.MutationHookOptions<CreateEventProposalMutationData, CreateEventProposalMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateEventProposalMutationData, CreateEventProposalMutationVariables>(CreateEventProposalDocument, options);
       }
 export type CreateEventProposalMutationHookResult = ReturnType<typeof useCreateEventProposalMutation>;
-export type CreateEventProposalMutationResult = Apollo.MutationResult<CreateEventProposalMutation>;
-export type CreateEventProposalMutationOptions = Apollo.BaseMutationOptions<CreateEventProposalMutation, CreateEventProposalMutationVariables>;
+export type CreateEventProposalMutationResult = Apollo.MutationResult<CreateEventProposalMutationData>;
+export type CreateEventProposalMutationOptions = Apollo.BaseMutationOptions<CreateEventProposalMutationData, CreateEventProposalMutationVariables>;
 export const UpdateEventProposalDocument = gql`
     mutation UpdateEventProposal($input: UpdateEventProposalInput!) {
   updateEventProposal(input: $input) {
@@ -154,7 +156,7 @@ export const UpdateEventProposalDocument = gql`
   }
 }
     ${EventProposalFieldsFragmentDoc}`;
-export type UpdateEventProposalMutationFn = Apollo.MutationFunction<UpdateEventProposalMutation, UpdateEventProposalMutationVariables>;
+export type UpdateEventProposalMutationFn = Apollo.MutationFunction<UpdateEventProposalMutationData, UpdateEventProposalMutationVariables>;
 
 /**
  * __useUpdateEventProposalMutation__
@@ -173,12 +175,13 @@ export type UpdateEventProposalMutationFn = Apollo.MutationFunction<UpdateEventP
  *   },
  * });
  */
-export function useUpdateEventProposalMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventProposalMutation, UpdateEventProposalMutationVariables>) {
-        return Apollo.useMutation<UpdateEventProposalMutation, UpdateEventProposalMutationVariables>(UpdateEventProposalDocument, baseOptions);
+export function useUpdateEventProposalMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventProposalMutationData, UpdateEventProposalMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateEventProposalMutationData, UpdateEventProposalMutationVariables>(UpdateEventProposalDocument, options);
       }
 export type UpdateEventProposalMutationHookResult = ReturnType<typeof useUpdateEventProposalMutation>;
-export type UpdateEventProposalMutationResult = Apollo.MutationResult<UpdateEventProposalMutation>;
-export type UpdateEventProposalMutationOptions = Apollo.BaseMutationOptions<UpdateEventProposalMutation, UpdateEventProposalMutationVariables>;
+export type UpdateEventProposalMutationResult = Apollo.MutationResult<UpdateEventProposalMutationData>;
+export type UpdateEventProposalMutationOptions = Apollo.BaseMutationOptions<UpdateEventProposalMutationData, UpdateEventProposalMutationVariables>;
 export const DeleteEventProposalDocument = gql`
     mutation DeleteEventProposal($id: Int!) {
   deleteEventProposal(input: {id: $id}) {
@@ -186,7 +189,7 @@ export const DeleteEventProposalDocument = gql`
   }
 }
     `;
-export type DeleteEventProposalMutationFn = Apollo.MutationFunction<DeleteEventProposalMutation, DeleteEventProposalMutationVariables>;
+export type DeleteEventProposalMutationFn = Apollo.MutationFunction<DeleteEventProposalMutationData, DeleteEventProposalMutationVariables>;
 
 /**
  * __useDeleteEventProposalMutation__
@@ -205,12 +208,13 @@ export type DeleteEventProposalMutationFn = Apollo.MutationFunction<DeleteEventP
  *   },
  * });
  */
-export function useDeleteEventProposalMutation(baseOptions?: Apollo.MutationHookOptions<DeleteEventProposalMutation, DeleteEventProposalMutationVariables>) {
-        return Apollo.useMutation<DeleteEventProposalMutation, DeleteEventProposalMutationVariables>(DeleteEventProposalDocument, baseOptions);
+export function useDeleteEventProposalMutation(baseOptions?: Apollo.MutationHookOptions<DeleteEventProposalMutationData, DeleteEventProposalMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteEventProposalMutationData, DeleteEventProposalMutationVariables>(DeleteEventProposalDocument, options);
       }
 export type DeleteEventProposalMutationHookResult = ReturnType<typeof useDeleteEventProposalMutation>;
-export type DeleteEventProposalMutationResult = Apollo.MutationResult<DeleteEventProposalMutation>;
-export type DeleteEventProposalMutationOptions = Apollo.BaseMutationOptions<DeleteEventProposalMutation, DeleteEventProposalMutationVariables>;
+export type DeleteEventProposalMutationResult = Apollo.MutationResult<DeleteEventProposalMutationData>;
+export type DeleteEventProposalMutationOptions = Apollo.BaseMutationOptions<DeleteEventProposalMutationData, DeleteEventProposalMutationVariables>;
 export const SubmitEventProposalDocument = gql`
     mutation SubmitEventProposal($input: SubmitEventProposalInput!) {
   submitEventProposal(input: $input) {
@@ -221,7 +225,7 @@ export const SubmitEventProposalDocument = gql`
   }
 }
     ${EventProposalFieldsFragmentDoc}`;
-export type SubmitEventProposalMutationFn = Apollo.MutationFunction<SubmitEventProposalMutation, SubmitEventProposalMutationVariables>;
+export type SubmitEventProposalMutationFn = Apollo.MutationFunction<SubmitEventProposalMutationData, SubmitEventProposalMutationVariables>;
 
 /**
  * __useSubmitEventProposalMutation__
@@ -240,12 +244,13 @@ export type SubmitEventProposalMutationFn = Apollo.MutationFunction<SubmitEventP
  *   },
  * });
  */
-export function useSubmitEventProposalMutation(baseOptions?: Apollo.MutationHookOptions<SubmitEventProposalMutation, SubmitEventProposalMutationVariables>) {
-        return Apollo.useMutation<SubmitEventProposalMutation, SubmitEventProposalMutationVariables>(SubmitEventProposalDocument, baseOptions);
+export function useSubmitEventProposalMutation(baseOptions?: Apollo.MutationHookOptions<SubmitEventProposalMutationData, SubmitEventProposalMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SubmitEventProposalMutationData, SubmitEventProposalMutationVariables>(SubmitEventProposalDocument, options);
       }
 export type SubmitEventProposalMutationHookResult = ReturnType<typeof useSubmitEventProposalMutation>;
-export type SubmitEventProposalMutationResult = Apollo.MutationResult<SubmitEventProposalMutation>;
-export type SubmitEventProposalMutationOptions = Apollo.BaseMutationOptions<SubmitEventProposalMutation, SubmitEventProposalMutationVariables>;
+export type SubmitEventProposalMutationResult = Apollo.MutationResult<SubmitEventProposalMutationData>;
+export type SubmitEventProposalMutationOptions = Apollo.BaseMutationOptions<SubmitEventProposalMutationData, SubmitEventProposalMutationVariables>;
 export const TransitionEventProposalDocument = gql`
     mutation TransitionEventProposal($eventProposalId: Int!, $status: String!, $dropEvent: Boolean) {
   transitionEventProposal(
@@ -258,7 +263,7 @@ export const TransitionEventProposalDocument = gql`
   }
 }
     ${EventProposalFieldsFragmentDoc}`;
-export type TransitionEventProposalMutationFn = Apollo.MutationFunction<TransitionEventProposalMutation, TransitionEventProposalMutationVariables>;
+export type TransitionEventProposalMutationFn = Apollo.MutationFunction<TransitionEventProposalMutationData, TransitionEventProposalMutationVariables>;
 
 /**
  * __useTransitionEventProposalMutation__
@@ -279,12 +284,13 @@ export type TransitionEventProposalMutationFn = Apollo.MutationFunction<Transiti
  *   },
  * });
  */
-export function useTransitionEventProposalMutation(baseOptions?: Apollo.MutationHookOptions<TransitionEventProposalMutation, TransitionEventProposalMutationVariables>) {
-        return Apollo.useMutation<TransitionEventProposalMutation, TransitionEventProposalMutationVariables>(TransitionEventProposalDocument, baseOptions);
+export function useTransitionEventProposalMutation(baseOptions?: Apollo.MutationHookOptions<TransitionEventProposalMutationData, TransitionEventProposalMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<TransitionEventProposalMutationData, TransitionEventProposalMutationVariables>(TransitionEventProposalDocument, options);
       }
 export type TransitionEventProposalMutationHookResult = ReturnType<typeof useTransitionEventProposalMutation>;
-export type TransitionEventProposalMutationResult = Apollo.MutationResult<TransitionEventProposalMutation>;
-export type TransitionEventProposalMutationOptions = Apollo.BaseMutationOptions<TransitionEventProposalMutation, TransitionEventProposalMutationVariables>;
+export type TransitionEventProposalMutationResult = Apollo.MutationResult<TransitionEventProposalMutationData>;
+export type TransitionEventProposalMutationOptions = Apollo.BaseMutationOptions<TransitionEventProposalMutationData, TransitionEventProposalMutationVariables>;
 export const UpdateEventProposalAdminNotesDocument = gql`
     mutation UpdateEventProposalAdminNotes($eventProposalId: Int!, $adminNotes: String!) {
   updateEventProposalAdminNotes(
@@ -297,7 +303,7 @@ export const UpdateEventProposalAdminNotesDocument = gql`
   }
 }
     ${EventProposalFieldsFragmentDoc}`;
-export type UpdateEventProposalAdminNotesMutationFn = Apollo.MutationFunction<UpdateEventProposalAdminNotesMutation, UpdateEventProposalAdminNotesMutationVariables>;
+export type UpdateEventProposalAdminNotesMutationFn = Apollo.MutationFunction<UpdateEventProposalAdminNotesMutationData, UpdateEventProposalAdminNotesMutationVariables>;
 
 /**
  * __useUpdateEventProposalAdminNotesMutation__
@@ -317,9 +323,10 @@ export type UpdateEventProposalAdminNotesMutationFn = Apollo.MutationFunction<Up
  *   },
  * });
  */
-export function useUpdateEventProposalAdminNotesMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventProposalAdminNotesMutation, UpdateEventProposalAdminNotesMutationVariables>) {
-        return Apollo.useMutation<UpdateEventProposalAdminNotesMutation, UpdateEventProposalAdminNotesMutationVariables>(UpdateEventProposalAdminNotesDocument, baseOptions);
+export function useUpdateEventProposalAdminNotesMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventProposalAdminNotesMutationData, UpdateEventProposalAdminNotesMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateEventProposalAdminNotesMutationData, UpdateEventProposalAdminNotesMutationVariables>(UpdateEventProposalAdminNotesDocument, options);
       }
 export type UpdateEventProposalAdminNotesMutationHookResult = ReturnType<typeof useUpdateEventProposalAdminNotesMutation>;
-export type UpdateEventProposalAdminNotesMutationResult = Apollo.MutationResult<UpdateEventProposalAdminNotesMutation>;
-export type UpdateEventProposalAdminNotesMutationOptions = Apollo.BaseMutationOptions<UpdateEventProposalAdminNotesMutation, UpdateEventProposalAdminNotesMutationVariables>;
+export type UpdateEventProposalAdminNotesMutationResult = Apollo.MutationResult<UpdateEventProposalAdminNotesMutationData>;
+export type UpdateEventProposalAdminNotesMutationOptions = Apollo.BaseMutationOptions<UpdateEventProposalAdminNotesMutationData, UpdateEventProposalAdminNotesMutationVariables>;

--- a/app/javascript/EventProposals/queries.generated.ts
+++ b/app/javascript/EventProposals/queries.generated.ts
@@ -5,6 +5,7 @@ import { CommonFormFieldsFragment, CommonFormSectionFieldsFragment, CommonFormIt
 import { gql } from '@apollo/client';
 import { CommonFormFieldsFragmentDoc, CommonFormSectionFieldsFragmentDoc, CommonFormItemFieldsFragmentDoc } from '../Models/commonFormFragments.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type EventProposalFieldsFragment = (
   { __typename: 'EventProposal' }
   & Pick<Types.EventProposal, 'id' | 'title' | 'status' | 'form_response_attrs_json'>
@@ -35,12 +36,12 @@ export type EventProposalFormDataFragment = (
   & Pick<Types.Convention, 'id' | 'starts_at' | 'ends_at' | 'timezone_name' | 'timezone_mode' | 'event_mailing_list_domain'>
 );
 
-export type EventProposalQueryQueryVariables = Types.Exact<{
+export type EventProposalQueryVariables = Types.Exact<{
   eventProposalId: Types.Scalars['Int'];
 }>;
 
 
-export type EventProposalQueryQuery = (
+export type EventProposalQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -61,7 +62,7 @@ export type EventProposalQueryWithOwnerQueryVariables = Types.Exact<{
 }>;
 
 
-export type EventProposalQueryWithOwnerQuery = (
+export type EventProposalQueryWithOwnerQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -81,12 +82,12 @@ export type EventProposalQueryWithOwnerQuery = (
   ) }
 );
 
-export type EventProposalAdminNotesQueryQueryVariables = Types.Exact<{
+export type EventProposalAdminNotesQueryVariables = Types.Exact<{
   eventProposalId: Types.Scalars['Int'];
 }>;
 
 
-export type EventProposalAdminNotesQueryQuery = (
+export type EventProposalAdminNotesQueryData = (
   { __typename: 'Query' }
   & { eventProposal: (
     { __typename: 'EventProposal' }
@@ -94,10 +95,10 @@ export type EventProposalAdminNotesQueryQuery = (
   ) }
 );
 
-export type ProposeEventButtonQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type ProposeEventButtonQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type ProposeEventButtonQueryQuery = (
+export type ProposeEventButtonQueryData = (
   { __typename: 'Query' }
   & { myProfile?: Types.Maybe<(
     { __typename: 'UserConProfile' }
@@ -138,7 +139,7 @@ export type ProposeEventButtonQueryQuery = (
   ) }
 );
 
-export type EventProposalsAdminQueryQueryVariables = Types.Exact<{
+export type EventProposalsAdminQueryVariables = Types.Exact<{
   page?: Types.Maybe<Types.Scalars['Int']>;
   perPage?: Types.Maybe<Types.Scalars['Int']>;
   filters?: Types.Maybe<Types.EventProposalFiltersInput>;
@@ -146,7 +147,7 @@ export type EventProposalsAdminQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type EventProposalsAdminQueryQuery = (
+export type EventProposalsAdminQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -175,12 +176,12 @@ export type EventProposalsAdminQueryQuery = (
   ) }
 );
 
-export type EventProposalHistoryQueryQueryVariables = Types.Exact<{
+export type EventProposalHistoryQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type EventProposalHistoryQueryQuery = (
+export type EventProposalHistoryQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -272,30 +273,32 @@ export const EventProposalQueryDocument = gql`
 ${EventProposalFieldsFragmentDoc}`;
 
 /**
- * __useEventProposalQueryQuery__
+ * __useEventProposalQuery__
  *
- * To run a query within a React component, call `useEventProposalQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventProposalQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventProposalQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventProposalQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventProposalQueryQuery({
+ * const { data, loading, error } = useEventProposalQuery({
  *   variables: {
  *      eventProposalId: // value for 'eventProposalId'
  *   },
  * });
  */
-export function useEventProposalQueryQuery(baseOptions: Apollo.QueryHookOptions<EventProposalQueryQuery, EventProposalQueryQueryVariables>) {
-        return Apollo.useQuery<EventProposalQueryQuery, EventProposalQueryQueryVariables>(EventProposalQueryDocument, baseOptions);
+export function useEventProposalQuery(baseOptions: Apollo.QueryHookOptions<EventProposalQueryData, EventProposalQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventProposalQueryData, EventProposalQueryVariables>(EventProposalQueryDocument, options);
       }
-export function useEventProposalQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposalQueryQuery, EventProposalQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventProposalQueryQuery, EventProposalQueryQueryVariables>(EventProposalQueryDocument, baseOptions);
+export function useEventProposalQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposalQueryData, EventProposalQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventProposalQueryData, EventProposalQueryVariables>(EventProposalQueryDocument, options);
         }
-export type EventProposalQueryQueryHookResult = ReturnType<typeof useEventProposalQueryQuery>;
+export type EventProposalQueryHookResult = ReturnType<typeof useEventProposalQuery>;
 export type EventProposalQueryLazyQueryHookResult = ReturnType<typeof useEventProposalQueryLazyQuery>;
-export type EventProposalQueryQueryResult = Apollo.QueryResult<EventProposalQueryQuery, EventProposalQueryQueryVariables>;
+export type EventProposalQueryDataResult = Apollo.QueryResult<EventProposalQueryData, EventProposalQueryVariables>;
 export const EventProposalQueryWithOwnerDocument = gql`
     query EventProposalQueryWithOwner($eventProposalId: Int!) {
   convention: assertConvention {
@@ -322,30 +325,32 @@ export const EventProposalQueryWithOwnerDocument = gql`
 ${EventProposalFieldsFragmentDoc}`;
 
 /**
- * __useEventProposalQueryWithOwnerQuery__
+ * __useEventProposalQueryWithOwner__
  *
- * To run a query within a React component, call `useEventProposalQueryWithOwnerQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventProposalQueryWithOwnerQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventProposalQueryWithOwner` and pass it any options that fit your needs.
+ * When your component renders, `useEventProposalQueryWithOwner` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventProposalQueryWithOwnerQuery({
+ * const { data, loading, error } = useEventProposalQueryWithOwner({
  *   variables: {
  *      eventProposalId: // value for 'eventProposalId'
  *   },
  * });
  */
-export function useEventProposalQueryWithOwnerQuery(baseOptions: Apollo.QueryHookOptions<EventProposalQueryWithOwnerQuery, EventProposalQueryWithOwnerQueryVariables>) {
-        return Apollo.useQuery<EventProposalQueryWithOwnerQuery, EventProposalQueryWithOwnerQueryVariables>(EventProposalQueryWithOwnerDocument, baseOptions);
+export function useEventProposalQueryWithOwner(baseOptions: Apollo.QueryHookOptions<EventProposalQueryWithOwnerQueryData, EventProposalQueryWithOwnerQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventProposalQueryWithOwnerQueryData, EventProposalQueryWithOwnerQueryVariables>(EventProposalQueryWithOwnerDocument, options);
       }
-export function useEventProposalQueryWithOwnerLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposalQueryWithOwnerQuery, EventProposalQueryWithOwnerQueryVariables>) {
-          return Apollo.useLazyQuery<EventProposalQueryWithOwnerQuery, EventProposalQueryWithOwnerQueryVariables>(EventProposalQueryWithOwnerDocument, baseOptions);
+export function useEventProposalQueryWithOwnerLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposalQueryWithOwnerQueryData, EventProposalQueryWithOwnerQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventProposalQueryWithOwnerQueryData, EventProposalQueryWithOwnerQueryVariables>(EventProposalQueryWithOwnerDocument, options);
         }
-export type EventProposalQueryWithOwnerQueryHookResult = ReturnType<typeof useEventProposalQueryWithOwnerQuery>;
+export type EventProposalQueryWithOwnerHookResult = ReturnType<typeof useEventProposalQueryWithOwner>;
 export type EventProposalQueryWithOwnerLazyQueryHookResult = ReturnType<typeof useEventProposalQueryWithOwnerLazyQuery>;
-export type EventProposalQueryWithOwnerQueryResult = Apollo.QueryResult<EventProposalQueryWithOwnerQuery, EventProposalQueryWithOwnerQueryVariables>;
+export type EventProposalQueryWithOwnerQueryResult = Apollo.QueryResult<EventProposalQueryWithOwnerQueryData, EventProposalQueryWithOwnerQueryVariables>;
 export const EventProposalAdminNotesQueryDocument = gql`
     query EventProposalAdminNotesQuery($eventProposalId: Int!) {
   eventProposal(id: $eventProposalId) {
@@ -356,30 +361,32 @@ export const EventProposalAdminNotesQueryDocument = gql`
     `;
 
 /**
- * __useEventProposalAdminNotesQueryQuery__
+ * __useEventProposalAdminNotesQuery__
  *
- * To run a query within a React component, call `useEventProposalAdminNotesQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventProposalAdminNotesQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventProposalAdminNotesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventProposalAdminNotesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventProposalAdminNotesQueryQuery({
+ * const { data, loading, error } = useEventProposalAdminNotesQuery({
  *   variables: {
  *      eventProposalId: // value for 'eventProposalId'
  *   },
  * });
  */
-export function useEventProposalAdminNotesQueryQuery(baseOptions: Apollo.QueryHookOptions<EventProposalAdminNotesQueryQuery, EventProposalAdminNotesQueryQueryVariables>) {
-        return Apollo.useQuery<EventProposalAdminNotesQueryQuery, EventProposalAdminNotesQueryQueryVariables>(EventProposalAdminNotesQueryDocument, baseOptions);
+export function useEventProposalAdminNotesQuery(baseOptions: Apollo.QueryHookOptions<EventProposalAdminNotesQueryData, EventProposalAdminNotesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventProposalAdminNotesQueryData, EventProposalAdminNotesQueryVariables>(EventProposalAdminNotesQueryDocument, options);
       }
-export function useEventProposalAdminNotesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposalAdminNotesQueryQuery, EventProposalAdminNotesQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventProposalAdminNotesQueryQuery, EventProposalAdminNotesQueryQueryVariables>(EventProposalAdminNotesQueryDocument, baseOptions);
+export function useEventProposalAdminNotesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposalAdminNotesQueryData, EventProposalAdminNotesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventProposalAdminNotesQueryData, EventProposalAdminNotesQueryVariables>(EventProposalAdminNotesQueryDocument, options);
         }
-export type EventProposalAdminNotesQueryQueryHookResult = ReturnType<typeof useEventProposalAdminNotesQueryQuery>;
+export type EventProposalAdminNotesQueryHookResult = ReturnType<typeof useEventProposalAdminNotesQuery>;
 export type EventProposalAdminNotesQueryLazyQueryHookResult = ReturnType<typeof useEventProposalAdminNotesQueryLazyQuery>;
-export type EventProposalAdminNotesQueryQueryResult = Apollo.QueryResult<EventProposalAdminNotesQueryQuery, EventProposalAdminNotesQueryQueryVariables>;
+export type EventProposalAdminNotesQueryDataResult = Apollo.QueryResult<EventProposalAdminNotesQueryData, EventProposalAdminNotesQueryVariables>;
 export const ProposeEventButtonQueryDocument = gql`
     query ProposeEventButtonQuery {
   myProfile {
@@ -426,29 +433,31 @@ export const ProposeEventButtonQueryDocument = gql`
     `;
 
 /**
- * __useProposeEventButtonQueryQuery__
+ * __useProposeEventButtonQuery__
  *
- * To run a query within a React component, call `useProposeEventButtonQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useProposeEventButtonQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useProposeEventButtonQuery` and pass it any options that fit your needs.
+ * When your component renders, `useProposeEventButtonQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useProposeEventButtonQueryQuery({
+ * const { data, loading, error } = useProposeEventButtonQuery({
  *   variables: {
  *   },
  * });
  */
-export function useProposeEventButtonQueryQuery(baseOptions?: Apollo.QueryHookOptions<ProposeEventButtonQueryQuery, ProposeEventButtonQueryQueryVariables>) {
-        return Apollo.useQuery<ProposeEventButtonQueryQuery, ProposeEventButtonQueryQueryVariables>(ProposeEventButtonQueryDocument, baseOptions);
+export function useProposeEventButtonQuery(baseOptions?: Apollo.QueryHookOptions<ProposeEventButtonQueryData, ProposeEventButtonQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ProposeEventButtonQueryData, ProposeEventButtonQueryVariables>(ProposeEventButtonQueryDocument, options);
       }
-export function useProposeEventButtonQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposeEventButtonQueryQuery, ProposeEventButtonQueryQueryVariables>) {
-          return Apollo.useLazyQuery<ProposeEventButtonQueryQuery, ProposeEventButtonQueryQueryVariables>(ProposeEventButtonQueryDocument, baseOptions);
+export function useProposeEventButtonQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ProposeEventButtonQueryData, ProposeEventButtonQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ProposeEventButtonQueryData, ProposeEventButtonQueryVariables>(ProposeEventButtonQueryDocument, options);
         }
-export type ProposeEventButtonQueryQueryHookResult = ReturnType<typeof useProposeEventButtonQueryQuery>;
+export type ProposeEventButtonQueryHookResult = ReturnType<typeof useProposeEventButtonQuery>;
 export type ProposeEventButtonQueryLazyQueryHookResult = ReturnType<typeof useProposeEventButtonQueryLazyQuery>;
-export type ProposeEventButtonQueryQueryResult = Apollo.QueryResult<ProposeEventButtonQueryQuery, ProposeEventButtonQueryQueryVariables>;
+export type ProposeEventButtonQueryDataResult = Apollo.QueryResult<ProposeEventButtonQueryData, ProposeEventButtonQueryVariables>;
 export const EventProposalsAdminQueryDocument = gql`
     query EventProposalsAdminQuery($page: Int, $perPage: Int, $filters: EventProposalFiltersInput, $sort: [SortInput!]) {
   convention: assertConvention {
@@ -499,16 +508,16 @@ export const EventProposalsAdminQueryDocument = gql`
     `;
 
 /**
- * __useEventProposalsAdminQueryQuery__
+ * __useEventProposalsAdminQuery__
  *
- * To run a query within a React component, call `useEventProposalsAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventProposalsAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventProposalsAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventProposalsAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventProposalsAdminQueryQuery({
+ * const { data, loading, error } = useEventProposalsAdminQuery({
  *   variables: {
  *      page: // value for 'page'
  *      perPage: // value for 'perPage'
@@ -517,15 +526,17 @@ export const EventProposalsAdminQueryDocument = gql`
  *   },
  * });
  */
-export function useEventProposalsAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<EventProposalsAdminQueryQuery, EventProposalsAdminQueryQueryVariables>) {
-        return Apollo.useQuery<EventProposalsAdminQueryQuery, EventProposalsAdminQueryQueryVariables>(EventProposalsAdminQueryDocument, baseOptions);
+export function useEventProposalsAdminQuery(baseOptions?: Apollo.QueryHookOptions<EventProposalsAdminQueryData, EventProposalsAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventProposalsAdminQueryData, EventProposalsAdminQueryVariables>(EventProposalsAdminQueryDocument, options);
       }
-export function useEventProposalsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposalsAdminQueryQuery, EventProposalsAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventProposalsAdminQueryQuery, EventProposalsAdminQueryQueryVariables>(EventProposalsAdminQueryDocument, baseOptions);
+export function useEventProposalsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposalsAdminQueryData, EventProposalsAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventProposalsAdminQueryData, EventProposalsAdminQueryVariables>(EventProposalsAdminQueryDocument, options);
         }
-export type EventProposalsAdminQueryQueryHookResult = ReturnType<typeof useEventProposalsAdminQueryQuery>;
+export type EventProposalsAdminQueryHookResult = ReturnType<typeof useEventProposalsAdminQuery>;
 export type EventProposalsAdminQueryLazyQueryHookResult = ReturnType<typeof useEventProposalsAdminQueryLazyQuery>;
-export type EventProposalsAdminQueryQueryResult = Apollo.QueryResult<EventProposalsAdminQueryQuery, EventProposalsAdminQueryQueryVariables>;
+export type EventProposalsAdminQueryDataResult = Apollo.QueryResult<EventProposalsAdminQueryData, EventProposalsAdminQueryVariables>;
 export const EventProposalHistoryQueryDocument = gql`
     query EventProposalHistoryQuery($id: Int!) {
   convention: assertConvention {
@@ -571,27 +582,29 @@ export const EventProposalHistoryQueryDocument = gql`
     ${CommonFormFieldsFragmentDoc}`;
 
 /**
- * __useEventProposalHistoryQueryQuery__
+ * __useEventProposalHistoryQuery__
  *
- * To run a query within a React component, call `useEventProposalHistoryQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventProposalHistoryQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventProposalHistoryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventProposalHistoryQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventProposalHistoryQueryQuery({
+ * const { data, loading, error } = useEventProposalHistoryQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useEventProposalHistoryQueryQuery(baseOptions: Apollo.QueryHookOptions<EventProposalHistoryQueryQuery, EventProposalHistoryQueryQueryVariables>) {
-        return Apollo.useQuery<EventProposalHistoryQueryQuery, EventProposalHistoryQueryQueryVariables>(EventProposalHistoryQueryDocument, baseOptions);
+export function useEventProposalHistoryQuery(baseOptions: Apollo.QueryHookOptions<EventProposalHistoryQueryData, EventProposalHistoryQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventProposalHistoryQueryData, EventProposalHistoryQueryVariables>(EventProposalHistoryQueryDocument, options);
       }
-export function useEventProposalHistoryQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposalHistoryQueryQuery, EventProposalHistoryQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventProposalHistoryQueryQuery, EventProposalHistoryQueryQueryVariables>(EventProposalHistoryQueryDocument, baseOptions);
+export function useEventProposalHistoryQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposalHistoryQueryData, EventProposalHistoryQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventProposalHistoryQueryData, EventProposalHistoryQueryVariables>(EventProposalHistoryQueryDocument, options);
         }
-export type EventProposalHistoryQueryQueryHookResult = ReturnType<typeof useEventProposalHistoryQueryQuery>;
+export type EventProposalHistoryQueryHookResult = ReturnType<typeof useEventProposalHistoryQuery>;
 export type EventProposalHistoryQueryLazyQueryHookResult = ReturnType<typeof useEventProposalHistoryQueryLazyQuery>;
-export type EventProposalHistoryQueryQueryResult = Apollo.QueryResult<EventProposalHistoryQueryQuery, EventProposalHistoryQueryQueryVariables>;
+export type EventProposalHistoryQueryDataResult = Apollo.QueryResult<EventProposalHistoryQueryData, EventProposalHistoryQueryVariables>;

--- a/app/javascript/EventRatings/mutations.generated.ts
+++ b/app/javascript/EventRatings/mutations.generated.ts
@@ -3,13 +3,14 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type RateEventMutationVariables = Types.Exact<{
   eventId: Types.Scalars['Int'];
   rating: Types.Scalars['Int'];
 }>;
 
 
-export type RateEventMutation = (
+export type RateEventMutationData = (
   { __typename: 'Mutation' }
   & { rateEvent?: Types.Maybe<(
     { __typename: 'RateEventPayload' }
@@ -31,7 +32,7 @@ export const RateEventDocument = gql`
   }
 }
     `;
-export type RateEventMutationFn = Apollo.MutationFunction<RateEventMutation, RateEventMutationVariables>;
+export type RateEventMutationFn = Apollo.MutationFunction<RateEventMutationData, RateEventMutationVariables>;
 
 /**
  * __useRateEventMutation__
@@ -51,9 +52,10 @@ export type RateEventMutationFn = Apollo.MutationFunction<RateEventMutation, Rat
  *   },
  * });
  */
-export function useRateEventMutation(baseOptions?: Apollo.MutationHookOptions<RateEventMutation, RateEventMutationVariables>) {
-        return Apollo.useMutation<RateEventMutation, RateEventMutationVariables>(RateEventDocument, baseOptions);
+export function useRateEventMutation(baseOptions?: Apollo.MutationHookOptions<RateEventMutationData, RateEventMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RateEventMutationData, RateEventMutationVariables>(RateEventDocument, options);
       }
 export type RateEventMutationHookResult = ReturnType<typeof useRateEventMutation>;
-export type RateEventMutationResult = Apollo.MutationResult<RateEventMutation>;
-export type RateEventMutationOptions = Apollo.BaseMutationOptions<RateEventMutation, RateEventMutationVariables>;
+export type RateEventMutationResult = Apollo.MutationResult<RateEventMutationData>;
+export type RateEventMutationOptions = Apollo.BaseMutationOptions<RateEventMutationData, RateEventMutationVariables>;

--- a/app/javascript/EventsApp/EventList/EventCard.tsx
+++ b/app/javascript/EventsApp/EventList/EventCard.tsx
@@ -14,12 +14,12 @@ import RateEventControl from '../../EventRatings/RateEventControl';
 import useRateEvent from '../../EventRatings/useRateEvent';
 import Gravatar from '../../Gravatar';
 import { arrayToSentenceReact, joinReact } from '../../RenderingUtils';
-import { EventListEventsQueryQuery } from './queries.generated';
+import { EventListEventsQueryData } from './queries.generated';
 import { notEmpty } from '../../ValueUtils';
 import { useAppDateTimeFormat } from '../../TimeUtils';
 import { useFormatRunTime } from '../runTimeFormatting';
 
-type ConventionType = NonNullable<EventListEventsQueryQuery['convention']>;
+type ConventionType = NonNullable<EventListEventsQueryData['convention']>;
 type EventType = ConventionType['events_paginated']['entries'][0];
 
 function renderFirstRunTime(
@@ -88,7 +88,7 @@ function teamIsAllAuthors(author?: string, teamMembers?: EventType['team_members
 export type EventCardProps = {
   event: EventType;
   sortBy?: SortingRule<
-    NonNullable<EventListEventsQueryQuery['convention']>['events_paginated']['entries'][number]
+    NonNullable<EventListEventsQueryData['convention']>['events_paginated']['entries'][number]
   >[];
   canReadSchedule?: boolean;
 };

--- a/app/javascript/EventsApp/EventList/EventListCategoryDropdown.tsx
+++ b/app/javascript/EventsApp/EventList/EventListCategoryDropdown.tsx
@@ -3,12 +3,12 @@ import { pluralize } from 'inflected';
 import { useLocation } from 'react-router-dom';
 
 import ChoiceSet from '../../BuiltInFormControls/ChoiceSet';
-import { EventListEventsQueryQuery } from './queries.generated';
+import { EventListEventsQueryData } from './queries.generated';
 import { notEmpty, parseIntOrNull } from '../../ValueUtils';
 import { DropdownMenu } from '../../UIComponents/DropdownMenu';
 import { locationsEqualWithSearchParamsTransform } from '../../URLUtils';
 
-type ConventionType = NonNullable<EventListEventsQueryQuery['convention']>;
+type ConventionType = NonNullable<EventListEventsQueryData['convention']>;
 type LocationType = ReturnType<typeof useLocation>;
 
 function shouldAutoCloseOnNavigate(prevLocation: LocationType, location: LocationType) {

--- a/app/javascript/EventsApp/EventList/EventListEvents.tsx
+++ b/app/javascript/EventsApp/EventList/EventListEvents.tsx
@@ -7,15 +7,15 @@ import EventCard from './EventCard';
 import getSortedRuns from './getSortedRuns';
 import { timespanFromConvention, getConventionDayTimespans } from '../../TimespanUtils';
 import AppRootContext from '../../AppRootContext';
-import { EventListEventsQueryQuery } from './queries.generated';
+import { EventListEventsQueryData } from './queries.generated';
 import { FiniteTimespan } from '../../Timespan';
 import { useAppDateTimeFormat } from '../../TimeUtils';
 
 export type EventListEventsProps = {
-  convention: NonNullable<EventListEventsQueryQuery['convention']>;
-  eventsPaginated: NonNullable<EventListEventsQueryQuery['convention']>['events_paginated'];
+  convention: NonNullable<EventListEventsQueryData['convention']>;
+  eventsPaginated: NonNullable<EventListEventsQueryData['convention']>['events_paginated'];
   sortBy?: SortingRule<
-    NonNullable<EventListEventsQueryQuery['convention']>['events_paginated']['entries'][number]
+    NonNullable<EventListEventsQueryData['convention']>['events_paginated']['entries'][number]
   >[];
   canReadSchedule: boolean;
   fetchMoreIfNeeded: () => void;

--- a/app/javascript/EventsApp/EventList/index.tsx
+++ b/app/javascript/EventsApp/EventList/index.tsx
@@ -20,7 +20,7 @@ import AppRootContext from '../../AppRootContext';
 import EventListMyRatingSelector from './EventListMyRatingSelector';
 import useAsyncFunction from '../../useAsyncFunction';
 import LoadingIndicator from '../../LoadingIndicator';
-import { EventListEventsQueryQuery, useEventListEventsQueryQuery } from './queries.generated';
+import { EventListEventsQueryData, useEventListEventsQuery } from './queries.generated';
 
 const PAGE_SIZE = 20;
 
@@ -30,9 +30,9 @@ const filterCodecs = buildFieldFilterCodecs({
   title_prefix: FilterCodecs.nonEmptyString,
 });
 
-type FetchMoreFunction = ReturnType<typeof useEventListEventsQueryQuery>['fetchMore'];
+type FetchMoreFunction = ReturnType<typeof useEventListEventsQuery>['fetchMore'];
 type EventType = NonNullable<
-  EventListEventsQueryQuery['convention']
+  EventListEventsQueryData['convention']
 >['events_paginated']['entries'][number];
 
 const fetchMoreEvents = async (fetchMore: FetchMoreFunction, page: number) => {
@@ -40,7 +40,7 @@ const fetchMoreEvents = async (fetchMore: FetchMoreFunction, page: number) => {
     await fetchMore({
       variables: { page, pageSize: PAGE_SIZE },
       updateQuery: (prev, { fetchMoreResult }) => {
-        const updatedQuery: EventListEventsQueryQuery = {
+        const updatedQuery: EventListEventsQueryData = {
           ...prev,
           convention: {
             ...prev.convention!,
@@ -75,7 +75,7 @@ function EventList() {
     : [{ id: 'title', desc: false }];
   const [cachedConventionName, setCachedConventionName] = useState<string>();
   const [cachedEventCategories, setCachedEventCategories] = useState<
-    NonNullable<EventListEventsQueryQuery['convention']>['event_categories']
+    NonNullable<EventListEventsQueryData['convention']>['event_categories']
   >();
   const [cachedPageCount, setCachedPageCount] = useState<number>();
   const defaultFiltered = myProfile
@@ -88,7 +88,7 @@ function EventList() {
   const effectiveFilters: Filters<EventType> =
     filters && filters.length > 0 ? filters : defaultFiltered;
 
-  const { data, loading, error, fetchMore } = useEventListEventsQueryQuery({
+  const { data, loading, error, fetchMore } = useEventListEventsQuery({
     variables: {
       page: 1,
       pageSize: PAGE_SIZE,

--- a/app/javascript/EventsApp/EventList/queries.generated.ts
+++ b/app/javascript/EventsApp/EventList/queries.generated.ts
@@ -5,7 +5,8 @@ import { CommonConventionDataFragment } from '../queries.generated';
 import { gql } from '@apollo/client';
 import { CommonConventionDataFragmentDoc } from '../queries.generated';
 import * as Apollo from '@apollo/client';
-export type EventListEventsQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type EventListEventsQueryVariables = Types.Exact<{
   page?: Types.Maybe<Types.Scalars['Int']>;
   pageSize?: Types.Maybe<Types.Scalars['Int']>;
   filters?: Types.Maybe<Types.EventFiltersInput>;
@@ -13,7 +14,7 @@ export type EventListEventsQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type EventListEventsQueryQuery = (
+export type EventListEventsQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -100,16 +101,16 @@ export const EventListEventsQueryDocument = gql`
     ${CommonConventionDataFragmentDoc}`;
 
 /**
- * __useEventListEventsQueryQuery__
+ * __useEventListEventsQuery__
  *
- * To run a query within a React component, call `useEventListEventsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventListEventsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventListEventsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventListEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventListEventsQueryQuery({
+ * const { data, loading, error } = useEventListEventsQuery({
  *   variables: {
  *      page: // value for 'page'
  *      pageSize: // value for 'pageSize'
@@ -118,12 +119,14 @@ export const EventListEventsQueryDocument = gql`
  *   },
  * });
  */
-export function useEventListEventsQueryQuery(baseOptions?: Apollo.QueryHookOptions<EventListEventsQueryQuery, EventListEventsQueryQueryVariables>) {
-        return Apollo.useQuery<EventListEventsQueryQuery, EventListEventsQueryQueryVariables>(EventListEventsQueryDocument, baseOptions);
+export function useEventListEventsQuery(baseOptions?: Apollo.QueryHookOptions<EventListEventsQueryData, EventListEventsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventListEventsQueryData, EventListEventsQueryVariables>(EventListEventsQueryDocument, options);
       }
-export function useEventListEventsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventListEventsQueryQuery, EventListEventsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventListEventsQueryQuery, EventListEventsQueryQueryVariables>(EventListEventsQueryDocument, baseOptions);
+export function useEventListEventsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventListEventsQueryData, EventListEventsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventListEventsQueryData, EventListEventsQueryVariables>(EventListEventsQueryDocument, options);
         }
-export type EventListEventsQueryQueryHookResult = ReturnType<typeof useEventListEventsQueryQuery>;
+export type EventListEventsQueryHookResult = ReturnType<typeof useEventListEventsQuery>;
 export type EventListEventsQueryLazyQueryHookResult = ReturnType<typeof useEventListEventsQueryLazyQuery>;
-export type EventListEventsQueryQueryResult = Apollo.QueryResult<EventListEventsQueryQuery, EventListEventsQueryQueryVariables>;
+export type EventListEventsQueryDataResult = Apollo.QueryResult<EventListEventsQueryData, EventListEventsQueryVariables>;

--- a/app/javascript/EventsApp/EventPage/CreateModeratedSignupModal.tsx
+++ b/app/javascript/EventsApp/EventPage/CreateModeratedSignupModal.tsx
@@ -9,15 +9,15 @@ import ErrorDisplay from '../../ErrorDisplay';
 import LoadingIndicator from '../../LoadingIndicator';
 import { timespanFromRun } from '../../TimespanUtils';
 import useAsyncFunction from '../../useAsyncFunction';
-import { EventPageQueryQuery, useCreateModeratedSignupModalQueryQuery } from './queries.generated';
+import { EventPageQueryData, useCreateModeratedSignupModalQuery } from './queries.generated';
 import { SignupOption } from './buildSignupOptions';
 import { useCreateSignupRequestMutation } from './mutations.generated';
 
 export type CreateModeratedSignupModalProps = {
   visible: boolean;
   close: () => void;
-  run: EventPageQueryQuery['event']['runs'][0];
-  event: EventPageQueryQuery['event'];
+  run: EventPageQueryData['event']['runs'][0];
+  event: EventPageQueryData['event'];
   signupOption?: SignupOption;
 };
 
@@ -29,7 +29,7 @@ function CreateModeratedSignupModal({
   signupOption,
 }: CreateModeratedSignupModalProps) {
   const { conventionName, timezoneName } = useContext(AppRootContext);
-  const { data, loading, error } = useCreateModeratedSignupModalQueryQuery();
+  const { data, loading, error } = useCreateModeratedSignupModalQuery();
   const [createMutate] = useCreateSignupRequestMutation({
     refetchQueries: () => [{ query: EventPageQuery, variables: { eventId: event.id } }],
   });

--- a/app/javascript/EventsApp/EventPage/EventAdminMenu.tsx
+++ b/app/javascript/EventsApp/EventPage/EventAdminMenu.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import buildEventUrl from '../buildEventUrl';
 import ErrorDisplay from '../../ErrorDisplay';
 import LoadingIndicator from '../../LoadingIndicator';
-import { useEventPageQueryQuery } from './queries.generated';
+import { useEventPageQuery } from './queries.generated';
 
 export type EventAdminMenuProps = {
   eventId: number;
@@ -13,7 +13,7 @@ export type EventAdminMenuProps = {
 
 function EventAdminMenu({ eventId }: EventAdminMenuProps) {
   const { t } = useTranslation();
-  const { data, loading, error } = useEventPageQueryQuery({ variables: { eventId } });
+  const { data, loading, error } = useEventPageQuery({ variables: { eventId } });
 
   if (loading) {
     return <LoadingIndicator />;

--- a/app/javascript/EventsApp/EventPage/EventCapacityDisplay.tsx
+++ b/app/javascript/EventsApp/EventPage/EventCapacityDisplay.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { TFunction } from 'i18next';
 
 import sortBuckets from './sortBuckets';
-import { EventPageQueryQuery, RunCardRegistrationPolicyFieldsFragment } from './queries.generated';
+import { EventPageQueryData, RunCardRegistrationPolicyFieldsFragment } from './queries.generated';
 
 function describeBucketCapacity(
   bucket: RunCardRegistrationPolicyFieldsFragment['buckets'][0],
@@ -20,7 +20,7 @@ function describeBucketCapacity(
 }
 
 export type EventCapacityDisplayProps = {
-  event: EventPageQueryQuery['event'];
+  event: EventPageQueryData['event'];
 };
 
 function EventCapacityDisplay({ event }: EventCapacityDisplayProps) {

--- a/app/javascript/EventsApp/EventPage/EventHistory.tsx
+++ b/app/javascript/EventsApp/EventPage/EventHistory.tsx
@@ -6,7 +6,7 @@ import ErrorDisplay from '../../ErrorDisplay';
 import FormResponseChangeHistory from '../../FormPresenter/ItemChangeDisplays/FormResponseChangeHistory';
 import RouteActivatedBreadcrumbItem from '../../Breadcrumbs/RouteActivatedBreadcrumbItem';
 import BreadcrumbItem from '../../Breadcrumbs/BreadcrumbItem';
-import { useEventHistoryQueryQuery } from './eventHistoryQuery.generated';
+import { useEventHistoryQuery } from './eventHistoryQuery.generated';
 
 const EXCLUDE_FIELDS = new Set([
   'minimum_age',
@@ -23,7 +23,7 @@ export type EventHistoryProps = {
 
 function EventHistory({ eventId, eventPath }: EventHistoryProps) {
   const { t } = useTranslation();
-  const { data, loading, error } = useEventHistoryQueryQuery({
+  const { data, loading, error } = useEventHistoryQuery({
     variables: { id: eventId },
   });
 

--- a/app/javascript/EventsApp/EventPage/EventPageRunCard.tsx
+++ b/app/javascript/EventsApp/EventPage/EventPageRunCard.tsx
@@ -10,7 +10,7 @@ import { useConfirm } from '../../ModalDialogs/Confirm';
 import ErrorDisplay from '../../ErrorDisplay';
 import useModal from '../../ModalDialogs/useModal';
 import CreateModeratedSignupModal from './CreateModeratedSignupModal';
-import { EventPageQueryQuery, EventPageQueryQueryVariables } from './queries.generated';
+import { EventPageQueryData, EventPageQueryVariables } from './queries.generated';
 import {
   useCreateMySignupMutation,
   useWithdrawMySignupMutation,
@@ -19,11 +19,11 @@ import {
 
 function updateCacheAfterSignup(
   cache: ApolloCache<any>,
-  event: EventPageQueryQuery['event'],
-  run: EventPageQueryQuery['event']['runs'][0],
-  signup: EventPageQueryQuery['event']['runs'][0]['my_signups'][0],
+  event: EventPageQueryData['event'],
+  run: EventPageQueryData['event']['runs'][0],
+  signup: EventPageQueryData['event']['runs'][0]['my_signups'][0],
 ) {
-  const data = cache.readQuery<EventPageQueryQuery, EventPageQueryQueryVariables>({
+  const data = cache.readQuery<EventPageQueryData, EventPageQueryVariables>({
     query: EventPageQuery,
     variables: { eventId: event.id },
   });
@@ -54,10 +54,10 @@ function updateCacheAfterSignup(
 }
 
 export type EventPageRunCardProps = {
-  event: EventPageQueryQuery['event'];
-  run: EventPageQueryQuery['event']['runs'][0];
-  myProfile: EventPageQueryQuery['myProfile'];
-  currentAbility: EventPageQueryQuery['currentAbility'];
+  event: EventPageQueryData['event'];
+  run: EventPageQueryData['event']['runs'][0];
+  myProfile: EventPageQueryData['myProfile'];
+  currentAbility: EventPageQueryData['currentAbility'];
 };
 
 function EventPageRunCard({ event, run, myProfile, currentAbility }: EventPageRunCardProps) {

--- a/app/javascript/EventsApp/EventPage/LongFormEventDetails.tsx
+++ b/app/javascript/EventsApp/EventPage/LongFormEventDetails.tsx
@@ -2,14 +2,14 @@ import ErrorDisplay from '../../ErrorDisplay';
 import parsePageContent from '../../parsePageContent';
 import useSectionizedFormItems from './useSectionizedFormItems';
 import LoadingIndicator from '../../LoadingIndicator';
-import { useEventPageQueryQuery } from './queries.generated';
+import { useEventPageQuery } from './queries.generated';
 
 export type LongFormEventDetailsProps = {
   eventId: number;
 };
 
 function LongFormEventDetails({ eventId }: LongFormEventDetailsProps) {
-  const { data, loading, error } = useEventPageQueryQuery({ variables: { eventId } });
+  const { data, loading, error } = useEventPageQuery({ variables: { eventId } });
 
   const { longFormItems, formResponse } = useSectionizedFormItems(
     error || loading || !data ? undefined : data.event,

--- a/app/javascript/EventsApp/EventPage/RunCapacityGraph.tsx
+++ b/app/javascript/EventsApp/EventPage/RunCapacityGraph.tsx
@@ -4,14 +4,14 @@ import RunCapacityGraphBucket from './RunCapacityGraphBucket';
 import SignupCountData from '../SignupCountData';
 import sortBuckets from './sortBuckets';
 import BucketAvailabilityDisplay from './BucketAvailabilityDisplay';
-import { EventPageQueryQuery } from './queries.generated';
+import { EventPageQueryData } from './queries.generated';
 
 export type RunCapacityGraphProps = {
   run: Pick<
-    EventPageQueryQuery['event']['runs'][0],
+    EventPageQueryData['event']['runs'][0],
     'signup_count_by_state_and_bucket_key_and_counted'
   >;
-  event: Pick<EventPageQueryQuery['event'], 'registration_policy'>;
+  event: Pick<EventPageQueryData['event'], 'registration_policy'>;
   signupsAvailable: boolean;
 };
 

--- a/app/javascript/EventsApp/EventPage/RunCard.tsx
+++ b/app/javascript/EventsApp/EventPage/RunCard.tsx
@@ -15,12 +15,12 @@ import useAsyncFunction from '../../useAsyncFunction';
 import WithdrawSignupButton from './WithdrawSignupButton';
 import LoadingIndicator from '../../LoadingIndicator';
 import AuthenticationModalContext from '../../Authentication/AuthenticationModalContext';
-import { EventPageQueryQuery } from './queries.generated';
+import { EventPageQueryData } from './queries.generated';
 import { PartitionedSignupOptions, SignupOption } from './buildSignupOptions';
 import { useFormatRunTimespan } from '../runTimeFormatting';
 
 function describeSignupState(
-  mySignup: EventPageQueryQuery['event']['runs'][0]['my_signups'][0],
+  mySignup: EventPageQueryData['event']['runs'][0]['my_signups'][0],
   t: TFunction,
 ) {
   if (mySignup.state === 'confirmed') {
@@ -37,13 +37,13 @@ function describeSignupState(
 }
 
 export type RunCardProps = {
-  run: EventPageQueryQuery['event']['runs'][0];
-  event: EventPageQueryQuery['event'];
+  run: EventPageQueryData['event']['runs'][0];
+  event: EventPageQueryData['event'];
   signupOptions: PartitionedSignupOptions;
-  currentAbility: EventPageQueryQuery['currentAbility'];
+  currentAbility: EventPageQueryData['currentAbility'];
   myProfile?: object | null;
-  mySignup?: EventPageQueryQuery['event']['runs'][0]['my_signups'][0] | null;
-  myPendingSignupRequest?: EventPageQueryQuery['event']['runs'][0]['my_signup_requests'][0] | null;
+  mySignup?: EventPageQueryData['event']['runs'][0]['my_signups'][0] | null;
+  myPendingSignupRequest?: EventPageQueryData['event']['runs'][0]['my_signup_requests'][0] | null;
   showViewSignups?: boolean;
   createSignup: (signupOption: SignupOption) => Promise<any>;
   withdrawSignup: () => Promise<any>;

--- a/app/javascript/EventsApp/EventPage/RunsSection.tsx
+++ b/app/javascript/EventsApp/EventPage/RunsSection.tsx
@@ -7,10 +7,10 @@ import RunCapacityGraph from './RunCapacityGraph';
 import ErrorDisplay from '../../ErrorDisplay';
 import EventPageRunCard from './EventPageRunCard';
 import LoadingIndicator from '../../LoadingIndicator';
-import { EventPageQueryQuery, useEventPageQueryQuery } from './queries.generated';
+import { EventPageQueryData, useEventPageQuery } from './queries.generated';
 
 type FakeRunProps = {
-  event: EventPageQueryQuery['event'];
+  event: EventPageQueryData['event'];
 };
 
 function FakeRun({ event }: FakeRunProps) {
@@ -43,7 +43,7 @@ export type RunsSectionProps = {
 };
 
 function RunsSection({ eventId }: RunsSectionProps) {
-  const { data, loading, error } = useEventPageQueryQuery({ variables: { eventId } });
+  const { data, loading, error } = useEventPageQuery({ variables: { eventId } });
 
   const sortedRuns = useMemo(
     () =>

--- a/app/javascript/EventsApp/EventPage/ShortFormEventDetails.tsx
+++ b/app/javascript/EventsApp/EventPage/ShortFormEventDetails.tsx
@@ -10,7 +10,7 @@ import teamMembersForDisplay from '../teamMembersForDisplay';
 import Gravatar from '../../Gravatar';
 import { formResponseValueIsComplete } from '../../Models/FormItem';
 import LoadingIndicator from '../../LoadingIndicator';
-import { useEventPageQueryQuery } from './queries.generated';
+import { useEventPageQuery } from './queries.generated';
 
 export type ShortFormEventDetailsProps = {
   eventId: number;
@@ -18,7 +18,7 @@ export type ShortFormEventDetailsProps = {
 
 function ShortFormEventDetails({ eventId }: ShortFormEventDetailsProps) {
   const { t } = useTranslation();
-  const { data, loading, error } = useEventPageQueryQuery({ variables: { eventId } });
+  const { data, loading, error } = useEventPageQuery({ variables: { eventId } });
 
   const { shortFormItems, formResponse } = useSectionizedFormItems(
     error || loading || !data ? undefined : data.event,

--- a/app/javascript/EventsApp/EventPage/ViewSignupsOptions.tsx
+++ b/app/javascript/EventsApp/EventPage/ViewSignupsOptions.tsx
@@ -2,12 +2,12 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import buildEventUrl from '../buildEventUrl';
-import { EventPageQueryQuery } from './queries.generated';
+import { EventPageQueryData } from './queries.generated';
 
 export type ViewSignupsOptionsProps = {
-  event: EventPageQueryQuery['event'];
-  run: EventPageQueryQuery['event']['runs'][0];
-  currentAbility: EventPageQueryQuery['currentAbility'];
+  event: EventPageQueryData['event'];
+  run: EventPageQueryData['event']['runs'][0];
+  currentAbility: EventPageQueryData['currentAbility'];
 };
 
 function ViewSignupsOptions({ event, run, currentAbility }: ViewSignupsOptionsProps) {

--- a/app/javascript/EventsApp/EventPage/WithdrawMySignupButton.tsx
+++ b/app/javascript/EventsApp/EventPage/WithdrawMySignupButton.tsx
@@ -3,12 +3,12 @@ import { useTranslation } from 'react-i18next';
 import WithdrawSignupButton, { WithdrawSignupButtonProps } from './WithdrawSignupButton';
 import { useConfirm } from '../../ModalDialogs/Confirm';
 import ErrorDisplay from '../../ErrorDisplay';
-import { EventPageQueryQuery } from './queries.generated';
+import { EventPageQueryData } from './queries.generated';
 import { useWithdrawMySignupMutation } from './mutations.generated';
 
 export type WithdrawMySignupButtonProps = Omit<WithdrawSignupButtonProps, 'withdrawSignup'> & {
-  run: EventPageQueryQuery['event']['runs'][0];
-  event: EventPageQueryQuery['event'];
+  run: EventPageQueryData['event']['runs'][0];
+  event: EventPageQueryData['event'];
   reloadOnSuccess?: boolean;
 };
 

--- a/app/javascript/EventsApp/EventPage/buildSignupOptions.ts
+++ b/app/javascript/EventsApp/EventPage/buildSignupOptions.ts
@@ -1,5 +1,5 @@
 import { notEmpty } from '../../ValueUtils';
-import { EventPageQueryQuery, RunCardRegistrationPolicyFieldsFragment } from './queries.generated';
+import { EventPageQueryData, RunCardRegistrationPolicyFieldsFragment } from './queries.generated';
 import sortBuckets from './sortBuckets';
 
 type SignupOptionBucket = RunCardRegistrationPolicyFieldsFragment['buckets'][0];
@@ -62,7 +62,7 @@ function buildBucketSignupOption(
 }
 
 function buildNoPreferenceOptions(
-  event: Pick<EventPageQueryQuery['event'], 'registration_policy'>,
+  event: Pick<EventPageQueryData['event'], 'registration_policy'>,
 ): SignupOption[] {
   if ((event.registration_policy || {}).prevent_no_preference_signups) {
     return [];

--- a/app/javascript/EventsApp/EventPage/eventHistoryQuery.generated.ts
+++ b/app/javascript/EventsApp/EventPage/eventHistoryQuery.generated.ts
@@ -5,12 +5,13 @@ import { CommonFormFieldsFragment, CommonFormSectionFieldsFragment, CommonFormIt
 import { gql } from '@apollo/client';
 import { CommonFormFieldsFragmentDoc, CommonFormSectionFieldsFragmentDoc, CommonFormItemFieldsFragmentDoc } from '../../Models/commonFormFragments.generated';
 import * as Apollo from '@apollo/client';
-export type EventHistoryQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type EventHistoryQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type EventHistoryQueryQuery = (
+export type EventHistoryQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -88,27 +89,29 @@ export const EventHistoryQueryDocument = gql`
     ${CommonFormFieldsFragmentDoc}`;
 
 /**
- * __useEventHistoryQueryQuery__
+ * __useEventHistoryQuery__
  *
- * To run a query within a React component, call `useEventHistoryQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventHistoryQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventHistoryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventHistoryQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventHistoryQueryQuery({
+ * const { data, loading, error } = useEventHistoryQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useEventHistoryQueryQuery(baseOptions: Apollo.QueryHookOptions<EventHistoryQueryQuery, EventHistoryQueryQueryVariables>) {
-        return Apollo.useQuery<EventHistoryQueryQuery, EventHistoryQueryQueryVariables>(EventHistoryQueryDocument, baseOptions);
+export function useEventHistoryQuery(baseOptions: Apollo.QueryHookOptions<EventHistoryQueryData, EventHistoryQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventHistoryQueryData, EventHistoryQueryVariables>(EventHistoryQueryDocument, options);
       }
-export function useEventHistoryQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventHistoryQueryQuery, EventHistoryQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventHistoryQueryQuery, EventHistoryQueryQueryVariables>(EventHistoryQueryDocument, baseOptions);
+export function useEventHistoryQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventHistoryQueryData, EventHistoryQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventHistoryQueryData, EventHistoryQueryVariables>(EventHistoryQueryDocument, options);
         }
-export type EventHistoryQueryQueryHookResult = ReturnType<typeof useEventHistoryQueryQuery>;
+export type EventHistoryQueryHookResult = ReturnType<typeof useEventHistoryQuery>;
 export type EventHistoryQueryLazyQueryHookResult = ReturnType<typeof useEventHistoryQueryLazyQuery>;
-export type EventHistoryQueryQueryResult = Apollo.QueryResult<EventHistoryQueryQuery, EventHistoryQueryQueryVariables>;
+export type EventHistoryQueryDataResult = Apollo.QueryResult<EventHistoryQueryData, EventHistoryQueryVariables>;

--- a/app/javascript/EventsApp/EventPage/index.tsx
+++ b/app/javascript/EventsApp/EventPage/index.tsx
@@ -12,7 +12,7 @@ import RateEventControl from '../../EventRatings/RateEventControl';
 import AppRootContext from '../../AppRootContext';
 import useRateEvent from '../../EventRatings/useRateEvent';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { useEventPageQueryQuery } from './queries.generated';
+import { useEventPageQuery } from './queries.generated';
 import useSectionizedFormItems from './useSectionizedFormItems';
 import parsePageContent from '../../parsePageContent';
 
@@ -23,7 +23,7 @@ export type EventPageProps = {
 
 function EventPage({ eventId, eventPath }: EventPageProps) {
   const { myProfile } = useContext(AppRootContext);
-  const { data, loading, error } = useEventPageQueryQuery({ variables: { eventId } });
+  const { data, loading, error } = useEventPageQuery({ variables: { eventId } });
   const rateEvent = useRateEvent();
   const { secretFormItems, formResponse } = useSectionizedFormItems(data?.event);
 

--- a/app/javascript/EventsApp/EventPage/mutations.generated.ts
+++ b/app/javascript/EventsApp/EventPage/mutations.generated.ts
@@ -7,6 +7,7 @@ import { gql } from '@apollo/client';
 import { MySignupFieldsFragmentDoc, EventPageRunFieldsFragmentDoc, MySignupRequestFieldsFragmentDoc } from './queries.generated';
 import { RunBasicSignupDataFragmentDoc, CommonConventionDataFragmentDoc } from '../queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateMySignupMutationVariables = Types.Exact<{
   runId: Types.Scalars['Int'];
   requestedBucketKey?: Types.Maybe<Types.Scalars['String']>;
@@ -14,7 +15,7 @@ export type CreateMySignupMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateMySignupMutation = (
+export type CreateMySignupMutationData = (
   { __typename: 'Mutation' }
   & { createMySignup?: Types.Maybe<(
     { __typename: 'CreateMySignupPayload' }
@@ -37,7 +38,7 @@ export type WithdrawMySignupMutationVariables = Types.Exact<{
 }>;
 
 
-export type WithdrawMySignupMutation = (
+export type WithdrawMySignupMutationData = (
   { __typename: 'Mutation' }
   & { withdrawMySignup?: Types.Maybe<(
     { __typename: 'WithdrawMySignupPayload' }
@@ -62,7 +63,7 @@ export type CreateSignupRequestMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateSignupRequestMutation = (
+export type CreateSignupRequestMutationData = (
   { __typename: 'Mutation' }
   & { createSignupRequest?: Types.Maybe<(
     { __typename: 'CreateSignupRequestPayload' }
@@ -79,7 +80,7 @@ export type WithdrawSignupRequestMutationVariables = Types.Exact<{
 }>;
 
 
-export type WithdrawSignupRequestMutation = (
+export type WithdrawSignupRequestMutationData = (
   { __typename: 'Mutation' }
   & { withdrawSignupRequest?: Types.Maybe<(
     { __typename: 'WithdrawSignupRequestPayload' }
@@ -111,7 +112,7 @@ export const CreateMySignupDocument = gql`
     ${MySignupFieldsFragmentDoc}
 ${EventPageRunFieldsFragmentDoc}
 ${RunBasicSignupDataFragmentDoc}`;
-export type CreateMySignupMutationFn = Apollo.MutationFunction<CreateMySignupMutation, CreateMySignupMutationVariables>;
+export type CreateMySignupMutationFn = Apollo.MutationFunction<CreateMySignupMutationData, CreateMySignupMutationVariables>;
 
 /**
  * __useCreateMySignupMutation__
@@ -132,12 +133,13 @@ export type CreateMySignupMutationFn = Apollo.MutationFunction<CreateMySignupMut
  *   },
  * });
  */
-export function useCreateMySignupMutation(baseOptions?: Apollo.MutationHookOptions<CreateMySignupMutation, CreateMySignupMutationVariables>) {
-        return Apollo.useMutation<CreateMySignupMutation, CreateMySignupMutationVariables>(CreateMySignupDocument, baseOptions);
+export function useCreateMySignupMutation(baseOptions?: Apollo.MutationHookOptions<CreateMySignupMutationData, CreateMySignupMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateMySignupMutationData, CreateMySignupMutationVariables>(CreateMySignupDocument, options);
       }
 export type CreateMySignupMutationHookResult = ReturnType<typeof useCreateMySignupMutation>;
-export type CreateMySignupMutationResult = Apollo.MutationResult<CreateMySignupMutation>;
-export type CreateMySignupMutationOptions = Apollo.BaseMutationOptions<CreateMySignupMutation, CreateMySignupMutationVariables>;
+export type CreateMySignupMutationResult = Apollo.MutationResult<CreateMySignupMutationData>;
+export type CreateMySignupMutationOptions = Apollo.BaseMutationOptions<CreateMySignupMutationData, CreateMySignupMutationVariables>;
 export const WithdrawMySignupDocument = gql`
     mutation WithdrawMySignup($runId: Int!) {
   withdrawMySignup(input: {run_id: $runId}) {
@@ -155,7 +157,7 @@ export const WithdrawMySignupDocument = gql`
     ${MySignupFieldsFragmentDoc}
 ${EventPageRunFieldsFragmentDoc}
 ${RunBasicSignupDataFragmentDoc}`;
-export type WithdrawMySignupMutationFn = Apollo.MutationFunction<WithdrawMySignupMutation, WithdrawMySignupMutationVariables>;
+export type WithdrawMySignupMutationFn = Apollo.MutationFunction<WithdrawMySignupMutationData, WithdrawMySignupMutationVariables>;
 
 /**
  * __useWithdrawMySignupMutation__
@@ -174,12 +176,13 @@ export type WithdrawMySignupMutationFn = Apollo.MutationFunction<WithdrawMySignu
  *   },
  * });
  */
-export function useWithdrawMySignupMutation(baseOptions?: Apollo.MutationHookOptions<WithdrawMySignupMutation, WithdrawMySignupMutationVariables>) {
-        return Apollo.useMutation<WithdrawMySignupMutation, WithdrawMySignupMutationVariables>(WithdrawMySignupDocument, baseOptions);
+export function useWithdrawMySignupMutation(baseOptions?: Apollo.MutationHookOptions<WithdrawMySignupMutationData, WithdrawMySignupMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<WithdrawMySignupMutationData, WithdrawMySignupMutationVariables>(WithdrawMySignupDocument, options);
       }
 export type WithdrawMySignupMutationHookResult = ReturnType<typeof useWithdrawMySignupMutation>;
-export type WithdrawMySignupMutationResult = Apollo.MutationResult<WithdrawMySignupMutation>;
-export type WithdrawMySignupMutationOptions = Apollo.BaseMutationOptions<WithdrawMySignupMutation, WithdrawMySignupMutationVariables>;
+export type WithdrawMySignupMutationResult = Apollo.MutationResult<WithdrawMySignupMutationData>;
+export type WithdrawMySignupMutationOptions = Apollo.BaseMutationOptions<WithdrawMySignupMutationData, WithdrawMySignupMutationVariables>;
 export const CreateSignupRequestDocument = gql`
     mutation CreateSignupRequest($targetRunId: Int!, $requestedBucketKey: String, $replaceSignupId: Int) {
   createSignupRequest(
@@ -192,7 +195,7 @@ export const CreateSignupRequestDocument = gql`
   }
 }
     ${MySignupRequestFieldsFragmentDoc}`;
-export type CreateSignupRequestMutationFn = Apollo.MutationFunction<CreateSignupRequestMutation, CreateSignupRequestMutationVariables>;
+export type CreateSignupRequestMutationFn = Apollo.MutationFunction<CreateSignupRequestMutationData, CreateSignupRequestMutationVariables>;
 
 /**
  * __useCreateSignupRequestMutation__
@@ -213,12 +216,13 @@ export type CreateSignupRequestMutationFn = Apollo.MutationFunction<CreateSignup
  *   },
  * });
  */
-export function useCreateSignupRequestMutation(baseOptions?: Apollo.MutationHookOptions<CreateSignupRequestMutation, CreateSignupRequestMutationVariables>) {
-        return Apollo.useMutation<CreateSignupRequestMutation, CreateSignupRequestMutationVariables>(CreateSignupRequestDocument, baseOptions);
+export function useCreateSignupRequestMutation(baseOptions?: Apollo.MutationHookOptions<CreateSignupRequestMutationData, CreateSignupRequestMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateSignupRequestMutationData, CreateSignupRequestMutationVariables>(CreateSignupRequestDocument, options);
       }
 export type CreateSignupRequestMutationHookResult = ReturnType<typeof useCreateSignupRequestMutation>;
-export type CreateSignupRequestMutationResult = Apollo.MutationResult<CreateSignupRequestMutation>;
-export type CreateSignupRequestMutationOptions = Apollo.BaseMutationOptions<CreateSignupRequestMutation, CreateSignupRequestMutationVariables>;
+export type CreateSignupRequestMutationResult = Apollo.MutationResult<CreateSignupRequestMutationData>;
+export type CreateSignupRequestMutationOptions = Apollo.BaseMutationOptions<CreateSignupRequestMutationData, CreateSignupRequestMutationVariables>;
 export const WithdrawSignupRequestDocument = gql`
     mutation WithdrawSignupRequest($id: Int!) {
   withdrawSignupRequest(input: {id: $id}) {
@@ -229,7 +233,7 @@ export const WithdrawSignupRequestDocument = gql`
   }
 }
     ${MySignupRequestFieldsFragmentDoc}`;
-export type WithdrawSignupRequestMutationFn = Apollo.MutationFunction<WithdrawSignupRequestMutation, WithdrawSignupRequestMutationVariables>;
+export type WithdrawSignupRequestMutationFn = Apollo.MutationFunction<WithdrawSignupRequestMutationData, WithdrawSignupRequestMutationVariables>;
 
 /**
  * __useWithdrawSignupRequestMutation__
@@ -248,9 +252,10 @@ export type WithdrawSignupRequestMutationFn = Apollo.MutationFunction<WithdrawSi
  *   },
  * });
  */
-export function useWithdrawSignupRequestMutation(baseOptions?: Apollo.MutationHookOptions<WithdrawSignupRequestMutation, WithdrawSignupRequestMutationVariables>) {
-        return Apollo.useMutation<WithdrawSignupRequestMutation, WithdrawSignupRequestMutationVariables>(WithdrawSignupRequestDocument, baseOptions);
+export function useWithdrawSignupRequestMutation(baseOptions?: Apollo.MutationHookOptions<WithdrawSignupRequestMutationData, WithdrawSignupRequestMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<WithdrawSignupRequestMutationData, WithdrawSignupRequestMutationVariables>(WithdrawSignupRequestDocument, options);
       }
 export type WithdrawSignupRequestMutationHookResult = ReturnType<typeof useWithdrawSignupRequestMutation>;
-export type WithdrawSignupRequestMutationResult = Apollo.MutationResult<WithdrawSignupRequestMutation>;
-export type WithdrawSignupRequestMutationOptions = Apollo.BaseMutationOptions<WithdrawSignupRequestMutation, WithdrawSignupRequestMutationVariables>;
+export type WithdrawSignupRequestMutationResult = Apollo.MutationResult<WithdrawSignupRequestMutationData>;
+export type WithdrawSignupRequestMutationOptions = Apollo.BaseMutationOptions<WithdrawSignupRequestMutationData, WithdrawSignupRequestMutationVariables>;

--- a/app/javascript/EventsApp/EventPage/queries.generated.ts
+++ b/app/javascript/EventsApp/EventPage/queries.generated.ts
@@ -7,6 +7,7 @@ import { gql } from '@apollo/client';
 import { CommonConventionDataFragmentDoc } from '../queries.generated';
 import { CommonFormFieldsFragmentDoc, CommonFormSectionFieldsFragmentDoc, CommonFormItemFieldsFragmentDoc } from '../../Models/commonFormFragments.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type MySignupFieldsFragment = (
   { __typename: 'Signup' }
   & Pick<Types.Signup, 'id' | 'state' | 'waitlist_position'>
@@ -50,12 +51,12 @@ export type RunCardRegistrationPolicyFieldsFragment = (
   )> }
 );
 
-export type EventPageQueryQueryVariables = Types.Exact<{
+export type EventPageQueryVariables = Types.Exact<{
   eventId: Types.Scalars['Int'];
 }>;
 
 
-export type EventPageQueryQuery = (
+export type EventPageQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -105,10 +106,10 @@ export type EventPageQueryQuery = (
   ) }
 );
 
-export type CreateModeratedSignupModalQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CreateModeratedSignupModalQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CreateModeratedSignupModalQueryQuery = (
+export type CreateModeratedSignupModalQueryData = (
   { __typename: 'Query' }
   & { myProfile?: Types.Maybe<(
     { __typename: 'UserConProfile' }
@@ -255,30 +256,32 @@ ${RunCardRegistrationPolicyFieldsFragmentDoc}
 ${EventPageRunFieldsFragmentDoc}`;
 
 /**
- * __useEventPageQueryQuery__
+ * __useEventPageQuery__
  *
- * To run a query within a React component, call `useEventPageQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventPageQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventPageQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventPageQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventPageQueryQuery({
+ * const { data, loading, error } = useEventPageQuery({
  *   variables: {
  *      eventId: // value for 'eventId'
  *   },
  * });
  */
-export function useEventPageQueryQuery(baseOptions: Apollo.QueryHookOptions<EventPageQueryQuery, EventPageQueryQueryVariables>) {
-        return Apollo.useQuery<EventPageQueryQuery, EventPageQueryQueryVariables>(EventPageQueryDocument, baseOptions);
+export function useEventPageQuery(baseOptions: Apollo.QueryHookOptions<EventPageQueryData, EventPageQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventPageQueryData, EventPageQueryVariables>(EventPageQueryDocument, options);
       }
-export function useEventPageQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventPageQueryQuery, EventPageQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventPageQueryQuery, EventPageQueryQueryVariables>(EventPageQueryDocument, baseOptions);
+export function useEventPageQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventPageQueryData, EventPageQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventPageQueryData, EventPageQueryVariables>(EventPageQueryDocument, options);
         }
-export type EventPageQueryQueryHookResult = ReturnType<typeof useEventPageQueryQuery>;
+export type EventPageQueryHookResult = ReturnType<typeof useEventPageQuery>;
 export type EventPageQueryLazyQueryHookResult = ReturnType<typeof useEventPageQueryLazyQuery>;
-export type EventPageQueryQueryResult = Apollo.QueryResult<EventPageQueryQuery, EventPageQueryQueryVariables>;
+export type EventPageQueryDataResult = Apollo.QueryResult<EventPageQueryData, EventPageQueryVariables>;
 export const CreateModeratedSignupModalQueryDocument = gql`
     query CreateModeratedSignupModalQuery {
   myProfile {
@@ -302,26 +305,28 @@ export const CreateModeratedSignupModalQueryDocument = gql`
     `;
 
 /**
- * __useCreateModeratedSignupModalQueryQuery__
+ * __useCreateModeratedSignupModalQuery__
  *
- * To run a query within a React component, call `useCreateModeratedSignupModalQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCreateModeratedSignupModalQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCreateModeratedSignupModalQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCreateModeratedSignupModalQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCreateModeratedSignupModalQueryQuery({
+ * const { data, loading, error } = useCreateModeratedSignupModalQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCreateModeratedSignupModalQueryQuery(baseOptions?: Apollo.QueryHookOptions<CreateModeratedSignupModalQueryQuery, CreateModeratedSignupModalQueryQueryVariables>) {
-        return Apollo.useQuery<CreateModeratedSignupModalQueryQuery, CreateModeratedSignupModalQueryQueryVariables>(CreateModeratedSignupModalQueryDocument, baseOptions);
+export function useCreateModeratedSignupModalQuery(baseOptions?: Apollo.QueryHookOptions<CreateModeratedSignupModalQueryData, CreateModeratedSignupModalQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CreateModeratedSignupModalQueryData, CreateModeratedSignupModalQueryVariables>(CreateModeratedSignupModalQueryDocument, options);
       }
-export function useCreateModeratedSignupModalQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CreateModeratedSignupModalQueryQuery, CreateModeratedSignupModalQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CreateModeratedSignupModalQueryQuery, CreateModeratedSignupModalQueryQueryVariables>(CreateModeratedSignupModalQueryDocument, baseOptions);
+export function useCreateModeratedSignupModalQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CreateModeratedSignupModalQueryData, CreateModeratedSignupModalQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CreateModeratedSignupModalQueryData, CreateModeratedSignupModalQueryVariables>(CreateModeratedSignupModalQueryDocument, options);
         }
-export type CreateModeratedSignupModalQueryQueryHookResult = ReturnType<typeof useCreateModeratedSignupModalQueryQuery>;
+export type CreateModeratedSignupModalQueryHookResult = ReturnType<typeof useCreateModeratedSignupModalQuery>;
 export type CreateModeratedSignupModalQueryLazyQueryHookResult = ReturnType<typeof useCreateModeratedSignupModalQueryLazyQuery>;
-export type CreateModeratedSignupModalQueryQueryResult = Apollo.QueryResult<CreateModeratedSignupModalQueryQuery, CreateModeratedSignupModalQueryQueryVariables>;
+export type CreateModeratedSignupModalQueryDataResult = Apollo.QueryResult<CreateModeratedSignupModalQueryData, CreateModeratedSignupModalQueryVariables>;

--- a/app/javascript/EventsApp/EventPage/useSectionizedFormItems.ts
+++ b/app/javascript/EventsApp/EventPage/useSectionizedFormItems.ts
@@ -2,9 +2,9 @@ import { useMemo } from 'react';
 import { FreeTextFormItem, TypedFormItem } from '../../FormAdmin/FormItemUtils';
 
 import { getSortedParsedFormItems } from '../../Models/Form';
-import { EventPageQueryQuery } from './queries.generated';
+import { EventPageQueryData } from './queries.generated';
 
-type EventPageForm = NonNullable<EventPageQueryQuery['event']['form']>;
+type EventPageForm = NonNullable<EventPageQueryData['event']['form']>;
 
 function getSectionizedFormItems(formData: EventPageForm, formResponse: { [x: string]: any }) {
   const displayFormItems = getSortedParsedFormItems(formData).filter(
@@ -42,7 +42,7 @@ function getSectionizedFormItems(formData: EventPageForm, formResponse: { [x: st
   return { shortFormItems, secretFormItems, longFormItems };
 }
 
-export default function useSectionizedFormItems(event?: EventPageQueryQuery['event']) {
+export default function useSectionizedFormItems(event?: EventPageQueryData['event']) {
   const formResponse = useMemo(
     () => (event ? JSON.parse(event.form_response_attrs_json_with_rendered_markdown) : null),
     [event],

--- a/app/javascript/EventsApp/RunList/RunListEventRun.tsx
+++ b/app/javascript/EventsApp/RunList/RunListEventRun.tsx
@@ -2,14 +2,14 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { FiniteTimespan } from '../../Timespan';
 import { useAppDateTimeFormat } from '../../TimeUtils';
 import { useIntercodePopperWithAutoClosing } from '../../UIComponents/PopperUtils';
-import { ScheduleGridCombinedQueryQuery } from '../ScheduleGrid/queries.generated';
+import { ScheduleGridCombinedQueryData } from '../ScheduleGrid/queries.generated';
 import RunDetails from '../ScheduleGrid/RunDetails';
 import RunDisplay from '../ScheduleGrid/RunDisplay';
 import SignupCountData from '../SignupCountData';
 
 export type RunListEventRunProps = {
-  event: ScheduleGridCombinedQueryQuery['events'][number];
-  run: ScheduleGridCombinedQueryQuery['events'][number]['runs'][number];
+  event: ScheduleGridCombinedQueryData['events'][number];
+  run: ScheduleGridCombinedQueryData['events'][number]['runs'][number];
   timespan: FiniteTimespan;
   signupCountData: SignupCountData;
 };

--- a/app/javascript/EventsApp/RunList/index.tsx
+++ b/app/javascript/EventsApp/RunList/index.tsx
@@ -15,7 +15,7 @@ import usePageTitle from '../../usePageTitle';
 import { useConventionDayUrlPortion } from '../ScheduleGrid/ConventionDayTabContainer';
 import { PIXELS_PER_LANE } from '../ScheduleGrid/LayoutConstants';
 import { usePersonalScheduleFilters } from '../ScheduleGrid/PersonalScheduleFiltersBar';
-import { useScheduleGridCombinedQueryQuery } from '../ScheduleGrid/queries.generated';
+import { useScheduleGridCombinedQuery } from '../ScheduleGrid/queries.generated';
 import { findConflictingRuns } from '../ScheduleGrid/Schedule';
 import SignupCountData from '../SignupCountData';
 import RunListEventRun from './RunListEventRun';
@@ -35,7 +35,7 @@ function isElementInViewport(el: HTMLElement) {
 }
 
 function useLoadRunListData() {
-  return useScheduleGridCombinedQueryQuery({ variables: { extendedCounts: false } });
+  return useScheduleGridCombinedQuery({ variables: { extendedCounts: false } });
 }
 
 export default LoadQueryWrapper(useLoadRunListData, function RunList({ data }) {

--- a/app/javascript/EventsApp/ScheduleGrid/CategoryLegend.tsx
+++ b/app/javascript/EventsApp/ScheduleGrid/CategoryLegend.tsx
@@ -5,12 +5,12 @@ import FakeEventRun from './FakeEventRun';
 import ErrorDisplay from '../../ErrorDisplay';
 import { sortByLocaleString } from '../../ValueUtils';
 import LoadingIndicator from '../../LoadingIndicator';
-import { useCommonConventionDataQueryQuery } from '../queries.generated';
+import { useCommonConventionDataQuery } from '../queries.generated';
 import { SignupStatus } from './StylingUtils';
 
 function CategoryLegend() {
   const { t } = useTranslation();
-  const { data, loading, error } = useCommonConventionDataQueryQuery();
+  const { data, loading, error } = useCommonConventionDataQuery();
   const sortedEventCategories = useMemo(
     () =>
       error || loading || !data

--- a/app/javascript/EventsApp/ScheduleGrid/Schedule.ts
+++ b/app/javascript/EventsApp/ScheduleGrid/Schedule.ts
@@ -9,7 +9,7 @@ import {
   isCatchAllMatchRule,
   buildCategoryMatchRules,
 } from './ScheduleGridConfig';
-import { ScheduleGridEventFragmentFragment } from './queries.generated';
+import { ScheduleGridEventFragment } from './queries.generated';
 import { timespanFromRun } from '../../TimespanUtils';
 import { timeIsOnTheHour } from '../../TimeUtils';
 
@@ -22,17 +22,11 @@ function expandTimespanToNearestHour(timespan: FiniteTimespan) {
   return Timespan.fromDateTimes(start, finish) as FiniteTimespan;
 }
 
-type EventForConflictingRuns = Pick<
-  ScheduleGridEventFragmentFragment,
-  'can_play_concurrently' | 'id'
-> & {
+type EventForConflictingRuns = Pick<ScheduleGridEventFragment, 'can_play_concurrently' | 'id'> & {
   runs: {
-    my_signups: Pick<
-      ScheduleGridEventFragmentFragment['runs'][number]['my_signups'][number],
-      'state'
-    >[];
+    my_signups: Pick<ScheduleGridEventFragment['runs'][number]['my_signups'][number], 'state'>[];
     my_signup_requests: Pick<
-      ScheduleGridEventFragmentFragment['runs'][number]['my_signup_requests'][number],
+      ScheduleGridEventFragment['runs'][number]['my_signup_requests'][number],
       'state'
     >[];
   }[];
@@ -61,7 +55,7 @@ export function findConflictingRuns<T extends EventForConflictingRuns>(events: T
   return conflictingRuns;
 }
 
-export type ScheduleEvent = ScheduleGridEventFragmentFragment & {
+export type ScheduleEvent = ScheduleGridEventFragment & {
   displayTitle?: string;
   fake?: boolean;
 };

--- a/app/javascript/EventsApp/ScheduleGrid/ScheduleGridContext.tsx
+++ b/app/javascript/EventsApp/ScheduleGrid/ScheduleGridContext.tsx
@@ -27,9 +27,9 @@ import AppRootContext from '../../AppRootContext';
 import { ScheduleGridConfig } from './ScheduleGridConfig';
 import { TimezoneMode } from '../../graphqlTypes.generated';
 import {
-  ScheduleGridEventFragmentFragment,
-  useScheduleGridConventionDataQueryQuery,
-  useScheduleGridEventsQueryQuery,
+  ScheduleGridEventFragment,
+  useScheduleGridConventionDataQuery,
+  useScheduleGridEventsQuery,
 } from './queries.generated';
 import { FiniteTimespan } from '../../Timespan';
 
@@ -107,7 +107,7 @@ function checkRunDetailsVisibity(
 export function useScheduleGridProvider(
   config: ScheduleGridConfig | undefined,
   convention: ConventionForTimespanUtils | undefined,
-  events: ScheduleGridEventFragmentFragment[] | undefined,
+  events: ScheduleGridEventFragment[] | undefined,
   myRatingFilter?: number[],
   hideConflicts?: boolean,
 ): ScheduleGridContextValue {
@@ -234,7 +234,7 @@ function ScheduleGridProviderTabContent({
   afterLoaded,
 }: ScheduleGridProviderTabContentProps) {
   const { myRatingFilter, hideConflicts } = useContext(ScheduleGridFiltersContext);
-  const { data, error, loading } = useScheduleGridEventsQueryQuery({
+  const { data, error, loading } = useScheduleGridEventsQuery({
     variables: {
       ...getEventsQueryVariables(timespan, config.showExtendedCounts),
     },
@@ -284,7 +284,7 @@ export function ScheduleGridProvider({
   const { timezoneName } = useContext(AppRootContext);
   const filtersContextValue = { myRatingFilter, hideConflicts };
   const prefetchAll = IS_MOBILE;
-  const { data, loading, error } = useScheduleGridConventionDataQueryQuery();
+  const { data, loading, error } = useScheduleGridConventionDataQuery();
   const client = useApolloClient();
 
   const prefetchTimespan = useCallback(

--- a/app/javascript/EventsApp/ScheduleGrid/queries.generated.ts
+++ b/app/javascript/EventsApp/ScheduleGrid/queries.generated.ts
@@ -5,7 +5,8 @@ import { RunBasicSignupDataFragment, CommonConventionDataFragment } from '../que
 import { gql } from '@apollo/client';
 import { RunBasicSignupDataFragmentDoc, CommonConventionDataFragmentDoc } from '../queries.generated';
 import * as Apollo from '@apollo/client';
-export type ScheduleGridEventFragmentFragment = (
+const defaultOptions =  {}
+export type ScheduleGridEventFragment = (
   { __typename: 'Event' }
   & Pick<Types.Event, 'id' | 'title' | 'length_seconds' | 'short_blurb_html' | 'my_rating' | 'can_play_concurrently'>
   & { event_category: (
@@ -25,10 +26,10 @@ export type ScheduleGridEventFragmentFragment = (
   )> }
 );
 
-export type ScheduleGridConventionDataQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type ScheduleGridConventionDataQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type ScheduleGridConventionDataQueryQuery = (
+export type ScheduleGridConventionDataQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -37,30 +38,30 @@ export type ScheduleGridConventionDataQueryQuery = (
   ) }
 );
 
-export type ScheduleGridEventsQueryQueryVariables = Types.Exact<{
+export type ScheduleGridEventsQueryVariables = Types.Exact<{
   extendedCounts: Types.Scalars['Boolean'];
   start?: Types.Maybe<Types.Scalars['Date']>;
   finish?: Types.Maybe<Types.Scalars['Date']>;
 }>;
 
 
-export type ScheduleGridEventsQueryQuery = (
+export type ScheduleGridEventsQueryData = (
   { __typename: 'Query' }
   & { events: Array<(
     { __typename: 'Event' }
     & Pick<Types.Event, 'id'>
-    & ScheduleGridEventFragmentFragment
+    & ScheduleGridEventFragment
   )> }
 );
 
-export type ScheduleGridCombinedQueryQueryVariables = Types.Exact<{
+export type ScheduleGridCombinedQueryVariables = Types.Exact<{
   extendedCounts: Types.Scalars['Boolean'];
   start?: Types.Maybe<Types.Scalars['Date']>;
   finish?: Types.Maybe<Types.Scalars['Date']>;
 }>;
 
 
-export type ScheduleGridCombinedQueryQuery = (
+export type ScheduleGridCombinedQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -69,11 +70,11 @@ export type ScheduleGridCombinedQueryQuery = (
   ), events: Array<(
     { __typename: 'Event' }
     & Pick<Types.Event, 'id'>
-    & ScheduleGridEventFragmentFragment
+    & ScheduleGridEventFragment
   )> }
 );
 
-export const ScheduleGridEventFragmentFragmentDoc = gql`
+export const ScheduleGridEventFragmentDoc = gql`
     fragment ScheduleGridEventFragment on Event {
   id
   title
@@ -127,29 +128,31 @@ export const ScheduleGridConventionDataQueryDocument = gql`
     ${CommonConventionDataFragmentDoc}`;
 
 /**
- * __useScheduleGridConventionDataQueryQuery__
+ * __useScheduleGridConventionDataQuery__
  *
- * To run a query within a React component, call `useScheduleGridConventionDataQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useScheduleGridConventionDataQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useScheduleGridConventionDataQuery` and pass it any options that fit your needs.
+ * When your component renders, `useScheduleGridConventionDataQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useScheduleGridConventionDataQueryQuery({
+ * const { data, loading, error } = useScheduleGridConventionDataQuery({
  *   variables: {
  *   },
  * });
  */
-export function useScheduleGridConventionDataQueryQuery(baseOptions?: Apollo.QueryHookOptions<ScheduleGridConventionDataQueryQuery, ScheduleGridConventionDataQueryQueryVariables>) {
-        return Apollo.useQuery<ScheduleGridConventionDataQueryQuery, ScheduleGridConventionDataQueryQueryVariables>(ScheduleGridConventionDataQueryDocument, baseOptions);
+export function useScheduleGridConventionDataQuery(baseOptions?: Apollo.QueryHookOptions<ScheduleGridConventionDataQueryData, ScheduleGridConventionDataQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ScheduleGridConventionDataQueryData, ScheduleGridConventionDataQueryVariables>(ScheduleGridConventionDataQueryDocument, options);
       }
-export function useScheduleGridConventionDataQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ScheduleGridConventionDataQueryQuery, ScheduleGridConventionDataQueryQueryVariables>) {
-          return Apollo.useLazyQuery<ScheduleGridConventionDataQueryQuery, ScheduleGridConventionDataQueryQueryVariables>(ScheduleGridConventionDataQueryDocument, baseOptions);
+export function useScheduleGridConventionDataQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ScheduleGridConventionDataQueryData, ScheduleGridConventionDataQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ScheduleGridConventionDataQueryData, ScheduleGridConventionDataQueryVariables>(ScheduleGridConventionDataQueryDocument, options);
         }
-export type ScheduleGridConventionDataQueryQueryHookResult = ReturnType<typeof useScheduleGridConventionDataQueryQuery>;
+export type ScheduleGridConventionDataQueryHookResult = ReturnType<typeof useScheduleGridConventionDataQuery>;
 export type ScheduleGridConventionDataQueryLazyQueryHookResult = ReturnType<typeof useScheduleGridConventionDataQueryLazyQuery>;
-export type ScheduleGridConventionDataQueryQueryResult = Apollo.QueryResult<ScheduleGridConventionDataQueryQuery, ScheduleGridConventionDataQueryQueryVariables>;
+export type ScheduleGridConventionDataQueryDataResult = Apollo.QueryResult<ScheduleGridConventionDataQueryData, ScheduleGridConventionDataQueryVariables>;
 export const ScheduleGridEventsQueryDocument = gql`
     query ScheduleGridEventsQuery($extendedCounts: Boolean!, $start: Date, $finish: Date) {
   events(extendedCounts: $extendedCounts, start: $start, finish: $finish) {
@@ -157,19 +160,19 @@ export const ScheduleGridEventsQueryDocument = gql`
     ...ScheduleGridEventFragment
   }
 }
-    ${ScheduleGridEventFragmentFragmentDoc}`;
+    ${ScheduleGridEventFragmentDoc}`;
 
 /**
- * __useScheduleGridEventsQueryQuery__
+ * __useScheduleGridEventsQuery__
  *
- * To run a query within a React component, call `useScheduleGridEventsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useScheduleGridEventsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useScheduleGridEventsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useScheduleGridEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useScheduleGridEventsQueryQuery({
+ * const { data, loading, error } = useScheduleGridEventsQuery({
  *   variables: {
  *      extendedCounts: // value for 'extendedCounts'
  *      start: // value for 'start'
@@ -177,15 +180,17 @@ export const ScheduleGridEventsQueryDocument = gql`
  *   },
  * });
  */
-export function useScheduleGridEventsQueryQuery(baseOptions: Apollo.QueryHookOptions<ScheduleGridEventsQueryQuery, ScheduleGridEventsQueryQueryVariables>) {
-        return Apollo.useQuery<ScheduleGridEventsQueryQuery, ScheduleGridEventsQueryQueryVariables>(ScheduleGridEventsQueryDocument, baseOptions);
+export function useScheduleGridEventsQuery(baseOptions: Apollo.QueryHookOptions<ScheduleGridEventsQueryData, ScheduleGridEventsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ScheduleGridEventsQueryData, ScheduleGridEventsQueryVariables>(ScheduleGridEventsQueryDocument, options);
       }
-export function useScheduleGridEventsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ScheduleGridEventsQueryQuery, ScheduleGridEventsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<ScheduleGridEventsQueryQuery, ScheduleGridEventsQueryQueryVariables>(ScheduleGridEventsQueryDocument, baseOptions);
+export function useScheduleGridEventsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ScheduleGridEventsQueryData, ScheduleGridEventsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ScheduleGridEventsQueryData, ScheduleGridEventsQueryVariables>(ScheduleGridEventsQueryDocument, options);
         }
-export type ScheduleGridEventsQueryQueryHookResult = ReturnType<typeof useScheduleGridEventsQueryQuery>;
+export type ScheduleGridEventsQueryHookResult = ReturnType<typeof useScheduleGridEventsQuery>;
 export type ScheduleGridEventsQueryLazyQueryHookResult = ReturnType<typeof useScheduleGridEventsQueryLazyQuery>;
-export type ScheduleGridEventsQueryQueryResult = Apollo.QueryResult<ScheduleGridEventsQueryQuery, ScheduleGridEventsQueryQueryVariables>;
+export type ScheduleGridEventsQueryDataResult = Apollo.QueryResult<ScheduleGridEventsQueryData, ScheduleGridEventsQueryVariables>;
 export const ScheduleGridCombinedQueryDocument = gql`
     query ScheduleGridCombinedQuery($extendedCounts: Boolean!, $start: Date, $finish: Date) {
   convention: assertConvention {
@@ -199,19 +204,19 @@ export const ScheduleGridCombinedQueryDocument = gql`
   }
 }
     ${CommonConventionDataFragmentDoc}
-${ScheduleGridEventFragmentFragmentDoc}`;
+${ScheduleGridEventFragmentDoc}`;
 
 /**
- * __useScheduleGridCombinedQueryQuery__
+ * __useScheduleGridCombinedQuery__
  *
- * To run a query within a React component, call `useScheduleGridCombinedQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useScheduleGridCombinedQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useScheduleGridCombinedQuery` and pass it any options that fit your needs.
+ * When your component renders, `useScheduleGridCombinedQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useScheduleGridCombinedQueryQuery({
+ * const { data, loading, error } = useScheduleGridCombinedQuery({
  *   variables: {
  *      extendedCounts: // value for 'extendedCounts'
  *      start: // value for 'start'
@@ -219,12 +224,14 @@ ${ScheduleGridEventFragmentFragmentDoc}`;
  *   },
  * });
  */
-export function useScheduleGridCombinedQueryQuery(baseOptions: Apollo.QueryHookOptions<ScheduleGridCombinedQueryQuery, ScheduleGridCombinedQueryQueryVariables>) {
-        return Apollo.useQuery<ScheduleGridCombinedQueryQuery, ScheduleGridCombinedQueryQueryVariables>(ScheduleGridCombinedQueryDocument, baseOptions);
+export function useScheduleGridCombinedQuery(baseOptions: Apollo.QueryHookOptions<ScheduleGridCombinedQueryData, ScheduleGridCombinedQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ScheduleGridCombinedQueryData, ScheduleGridCombinedQueryVariables>(ScheduleGridCombinedQueryDocument, options);
       }
-export function useScheduleGridCombinedQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ScheduleGridCombinedQueryQuery, ScheduleGridCombinedQueryQueryVariables>) {
-          return Apollo.useLazyQuery<ScheduleGridCombinedQueryQuery, ScheduleGridCombinedQueryQueryVariables>(ScheduleGridCombinedQueryDocument, baseOptions);
+export function useScheduleGridCombinedQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ScheduleGridCombinedQueryData, ScheduleGridCombinedQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ScheduleGridCombinedQueryData, ScheduleGridCombinedQueryVariables>(ScheduleGridCombinedQueryDocument, options);
         }
-export type ScheduleGridCombinedQueryQueryHookResult = ReturnType<typeof useScheduleGridCombinedQueryQuery>;
+export type ScheduleGridCombinedQueryHookResult = ReturnType<typeof useScheduleGridCombinedQuery>;
 export type ScheduleGridCombinedQueryLazyQueryHookResult = ReturnType<typeof useScheduleGridCombinedQueryLazyQuery>;
-export type ScheduleGridCombinedQueryQueryResult = Apollo.QueryResult<ScheduleGridCombinedQueryQuery, ScheduleGridCombinedQueryQueryVariables>;
+export type ScheduleGridCombinedQueryDataResult = Apollo.QueryResult<ScheduleGridCombinedQueryData, ScheduleGridCombinedQueryVariables>;

--- a/app/javascript/EventsApp/SignupAdmin/EditSignup.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/EditSignup.tsx
@@ -18,7 +18,7 @@ import usePageTitle from '../../usePageTitle';
 import Gravatar from '../../Gravatar';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
 import AppRootContext from '../../AppRootContext';
-import { SignupFieldsFragment, useAdminSignupQueryQuery } from './queries.generated';
+import { SignupFieldsFragment, useAdminSignupQuery } from './queries.generated';
 import { useUpdateSignupCountedMutation } from './mutations.generated';
 import { useFormatRunTimespan } from '../runTimeFormatting';
 
@@ -106,7 +106,7 @@ export type EditSignupProps = {
 function EditSignup({ teamMembersUrl }: EditSignupProps) {
   const { timezoneName } = useContext(AppRootContext);
   const id = Number.parseInt(useParams<{ id: string }>().id, 10);
-  const { data, loading, error } = useAdminSignupQueryQuery({ variables: { id } });
+  const { data, loading, error } = useAdminSignupQuery({ variables: { id } });
   const changeBucketModal = useModal();
   const forceConfirmModal = useModal();
   const [updateCountedMutate] = useUpdateSignupCountedMutation();

--- a/app/javascript/EventsApp/SignupAdmin/RunEmailList.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/RunEmailList.tsx
@@ -9,15 +9,15 @@ import usePageTitle from '../../usePageTitle';
 import LoadingIndicator from '../../LoadingIndicator';
 import ErrorDisplay from '../../ErrorDisplay';
 import {
-  RunSignupsTableSignupsQueryQuery,
-  useRunSignupsTableSignupsQueryQuery,
+  RunSignupsTableSignupsQueryData,
+  useRunSignupsTableSignupsQuery,
 } from './queries.generated';
 
 function getEmails({
   data,
   includes,
 }: {
-  data: RunSignupsTableSignupsQueryQuery;
+  data: RunSignupsTableSignupsQueryData;
   includes: string[];
 }) {
   const teamMemberUserConProfileIds = data.event.team_members.map(
@@ -62,7 +62,7 @@ export type RunEmailListProps = {
 function RunEmailList({ runId, eventId, separator }: RunEmailListProps) {
   const { t } = useTranslation();
   const [includes, setIncludes] = useState(['teamMembers', 'confirmed']);
-  const { data, loading, error } = useRunSignupsTableSignupsQueryQuery({
+  const { data, loading, error } = useRunSignupsTableSignupsQuery({
     variables: {
       runId,
       eventId,

--- a/app/javascript/EventsApp/SignupAdmin/RunHeader.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/RunHeader.tsx
@@ -5,7 +5,7 @@ import { timespanFromRun } from '../../TimespanUtils';
 import LoadingIndicator from '../../LoadingIndicator';
 import ErrorDisplay from '../../ErrorDisplay';
 import AppRootContext from '../../AppRootContext';
-import { useRunHeaderRunInfoQueryQuery } from './queries.generated';
+import { useRunHeaderRunInfoQuery } from './queries.generated';
 import { useFormatRunTimespan } from '../runTimeFormatting';
 
 export type RunHeaderProps = {
@@ -16,7 +16,7 @@ export type RunHeaderProps = {
 function RunHeader({ eventId, runId }: RunHeaderProps) {
   const { t } = useTranslation();
   const { timezoneName } = useContext(AppRootContext);
-  const { data, loading, error } = useRunHeaderRunInfoQueryQuery({
+  const { data, loading, error } = useRunHeaderRunInfoQuery({
     variables: { runId, eventId },
   });
   const formatRunTimespan = useFormatRunTimespan();

--- a/app/javascript/EventsApp/SignupAdmin/RunSignupChangesTable.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/RunSignupChangesTable.tsx
@@ -17,14 +17,14 @@ import TableHeader from '../../Tables/TableHeader';
 import usePageTitle from '../../usePageTitle';
 import useValueUnless from '../../useValueUnless';
 import SignupChangesTableExportButton from '../../Tables/SignupChangesTableExportButton';
-import { RunSignupChangesQueryQuery, useRunSignupChangesQueryQuery } from './queries.generated';
+import { RunSignupChangesQueryData, useRunSignupChangesQuery } from './queries.generated';
 import ReactTableWithTheWorks from '../../Tables/ReactTableWithTheWorks';
 
 const FILTER_CODECS = buildFieldFilterCodecs({
   action: FilterCodecs.stringArray,
 });
 
-type SignupChangeType = RunSignupChangesQueryQuery['run']['signup_changes_paginated']['entries'][0];
+type SignupChangeType = RunSignupChangesQueryData['run']['signup_changes_paginated']['entries'][0];
 
 const getPossibleColumns: (t: TFunction) => Column<SignupChangeType>[] = (t) => [
   {
@@ -80,7 +80,7 @@ function RunSignupChangesTable({ runId }: RunSignupChangesTableProps) {
     getData: ({ data }) => data.run.signup_changes_paginated.entries,
     getPages: ({ data }) => data.run.signup_changes_paginated.total_pages,
     getPossibleColumns: getPossibleColumnsFunc,
-    useQuery: useRunSignupChangesQueryQuery,
+    useQuery: useRunSignupChangesQuery,
     storageKeyPrefix: 'signupSpy',
     variables: { runId },
   });

--- a/app/javascript/EventsApp/SignupAdmin/RunSignupSummary.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/RunSignupSummary.tsx
@@ -12,9 +12,9 @@ import useValueUnless from '../../useValueUnless';
 import ErrorDisplay from '../../ErrorDisplay';
 import Gravatar from '../../Gravatar';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { RunSignupSummaryQueryQuery, useRunSignupSummaryQueryQuery } from './queries.generated';
+import { RunSignupSummaryQueryData, useRunSignupSummaryQuery } from './queries.generated';
 
-type EventType = RunSignupSummaryQueryQuery['event'];
+type EventType = RunSignupSummaryQueryData['event'];
 type SignupType = EventType['run']['signups_paginated']['entries'][0];
 
 function isTeamMember(signup: SignupType, teamMembers: EventType['team_members']) {
@@ -61,7 +61,7 @@ export type RunSignupSummaryProps = {
 
 function RunSignupSummary({ eventId, runId, eventPath }: RunSignupSummaryProps) {
   const { t } = useTranslation();
-  const { data, loading, error } = useRunSignupSummaryQueryQuery({
+  const { data, loading, error } = useRunSignupSummaryQuery({
     variables: { eventId, runId },
   });
 

--- a/app/javascript/EventsApp/SignupAdmin/RunSignupsTable.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/RunSignupsTable.tsx
@@ -23,10 +23,10 @@ import useValueUnless from '../../useValueUnless';
 import UserConProfileWithGravatarCell from '../../Tables/UserConProfileWithGravatarCell';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
 import {
-  RunSignupsTableSignupsQueryQuery,
-  RunSignupsTableSignupsQueryQueryVariables,
-  useRunSignupsTableSignupsQueryQuery,
-  useSignupAdminEventQueryQuery,
+  RunSignupsTableSignupsQueryData,
+  RunSignupsTableSignupsQueryVariables,
+  useRunSignupsTableSignupsQuery,
+  useSignupAdminEventQuery,
 } from './queries.generated';
 
 const { encodeFilterValue, decodeFilterValue } = buildFieldFilterCodecs({
@@ -34,7 +34,7 @@ const { encodeFilterValue, decodeFilterValue } = buildFieldFilterCodecs({
   bucket: FilterCodecs.stringArray,
 });
 
-type SignupType = RunSignupsTableSignupsQueryQuery['event']['run']['signups_paginated']['entries'][0];
+type SignupType = RunSignupsTableSignupsQueryData['event']['run']['signups_paginated']['entries'][0];
 
 const SignupStateFilter = (props: FilterProps<SignupType>) => {
   const { t } = useTranslation();
@@ -71,12 +71,12 @@ const AgeRestrictionsCheckCell = ({ value }: CellProps<SignupType, string>) => {
 
 const BucketCell = ({ row: { original } }: CellProps<SignupType>) => {
   const { t } = useTranslation();
-  const data = useContext(QueryDataContext) as RunSignupsTableSignupsQueryQuery;
+  const data = useContext(QueryDataContext) as RunSignupsTableSignupsQueryData;
   return <>{formatBucket(original, data.event, t)}</>;
 };
 
 const BucketFilter = (props: FilterProps<SignupType>) => {
-  const data = useContext(QueryDataContext) as RunSignupsTableSignupsQueryQuery;
+  const data = useContext(QueryDataContext) as RunSignupsTableSignupsQueryData;
   const choices = useMemo(
     () =>
       data?.event
@@ -171,7 +171,7 @@ export type RunSignupsTableProps = {
 function RunSignupsTable({ defaultVisibleColumns, eventId, runId, runPath }: RunSignupsTableProps) {
   const { t } = useTranslation();
   const history = useHistory();
-  const { data, loading, error } = useSignupAdminEventQueryQuery({ variables: { eventId } });
+  const { data, loading, error } = useSignupAdminEventQuery({ variables: { eventId } });
   const getPossibleColumnsFunc = useMemo(() => () => getPossibleColumns(t), [t]);
 
   const {
@@ -180,9 +180,9 @@ function RunSignupsTable({ defaultVisibleColumns, eventId, runId, runPath }: Run
     tableHeaderProps,
     queryData,
   } = useReactTableWithTheWorks<
-    RunSignupsTableSignupsQueryQuery,
-    RunSignupsTableSignupsQueryQuery['event']['run']['signups_paginated']['entries'][number],
-    RunSignupsTableSignupsQueryQueryVariables
+    RunSignupsTableSignupsQueryData,
+    RunSignupsTableSignupsQueryData['event']['run']['signups_paginated']['entries'][number],
+    RunSignupsTableSignupsQueryVariables
   >({
     decodeFilterValue,
     defaultVisibleColumns,
@@ -190,7 +190,7 @@ function RunSignupsTable({ defaultVisibleColumns, eventId, runId, runPath }: Run
     getData: ({ data: tableData }) => tableData.event.run.signups_paginated.entries,
     getPages: ({ data: tableData }) => tableData.event.run.signups_paginated.total_pages,
     getPossibleColumns: getPossibleColumnsFunc,
-    useQuery: useRunSignupsTableSignupsQueryQuery,
+    useQuery: useRunSignupsTableSignupsQuery,
     storageKeyPrefix: 'adminSignups',
     variables: { eventId, runId },
   });

--- a/app/javascript/EventsApp/SignupAdmin/UserConProfileSignupsCard.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/UserConProfileSignupsCard.tsx
@@ -12,16 +12,13 @@ import ErrorDisplay from '../../ErrorDisplay';
 import LoadingIndicator from '../../LoadingIndicator';
 import AddToCalendarDropdown from './AddToCalendarDropdown';
 import AppRootContext from '../../AppRootContext';
-import {
-  UserConProfileSignupsQueryQuery,
-  useUserConProfileSignupsQueryQuery,
-} from './queries.generated';
+import { UserConProfileSignupsQueryData, useUserConProfileSignupsQuery } from './queries.generated';
 import { useWithdrawAllUserConProfileSignupsMutation } from './mutations.generated';
 import { joinReact } from '../../RenderingUtils';
 import { useFormatRunTimespan } from '../runTimeFormatting';
 
 function filterAndSortSignups(
-  signups: UserConProfileSignupsQueryQuery['userConProfile']['signups'],
+  signups: UserConProfileSignupsQueryData['userConProfile']['signups'],
 ) {
   const filteredSignups = signups.filter(({ state }) => state !== 'withdrawn');
 
@@ -35,7 +32,7 @@ export type UserConProfileSignupsCardProps = {
 function UserConProfileSignupsCard({ userConProfileId }: UserConProfileSignupsCardProps) {
   const { t } = useTranslation();
   const { timezoneName } = useContext(AppRootContext);
-  const { data, error, loading } = useUserConProfileSignupsQueryQuery({
+  const { data, error, loading } = useUserConProfileSignupsQuery({
     variables: { id: userConProfileId },
   });
   const [withdrawAllSignups] = useWithdrawAllUserConProfileSignupsMutation();
@@ -76,9 +73,7 @@ function UserConProfileSignupsCard({ userConProfileId }: UserConProfileSignupsCa
     <Link to={buildEventUrl(event)}>{event.title}</Link>
   );
 
-  const renderSignup = (
-    signup: UserConProfileSignupsQueryQuery['userConProfile']['signups'][0],
-  ) => (
+  const renderSignup = (signup: UserConProfileSignupsQueryData['userConProfile']['signups'][0]) => (
     <li className="list-group-item" key={signup.id}>
       <ul className="list-unstyled">
         <li>
@@ -105,8 +100,8 @@ function UserConProfileSignupsCard({ userConProfileId }: UserConProfileSignupsCa
   );
 
   const renderUnSignedUpTeamMemberEvents = (
-    userConProfile: UserConProfileSignupsQueryQuery['userConProfile'],
-    myProfile: UserConProfileSignupsQueryQuery['myProfile'],
+    userConProfile: UserConProfileSignupsQueryData['userConProfile'],
+    myProfile: UserConProfileSignupsQueryData['myProfile'],
   ) => {
     if (unSignedUpEvents.length === 0) {
       return null;

--- a/app/javascript/EventsApp/SignupAdmin/index.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/index.tsx
@@ -6,7 +6,7 @@ import EditSignup from './EditSignup';
 import SignupsIndex from './SignupsIndex';
 import ErrorDisplay from '../../ErrorDisplay';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { useSignupAdminEventQueryQuery } from './queries.generated';
+import { useSignupAdminEventQuery } from './queries.generated';
 
 export type SignupAdminProps = {
   runId: number;
@@ -17,7 +17,7 @@ export type SignupAdminProps = {
 function SignupAdmin({ runId, eventId, eventPath }: SignupAdminProps) {
   const { t } = useTranslation();
   const location = useLocation();
-  const { data, loading, error } = useSignupAdminEventQueryQuery({ variables: { eventId } });
+  const { data, loading, error } = useSignupAdminEventQuery({ variables: { eventId } });
   const runPath = `${eventPath}/runs/${runId}`;
 
   if (loading) {

--- a/app/javascript/EventsApp/SignupAdmin/mutations.generated.ts
+++ b/app/javascript/EventsApp/SignupAdmin/mutations.generated.ts
@@ -1,21 +1,22 @@
 /* eslint-disable */
 import * as Types from '../../graphqlTypes.generated';
 
-import { SignupFieldsFragment, UserConProfileSignupsFragmentFragment } from './queries.generated';
+import { SignupFieldsFragment, UserConProfileSignupsFragment } from './queries.generated';
 import { EventPageRunFieldsFragment } from '../EventPage/queries.generated';
 import { RunBasicSignupDataFragment, CommonConventionDataFragment } from '../queries.generated';
 import { gql } from '@apollo/client';
-import { SignupFieldsFragmentDoc, UserConProfileSignupsFragmentFragmentDoc } from './queries.generated';
+import { SignupFieldsFragmentDoc, UserConProfileSignupsFragmentDoc } from './queries.generated';
 import { EventPageRunFieldsFragmentDoc } from '../EventPage/queries.generated';
 import { RunBasicSignupDataFragmentDoc, CommonConventionDataFragmentDoc } from '../queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type ChangeSignupBucketMutationVariables = Types.Exact<{
   signupId: Types.Scalars['Int'];
   bucketKey: Types.Scalars['String'];
 }>;
 
 
-export type ChangeSignupBucketMutation = (
+export type ChangeSignupBucketMutationData = (
   { __typename: 'Mutation' }
   & { updateSignupBucket?: Types.Maybe<(
     { __typename: 'UpdateSignupBucketPayload' }
@@ -39,7 +40,7 @@ export type ForceConfirmSignupMutationVariables = Types.Exact<{
 }>;
 
 
-export type ForceConfirmSignupMutation = (
+export type ForceConfirmSignupMutationData = (
   { __typename: 'Mutation' }
   & { forceConfirmSignup?: Types.Maybe<(
     { __typename: 'ForceConfirmSignupPayload' }
@@ -63,7 +64,7 @@ export type UpdateSignupCountedMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateSignupCountedMutation = (
+export type UpdateSignupCountedMutationData = (
   { __typename: 'Mutation' }
   & { updateSignupCounted?: Types.Maybe<(
     { __typename: 'UpdateSignupCountedPayload' }
@@ -86,14 +87,14 @@ export type WithdrawAllUserConProfileSignupsMutationVariables = Types.Exact<{
 }>;
 
 
-export type WithdrawAllUserConProfileSignupsMutation = (
+export type WithdrawAllUserConProfileSignupsMutationData = (
   { __typename: 'Mutation' }
   & { withdrawAllUserConProfileSignups?: Types.Maybe<(
     { __typename: 'WithdrawAllUserConProfileSignupsPayload' }
     & { user_con_profile: (
       { __typename: 'UserConProfile' }
       & Pick<Types.UserConProfile, 'id'>
-      & UserConProfileSignupsFragmentFragment
+      & UserConProfileSignupsFragment
     ) }
   )> }
 );
@@ -116,7 +117,7 @@ export const ChangeSignupBucketDocument = gql`
     ${SignupFieldsFragmentDoc}
 ${EventPageRunFieldsFragmentDoc}
 ${RunBasicSignupDataFragmentDoc}`;
-export type ChangeSignupBucketMutationFn = Apollo.MutationFunction<ChangeSignupBucketMutation, ChangeSignupBucketMutationVariables>;
+export type ChangeSignupBucketMutationFn = Apollo.MutationFunction<ChangeSignupBucketMutationData, ChangeSignupBucketMutationVariables>;
 
 /**
  * __useChangeSignupBucketMutation__
@@ -136,12 +137,13 @@ export type ChangeSignupBucketMutationFn = Apollo.MutationFunction<ChangeSignupB
  *   },
  * });
  */
-export function useChangeSignupBucketMutation(baseOptions?: Apollo.MutationHookOptions<ChangeSignupBucketMutation, ChangeSignupBucketMutationVariables>) {
-        return Apollo.useMutation<ChangeSignupBucketMutation, ChangeSignupBucketMutationVariables>(ChangeSignupBucketDocument, baseOptions);
+export function useChangeSignupBucketMutation(baseOptions?: Apollo.MutationHookOptions<ChangeSignupBucketMutationData, ChangeSignupBucketMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ChangeSignupBucketMutationData, ChangeSignupBucketMutationVariables>(ChangeSignupBucketDocument, options);
       }
 export type ChangeSignupBucketMutationHookResult = ReturnType<typeof useChangeSignupBucketMutation>;
-export type ChangeSignupBucketMutationResult = Apollo.MutationResult<ChangeSignupBucketMutation>;
-export type ChangeSignupBucketMutationOptions = Apollo.BaseMutationOptions<ChangeSignupBucketMutation, ChangeSignupBucketMutationVariables>;
+export type ChangeSignupBucketMutationResult = Apollo.MutationResult<ChangeSignupBucketMutationData>;
+export type ChangeSignupBucketMutationOptions = Apollo.BaseMutationOptions<ChangeSignupBucketMutationData, ChangeSignupBucketMutationVariables>;
 export const ForceConfirmSignupDocument = gql`
     mutation ForceConfirmSignup($signupId: Int!, $bucketKey: String!) {
   forceConfirmSignup(input: {id: $signupId, bucket_key: $bucketKey}) {
@@ -159,7 +161,7 @@ export const ForceConfirmSignupDocument = gql`
     ${SignupFieldsFragmentDoc}
 ${EventPageRunFieldsFragmentDoc}
 ${RunBasicSignupDataFragmentDoc}`;
-export type ForceConfirmSignupMutationFn = Apollo.MutationFunction<ForceConfirmSignupMutation, ForceConfirmSignupMutationVariables>;
+export type ForceConfirmSignupMutationFn = Apollo.MutationFunction<ForceConfirmSignupMutationData, ForceConfirmSignupMutationVariables>;
 
 /**
  * __useForceConfirmSignupMutation__
@@ -179,12 +181,13 @@ export type ForceConfirmSignupMutationFn = Apollo.MutationFunction<ForceConfirmS
  *   },
  * });
  */
-export function useForceConfirmSignupMutation(baseOptions?: Apollo.MutationHookOptions<ForceConfirmSignupMutation, ForceConfirmSignupMutationVariables>) {
-        return Apollo.useMutation<ForceConfirmSignupMutation, ForceConfirmSignupMutationVariables>(ForceConfirmSignupDocument, baseOptions);
+export function useForceConfirmSignupMutation(baseOptions?: Apollo.MutationHookOptions<ForceConfirmSignupMutationData, ForceConfirmSignupMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ForceConfirmSignupMutationData, ForceConfirmSignupMutationVariables>(ForceConfirmSignupDocument, options);
       }
 export type ForceConfirmSignupMutationHookResult = ReturnType<typeof useForceConfirmSignupMutation>;
-export type ForceConfirmSignupMutationResult = Apollo.MutationResult<ForceConfirmSignupMutation>;
-export type ForceConfirmSignupMutationOptions = Apollo.BaseMutationOptions<ForceConfirmSignupMutation, ForceConfirmSignupMutationVariables>;
+export type ForceConfirmSignupMutationResult = Apollo.MutationResult<ForceConfirmSignupMutationData>;
+export type ForceConfirmSignupMutationOptions = Apollo.BaseMutationOptions<ForceConfirmSignupMutationData, ForceConfirmSignupMutationVariables>;
 export const UpdateSignupCountedDocument = gql`
     mutation UpdateSignupCounted($signupId: Int!, $counted: Boolean!) {
   updateSignupCounted(input: {id: $signupId, counted: $counted}) {
@@ -202,7 +205,7 @@ export const UpdateSignupCountedDocument = gql`
     ${SignupFieldsFragmentDoc}
 ${EventPageRunFieldsFragmentDoc}
 ${RunBasicSignupDataFragmentDoc}`;
-export type UpdateSignupCountedMutationFn = Apollo.MutationFunction<UpdateSignupCountedMutation, UpdateSignupCountedMutationVariables>;
+export type UpdateSignupCountedMutationFn = Apollo.MutationFunction<UpdateSignupCountedMutationData, UpdateSignupCountedMutationVariables>;
 
 /**
  * __useUpdateSignupCountedMutation__
@@ -222,12 +225,13 @@ export type UpdateSignupCountedMutationFn = Apollo.MutationFunction<UpdateSignup
  *   },
  * });
  */
-export function useUpdateSignupCountedMutation(baseOptions?: Apollo.MutationHookOptions<UpdateSignupCountedMutation, UpdateSignupCountedMutationVariables>) {
-        return Apollo.useMutation<UpdateSignupCountedMutation, UpdateSignupCountedMutationVariables>(UpdateSignupCountedDocument, baseOptions);
+export function useUpdateSignupCountedMutation(baseOptions?: Apollo.MutationHookOptions<UpdateSignupCountedMutationData, UpdateSignupCountedMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateSignupCountedMutationData, UpdateSignupCountedMutationVariables>(UpdateSignupCountedDocument, options);
       }
 export type UpdateSignupCountedMutationHookResult = ReturnType<typeof useUpdateSignupCountedMutation>;
-export type UpdateSignupCountedMutationResult = Apollo.MutationResult<UpdateSignupCountedMutation>;
-export type UpdateSignupCountedMutationOptions = Apollo.BaseMutationOptions<UpdateSignupCountedMutation, UpdateSignupCountedMutationVariables>;
+export type UpdateSignupCountedMutationResult = Apollo.MutationResult<UpdateSignupCountedMutationData>;
+export type UpdateSignupCountedMutationOptions = Apollo.BaseMutationOptions<UpdateSignupCountedMutationData, UpdateSignupCountedMutationVariables>;
 export const WithdrawAllUserConProfileSignupsDocument = gql`
     mutation WithdrawAllUserConProfileSignups($userConProfileId: Int!) {
   withdrawAllUserConProfileSignups(
@@ -239,8 +243,8 @@ export const WithdrawAllUserConProfileSignupsDocument = gql`
     }
   }
 }
-    ${UserConProfileSignupsFragmentFragmentDoc}`;
-export type WithdrawAllUserConProfileSignupsMutationFn = Apollo.MutationFunction<WithdrawAllUserConProfileSignupsMutation, WithdrawAllUserConProfileSignupsMutationVariables>;
+    ${UserConProfileSignupsFragmentDoc}`;
+export type WithdrawAllUserConProfileSignupsMutationFn = Apollo.MutationFunction<WithdrawAllUserConProfileSignupsMutationData, WithdrawAllUserConProfileSignupsMutationVariables>;
 
 /**
  * __useWithdrawAllUserConProfileSignupsMutation__
@@ -259,9 +263,10 @@ export type WithdrawAllUserConProfileSignupsMutationFn = Apollo.MutationFunction
  *   },
  * });
  */
-export function useWithdrawAllUserConProfileSignupsMutation(baseOptions?: Apollo.MutationHookOptions<WithdrawAllUserConProfileSignupsMutation, WithdrawAllUserConProfileSignupsMutationVariables>) {
-        return Apollo.useMutation<WithdrawAllUserConProfileSignupsMutation, WithdrawAllUserConProfileSignupsMutationVariables>(WithdrawAllUserConProfileSignupsDocument, baseOptions);
+export function useWithdrawAllUserConProfileSignupsMutation(baseOptions?: Apollo.MutationHookOptions<WithdrawAllUserConProfileSignupsMutationData, WithdrawAllUserConProfileSignupsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<WithdrawAllUserConProfileSignupsMutationData, WithdrawAllUserConProfileSignupsMutationVariables>(WithdrawAllUserConProfileSignupsDocument, options);
       }
 export type WithdrawAllUserConProfileSignupsMutationHookResult = ReturnType<typeof useWithdrawAllUserConProfileSignupsMutation>;
-export type WithdrawAllUserConProfileSignupsMutationResult = Apollo.MutationResult<WithdrawAllUserConProfileSignupsMutation>;
-export type WithdrawAllUserConProfileSignupsMutationOptions = Apollo.BaseMutationOptions<WithdrawAllUserConProfileSignupsMutation, WithdrawAllUserConProfileSignupsMutationVariables>;
+export type WithdrawAllUserConProfileSignupsMutationResult = Apollo.MutationResult<WithdrawAllUserConProfileSignupsMutationData>;
+export type WithdrawAllUserConProfileSignupsMutationOptions = Apollo.BaseMutationOptions<WithdrawAllUserConProfileSignupsMutationData, WithdrawAllUserConProfileSignupsMutationVariables>;

--- a/app/javascript/EventsApp/SignupAdmin/queries.generated.ts
+++ b/app/javascript/EventsApp/SignupAdmin/queries.generated.ts
@@ -5,6 +5,7 @@ import { CommonConventionDataFragment } from '../queries.generated';
 import { gql } from '@apollo/client';
 import { CommonConventionDataFragmentDoc } from '../queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type SignupFieldsFragment = (
   { __typename: 'Signup' }
   & Pick<Types.Signup, 'id' | 'state' | 'counted' | 'bucket_key' | 'requested_bucket_key'>
@@ -41,7 +42,7 @@ export type SignupFieldsFragment = (
   ) }
 );
 
-export type UserConProfileSignupsFragmentFragment = (
+export type UserConProfileSignupsFragment = (
   { __typename: 'UserConProfile' }
   & Pick<Types.UserConProfile, 'id'>
   & { signups: Array<(
@@ -81,12 +82,12 @@ export type UserConProfileSignupsFragmentFragment = (
   )> }
 );
 
-export type SignupAdminEventQueryQueryVariables = Types.Exact<{
+export type SignupAdminEventQueryVariables = Types.Exact<{
   eventId: Types.Scalars['Int'];
 }>;
 
 
-export type SignupAdminEventQueryQuery = (
+export type SignupAdminEventQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -98,12 +99,12 @@ export type SignupAdminEventQueryQuery = (
   ) }
 );
 
-export type AdminSignupQueryQueryVariables = Types.Exact<{
+export type AdminSignupQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type AdminSignupQueryQuery = (
+export type AdminSignupQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -119,7 +120,7 @@ export type AdminSignupQueryQuery = (
   ) }
 );
 
-export type RunSignupsTableSignupsQueryQueryVariables = Types.Exact<{
+export type RunSignupsTableSignupsQueryVariables = Types.Exact<{
   eventId: Types.Scalars['Int'];
   runId: Types.Scalars['Int'];
   page?: Types.Maybe<Types.Scalars['Int']>;
@@ -129,7 +130,7 @@ export type RunSignupsTableSignupsQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type RunSignupsTableSignupsQueryQuery = (
+export type RunSignupsTableSignupsQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -175,13 +176,13 @@ export type RunSignupsTableSignupsQueryQuery = (
   ) }
 );
 
-export type RunHeaderRunInfoQueryQueryVariables = Types.Exact<{
+export type RunHeaderRunInfoQueryVariables = Types.Exact<{
   eventId: Types.Scalars['Int'];
   runId: Types.Scalars['Int'];
 }>;
 
 
-export type RunHeaderRunInfoQueryQuery = (
+export type RunHeaderRunInfoQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -204,13 +205,13 @@ export type RunHeaderRunInfoQueryQuery = (
   ) }
 );
 
-export type RunSignupSummaryQueryQueryVariables = Types.Exact<{
+export type RunSignupSummaryQueryVariables = Types.Exact<{
   eventId: Types.Scalars['Int'];
   runId: Types.Scalars['Int'];
 }>;
 
 
-export type RunSignupSummaryQueryQuery = (
+export type RunSignupSummaryQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -259,12 +260,12 @@ export type RunSignupSummaryQueryQuery = (
   ) }
 );
 
-export type UserConProfileSignupsQueryQueryVariables = Types.Exact<{
+export type UserConProfileSignupsQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type UserConProfileSignupsQueryQuery = (
+export type UserConProfileSignupsQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -288,11 +289,11 @@ export type UserConProfileSignupsQueryQuery = (
         & Pick<Types.Event, 'id' | 'title' | 'status'>
       ) }
     )> }
-    & UserConProfileSignupsFragmentFragment
+    & UserConProfileSignupsFragment
   ) }
 );
 
-export type RunSignupChangesQueryQueryVariables = Types.Exact<{
+export type RunSignupChangesQueryVariables = Types.Exact<{
   runId: Types.Scalars['Int'];
   filters?: Types.Maybe<Types.SignupChangeFiltersInput>;
   sort?: Types.Maybe<Array<Types.SortInput> | Types.SortInput>;
@@ -301,7 +302,7 @@ export type RunSignupChangesQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type RunSignupChangesQueryQuery = (
+export type RunSignupChangesQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -409,7 +410,7 @@ export const SignupFieldsFragmentDoc = gql`
   }
 }
     `;
-export const UserConProfileSignupsFragmentFragmentDoc = gql`
+export const UserConProfileSignupsFragmentDoc = gql`
     fragment UserConProfileSignupsFragment on UserConProfile {
   id
   signups {
@@ -467,30 +468,32 @@ export const SignupAdminEventQueryDocument = gql`
     ${CommonConventionDataFragmentDoc}`;
 
 /**
- * __useSignupAdminEventQueryQuery__
+ * __useSignupAdminEventQuery__
  *
- * To run a query within a React component, call `useSignupAdminEventQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useSignupAdminEventQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSignupAdminEventQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSignupAdminEventQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSignupAdminEventQueryQuery({
+ * const { data, loading, error } = useSignupAdminEventQuery({
  *   variables: {
  *      eventId: // value for 'eventId'
  *   },
  * });
  */
-export function useSignupAdminEventQueryQuery(baseOptions: Apollo.QueryHookOptions<SignupAdminEventQueryQuery, SignupAdminEventQueryQueryVariables>) {
-        return Apollo.useQuery<SignupAdminEventQueryQuery, SignupAdminEventQueryQueryVariables>(SignupAdminEventQueryDocument, baseOptions);
+export function useSignupAdminEventQuery(baseOptions: Apollo.QueryHookOptions<SignupAdminEventQueryData, SignupAdminEventQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SignupAdminEventQueryData, SignupAdminEventQueryVariables>(SignupAdminEventQueryDocument, options);
       }
-export function useSignupAdminEventQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SignupAdminEventQueryQuery, SignupAdminEventQueryQueryVariables>) {
-          return Apollo.useLazyQuery<SignupAdminEventQueryQuery, SignupAdminEventQueryQueryVariables>(SignupAdminEventQueryDocument, baseOptions);
+export function useSignupAdminEventQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SignupAdminEventQueryData, SignupAdminEventQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SignupAdminEventQueryData, SignupAdminEventQueryVariables>(SignupAdminEventQueryDocument, options);
         }
-export type SignupAdminEventQueryQueryHookResult = ReturnType<typeof useSignupAdminEventQueryQuery>;
+export type SignupAdminEventQueryHookResult = ReturnType<typeof useSignupAdminEventQuery>;
 export type SignupAdminEventQueryLazyQueryHookResult = ReturnType<typeof useSignupAdminEventQueryLazyQuery>;
-export type SignupAdminEventQueryQueryResult = Apollo.QueryResult<SignupAdminEventQueryQuery, SignupAdminEventQueryQueryVariables>;
+export type SignupAdminEventQueryDataResult = Apollo.QueryResult<SignupAdminEventQueryData, SignupAdminEventQueryVariables>;
 export const AdminSignupQueryDocument = gql`
     query AdminSignupQuery($id: Int!) {
   convention {
@@ -511,30 +514,32 @@ export const AdminSignupQueryDocument = gql`
 ${SignupFieldsFragmentDoc}`;
 
 /**
- * __useAdminSignupQueryQuery__
+ * __useAdminSignupQuery__
  *
- * To run a query within a React component, call `useAdminSignupQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useAdminSignupQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAdminSignupQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAdminSignupQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useAdminSignupQueryQuery({
+ * const { data, loading, error } = useAdminSignupQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useAdminSignupQueryQuery(baseOptions: Apollo.QueryHookOptions<AdminSignupQueryQuery, AdminSignupQueryQueryVariables>) {
-        return Apollo.useQuery<AdminSignupQueryQuery, AdminSignupQueryQueryVariables>(AdminSignupQueryDocument, baseOptions);
+export function useAdminSignupQuery(baseOptions: Apollo.QueryHookOptions<AdminSignupQueryData, AdminSignupQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AdminSignupQueryData, AdminSignupQueryVariables>(AdminSignupQueryDocument, options);
       }
-export function useAdminSignupQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminSignupQueryQuery, AdminSignupQueryQueryVariables>) {
-          return Apollo.useLazyQuery<AdminSignupQueryQuery, AdminSignupQueryQueryVariables>(AdminSignupQueryDocument, baseOptions);
+export function useAdminSignupQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminSignupQueryData, AdminSignupQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AdminSignupQueryData, AdminSignupQueryVariables>(AdminSignupQueryDocument, options);
         }
-export type AdminSignupQueryQueryHookResult = ReturnType<typeof useAdminSignupQueryQuery>;
+export type AdminSignupQueryHookResult = ReturnType<typeof useAdminSignupQuery>;
 export type AdminSignupQueryLazyQueryHookResult = ReturnType<typeof useAdminSignupQueryLazyQuery>;
-export type AdminSignupQueryQueryResult = Apollo.QueryResult<AdminSignupQueryQuery, AdminSignupQueryQueryVariables>;
+export type AdminSignupQueryDataResult = Apollo.QueryResult<AdminSignupQueryData, AdminSignupQueryVariables>;
 export const RunSignupsTableSignupsQueryDocument = gql`
     query RunSignupsTableSignupsQuery($eventId: Int!, $runId: Int!, $page: Int, $perPage: Int, $filters: SignupFiltersInput, $sort: [SortInput!]) {
   convention {
@@ -600,16 +605,16 @@ export const RunSignupsTableSignupsQueryDocument = gql`
     `;
 
 /**
- * __useRunSignupsTableSignupsQueryQuery__
+ * __useRunSignupsTableSignupsQuery__
  *
- * To run a query within a React component, call `useRunSignupsTableSignupsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useRunSignupsTableSignupsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useRunSignupsTableSignupsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRunSignupsTableSignupsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useRunSignupsTableSignupsQueryQuery({
+ * const { data, loading, error } = useRunSignupsTableSignupsQuery({
  *   variables: {
  *      eventId: // value for 'eventId'
  *      runId: // value for 'runId'
@@ -620,15 +625,17 @@ export const RunSignupsTableSignupsQueryDocument = gql`
  *   },
  * });
  */
-export function useRunSignupsTableSignupsQueryQuery(baseOptions: Apollo.QueryHookOptions<RunSignupsTableSignupsQueryQuery, RunSignupsTableSignupsQueryQueryVariables>) {
-        return Apollo.useQuery<RunSignupsTableSignupsQueryQuery, RunSignupsTableSignupsQueryQueryVariables>(RunSignupsTableSignupsQueryDocument, baseOptions);
+export function useRunSignupsTableSignupsQuery(baseOptions: Apollo.QueryHookOptions<RunSignupsTableSignupsQueryData, RunSignupsTableSignupsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RunSignupsTableSignupsQueryData, RunSignupsTableSignupsQueryVariables>(RunSignupsTableSignupsQueryDocument, options);
       }
-export function useRunSignupsTableSignupsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RunSignupsTableSignupsQueryQuery, RunSignupsTableSignupsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<RunSignupsTableSignupsQueryQuery, RunSignupsTableSignupsQueryQueryVariables>(RunSignupsTableSignupsQueryDocument, baseOptions);
+export function useRunSignupsTableSignupsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RunSignupsTableSignupsQueryData, RunSignupsTableSignupsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RunSignupsTableSignupsQueryData, RunSignupsTableSignupsQueryVariables>(RunSignupsTableSignupsQueryDocument, options);
         }
-export type RunSignupsTableSignupsQueryQueryHookResult = ReturnType<typeof useRunSignupsTableSignupsQueryQuery>;
+export type RunSignupsTableSignupsQueryHookResult = ReturnType<typeof useRunSignupsTableSignupsQuery>;
 export type RunSignupsTableSignupsQueryLazyQueryHookResult = ReturnType<typeof useRunSignupsTableSignupsQueryLazyQuery>;
-export type RunSignupsTableSignupsQueryQueryResult = Apollo.QueryResult<RunSignupsTableSignupsQueryQuery, RunSignupsTableSignupsQueryQueryVariables>;
+export type RunSignupsTableSignupsQueryDataResult = Apollo.QueryResult<RunSignupsTableSignupsQueryData, RunSignupsTableSignupsQueryVariables>;
 export const RunHeaderRunInfoQueryDocument = gql`
     query RunHeaderRunInfoQuery($eventId: Int!, $runId: Int!) {
   convention {
@@ -657,31 +664,33 @@ export const RunHeaderRunInfoQueryDocument = gql`
     ${CommonConventionDataFragmentDoc}`;
 
 /**
- * __useRunHeaderRunInfoQueryQuery__
+ * __useRunHeaderRunInfoQuery__
  *
- * To run a query within a React component, call `useRunHeaderRunInfoQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useRunHeaderRunInfoQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useRunHeaderRunInfoQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRunHeaderRunInfoQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useRunHeaderRunInfoQueryQuery({
+ * const { data, loading, error } = useRunHeaderRunInfoQuery({
  *   variables: {
  *      eventId: // value for 'eventId'
  *      runId: // value for 'runId'
  *   },
  * });
  */
-export function useRunHeaderRunInfoQueryQuery(baseOptions: Apollo.QueryHookOptions<RunHeaderRunInfoQueryQuery, RunHeaderRunInfoQueryQueryVariables>) {
-        return Apollo.useQuery<RunHeaderRunInfoQueryQuery, RunHeaderRunInfoQueryQueryVariables>(RunHeaderRunInfoQueryDocument, baseOptions);
+export function useRunHeaderRunInfoQuery(baseOptions: Apollo.QueryHookOptions<RunHeaderRunInfoQueryData, RunHeaderRunInfoQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RunHeaderRunInfoQueryData, RunHeaderRunInfoQueryVariables>(RunHeaderRunInfoQueryDocument, options);
       }
-export function useRunHeaderRunInfoQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RunHeaderRunInfoQueryQuery, RunHeaderRunInfoQueryQueryVariables>) {
-          return Apollo.useLazyQuery<RunHeaderRunInfoQueryQuery, RunHeaderRunInfoQueryQueryVariables>(RunHeaderRunInfoQueryDocument, baseOptions);
+export function useRunHeaderRunInfoQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RunHeaderRunInfoQueryData, RunHeaderRunInfoQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RunHeaderRunInfoQueryData, RunHeaderRunInfoQueryVariables>(RunHeaderRunInfoQueryDocument, options);
         }
-export type RunHeaderRunInfoQueryQueryHookResult = ReturnType<typeof useRunHeaderRunInfoQueryQuery>;
+export type RunHeaderRunInfoQueryHookResult = ReturnType<typeof useRunHeaderRunInfoQuery>;
 export type RunHeaderRunInfoQueryLazyQueryHookResult = ReturnType<typeof useRunHeaderRunInfoQueryLazyQuery>;
-export type RunHeaderRunInfoQueryQueryResult = Apollo.QueryResult<RunHeaderRunInfoQueryQuery, RunHeaderRunInfoQueryQueryVariables>;
+export type RunHeaderRunInfoQueryDataResult = Apollo.QueryResult<RunHeaderRunInfoQueryData, RunHeaderRunInfoQueryVariables>;
 export const RunSignupSummaryQueryDocument = gql`
     query RunSignupSummaryQuery($eventId: Int!, $runId: Int!) {
   convention {
@@ -737,31 +746,33 @@ export const RunSignupSummaryQueryDocument = gql`
     ${CommonConventionDataFragmentDoc}`;
 
 /**
- * __useRunSignupSummaryQueryQuery__
+ * __useRunSignupSummaryQuery__
  *
- * To run a query within a React component, call `useRunSignupSummaryQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useRunSignupSummaryQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useRunSignupSummaryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRunSignupSummaryQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useRunSignupSummaryQueryQuery({
+ * const { data, loading, error } = useRunSignupSummaryQuery({
  *   variables: {
  *      eventId: // value for 'eventId'
  *      runId: // value for 'runId'
  *   },
  * });
  */
-export function useRunSignupSummaryQueryQuery(baseOptions: Apollo.QueryHookOptions<RunSignupSummaryQueryQuery, RunSignupSummaryQueryQueryVariables>) {
-        return Apollo.useQuery<RunSignupSummaryQueryQuery, RunSignupSummaryQueryQueryVariables>(RunSignupSummaryQueryDocument, baseOptions);
+export function useRunSignupSummaryQuery(baseOptions: Apollo.QueryHookOptions<RunSignupSummaryQueryData, RunSignupSummaryQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RunSignupSummaryQueryData, RunSignupSummaryQueryVariables>(RunSignupSummaryQueryDocument, options);
       }
-export function useRunSignupSummaryQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RunSignupSummaryQueryQuery, RunSignupSummaryQueryQueryVariables>) {
-          return Apollo.useLazyQuery<RunSignupSummaryQueryQuery, RunSignupSummaryQueryQueryVariables>(RunSignupSummaryQueryDocument, baseOptions);
+export function useRunSignupSummaryQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RunSignupSummaryQueryData, RunSignupSummaryQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RunSignupSummaryQueryData, RunSignupSummaryQueryVariables>(RunSignupSummaryQueryDocument, options);
         }
-export type RunSignupSummaryQueryQueryHookResult = ReturnType<typeof useRunSignupSummaryQueryQuery>;
+export type RunSignupSummaryQueryHookResult = ReturnType<typeof useRunSignupSummaryQuery>;
 export type RunSignupSummaryQueryLazyQueryHookResult = ReturnType<typeof useRunSignupSummaryQueryLazyQuery>;
-export type RunSignupSummaryQueryQueryResult = Apollo.QueryResult<RunSignupSummaryQueryQuery, RunSignupSummaryQueryQueryVariables>;
+export type RunSignupSummaryQueryDataResult = Apollo.QueryResult<RunSignupSummaryQueryData, RunSignupSummaryQueryVariables>;
 export const UserConProfileSignupsQueryDocument = gql`
     query UserConProfileSignupsQuery($id: Int!) {
   convention {
@@ -790,33 +801,35 @@ export const UserConProfileSignupsQueryDocument = gql`
   }
 }
     ${CommonConventionDataFragmentDoc}
-${UserConProfileSignupsFragmentFragmentDoc}`;
+${UserConProfileSignupsFragmentDoc}`;
 
 /**
- * __useUserConProfileSignupsQueryQuery__
+ * __useUserConProfileSignupsQuery__
  *
- * To run a query within a React component, call `useUserConProfileSignupsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useUserConProfileSignupsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useUserConProfileSignupsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUserConProfileSignupsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useUserConProfileSignupsQueryQuery({
+ * const { data, loading, error } = useUserConProfileSignupsQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useUserConProfileSignupsQueryQuery(baseOptions: Apollo.QueryHookOptions<UserConProfileSignupsQueryQuery, UserConProfileSignupsQueryQueryVariables>) {
-        return Apollo.useQuery<UserConProfileSignupsQueryQuery, UserConProfileSignupsQueryQueryVariables>(UserConProfileSignupsQueryDocument, baseOptions);
+export function useUserConProfileSignupsQuery(baseOptions: Apollo.QueryHookOptions<UserConProfileSignupsQueryData, UserConProfileSignupsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<UserConProfileSignupsQueryData, UserConProfileSignupsQueryVariables>(UserConProfileSignupsQueryDocument, options);
       }
-export function useUserConProfileSignupsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserConProfileSignupsQueryQuery, UserConProfileSignupsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<UserConProfileSignupsQueryQuery, UserConProfileSignupsQueryQueryVariables>(UserConProfileSignupsQueryDocument, baseOptions);
+export function useUserConProfileSignupsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserConProfileSignupsQueryData, UserConProfileSignupsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<UserConProfileSignupsQueryData, UserConProfileSignupsQueryVariables>(UserConProfileSignupsQueryDocument, options);
         }
-export type UserConProfileSignupsQueryQueryHookResult = ReturnType<typeof useUserConProfileSignupsQueryQuery>;
+export type UserConProfileSignupsQueryHookResult = ReturnType<typeof useUserConProfileSignupsQuery>;
 export type UserConProfileSignupsQueryLazyQueryHookResult = ReturnType<typeof useUserConProfileSignupsQueryLazyQuery>;
-export type UserConProfileSignupsQueryQueryResult = Apollo.QueryResult<UserConProfileSignupsQueryQuery, UserConProfileSignupsQueryQueryVariables>;
+export type UserConProfileSignupsQueryDataResult = Apollo.QueryResult<UserConProfileSignupsQueryData, UserConProfileSignupsQueryVariables>;
 export const RunSignupChangesQueryDocument = gql`
     query RunSignupChangesQuery($runId: Int!, $filters: SignupChangeFiltersInput, $sort: [SortInput!], $page: Int, $perPage: Int) {
   convention {
@@ -889,16 +902,16 @@ export const RunSignupChangesQueryDocument = gql`
     `;
 
 /**
- * __useRunSignupChangesQueryQuery__
+ * __useRunSignupChangesQuery__
  *
- * To run a query within a React component, call `useRunSignupChangesQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useRunSignupChangesQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useRunSignupChangesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRunSignupChangesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useRunSignupChangesQueryQuery({
+ * const { data, loading, error } = useRunSignupChangesQuery({
  *   variables: {
  *      runId: // value for 'runId'
  *      filters: // value for 'filters'
@@ -908,12 +921,14 @@ export const RunSignupChangesQueryDocument = gql`
  *   },
  * });
  */
-export function useRunSignupChangesQueryQuery(baseOptions: Apollo.QueryHookOptions<RunSignupChangesQueryQuery, RunSignupChangesQueryQueryVariables>) {
-        return Apollo.useQuery<RunSignupChangesQueryQuery, RunSignupChangesQueryQueryVariables>(RunSignupChangesQueryDocument, baseOptions);
+export function useRunSignupChangesQuery(baseOptions: Apollo.QueryHookOptions<RunSignupChangesQueryData, RunSignupChangesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RunSignupChangesQueryData, RunSignupChangesQueryVariables>(RunSignupChangesQueryDocument, options);
       }
-export function useRunSignupChangesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RunSignupChangesQueryQuery, RunSignupChangesQueryQueryVariables>) {
-          return Apollo.useLazyQuery<RunSignupChangesQueryQuery, RunSignupChangesQueryQueryVariables>(RunSignupChangesQueryDocument, baseOptions);
+export function useRunSignupChangesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RunSignupChangesQueryData, RunSignupChangesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RunSignupChangesQueryData, RunSignupChangesQueryVariables>(RunSignupChangesQueryDocument, options);
         }
-export type RunSignupChangesQueryQueryHookResult = ReturnType<typeof useRunSignupChangesQueryQuery>;
+export type RunSignupChangesQueryHookResult = ReturnType<typeof useRunSignupChangesQuery>;
 export type RunSignupChangesQueryLazyQueryHookResult = ReturnType<typeof useRunSignupChangesQueryLazyQuery>;
-export type RunSignupChangesQueryQueryResult = Apollo.QueryResult<RunSignupChangesQueryQuery, RunSignupChangesQueryQueryVariables>;
+export type RunSignupChangesQueryDataResult = Apollo.QueryResult<RunSignupChangesQueryData, RunSignupChangesQueryVariables>;

--- a/app/javascript/EventsApp/StandaloneEditEvent/index.tsx
+++ b/app/javascript/EventsApp/StandaloneEditEvent/index.tsx
@@ -11,8 +11,8 @@ import usePageTitle from '../../usePageTitle';
 import useValueUnless from '../../useValueUnless';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
 import {
-  useStandaloneEditEventQueryQuery,
-  StandaloneEditEventQueryQuery,
+  useStandaloneEditEventQuery,
+  StandaloneEditEventQueryData,
   StandaloneEditEventQueryDocument,
 } from './queries.generated';
 import deserializeFormResponse, { WithFormResponse } from '../../Models/deserializeFormResponse';
@@ -25,11 +25,11 @@ import {
 } from './mutations.generated';
 
 export type StandaloneEditEventFormProps = {
-  initialEvent: WithFormResponse<StandaloneEditEventQueryQuery['event']>;
+  initialEvent: WithFormResponse<StandaloneEditEventQueryData['event']>;
   eventPath: string;
   eventForm: CommonFormFieldsFragment;
-  convention: NonNullable<StandaloneEditEventQueryQuery['convention']>;
-  currentAbility: StandaloneEditEventQueryQuery['currentAbility'];
+  convention: NonNullable<StandaloneEditEventQueryData['convention']>;
+  currentAbility: StandaloneEditEventQueryData['currentAbility'];
 };
 
 function StandaloneEditEventForm({
@@ -74,7 +74,7 @@ function StandaloneEditEventForm({
     createUpdater: useCallback(
       (store, updatedEventId, override) => {
         const queryOptions = { variables: { eventId: initialEvent.id } };
-        const storeData = store.readQuery<StandaloneEditEventQueryQuery>({
+        const storeData = store.readQuery<StandaloneEditEventQueryData>({
           query: StandaloneEditEventQueryDocument,
           ...queryOptions,
         });
@@ -101,7 +101,7 @@ function StandaloneEditEventForm({
     deleteUpdater: useCallback(
       (store, id) => {
         const queryOptions = { variables: { eventId: initialEvent.id } };
-        const storeData = store.readQuery<StandaloneEditEventQueryQuery>({
+        const storeData = store.readQuery<StandaloneEditEventQueryData>({
           query: StandaloneEditEventQueryDocument,
           ...queryOptions,
         });
@@ -158,7 +158,7 @@ export type StandaloneEditEventProps = {
 };
 
 function StandaloneEditEvent({ eventId, eventPath }: StandaloneEditEventProps) {
-  const { data, loading, error } = useStandaloneEditEventQueryQuery({ variables: { eventId } });
+  const { data, loading, error } = useStandaloneEditEventQuery({ variables: { eventId } });
 
   const initialEvent = useMemo(
     () => (error || loading || !data ? null : deserializeFormResponse(data.event)),

--- a/app/javascript/EventsApp/StandaloneEditEvent/mutations.generated.ts
+++ b/app/javascript/EventsApp/StandaloneEditEvent/mutations.generated.ts
@@ -5,12 +5,13 @@ import { StandaloneEditEvent_EventFieldsFragment, StandaloneEditEvent_MaximumEve
 import { gql } from '@apollo/client';
 import { StandaloneEditEvent_EventFieldsFragmentDoc, StandaloneEditEvent_MaximumEventProvidedTicketsOverrideFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type StandaloneDropEventMutationVariables = Types.Exact<{
   input: Types.DropEventInput;
 }>;
 
 
-export type StandaloneDropEventMutation = (
+export type StandaloneDropEventMutationData = (
   { __typename: 'Mutation' }
   & { dropEvent?: Types.Maybe<(
     { __typename: 'DropEventPayload' }
@@ -26,7 +27,7 @@ export type StandaloneUpdateEventMutationVariables = Types.Exact<{
 }>;
 
 
-export type StandaloneUpdateEventMutation = (
+export type StandaloneUpdateEventMutationData = (
   { __typename: 'Mutation' }
   & { updateEvent?: Types.Maybe<(
     { __typename: 'UpdateEventPayload' }
@@ -43,7 +44,7 @@ export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutationVariables
 }>;
 
 
-export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutation = (
+export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutationData = (
   { __typename: 'Mutation' }
   & { createMaximumEventProvidedTicketsOverride?: Types.Maybe<(
     { __typename: 'CreateMaximumEventProvidedTicketsOverridePayload' }
@@ -60,7 +61,7 @@ export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationVariables
 }>;
 
 
-export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutation = (
+export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationData = (
   { __typename: 'Mutation' }
   & { deleteMaximumEventProvidedTicketsOverride?: Types.Maybe<(
     { __typename: 'DeleteMaximumEventProvidedTicketsOverridePayload' }
@@ -77,7 +78,7 @@ export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationVariables
 }>;
 
 
-export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutation = (
+export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationData = (
   { __typename: 'Mutation' }
   & { updateMaximumEventProvidedTicketsOverride?: Types.Maybe<(
     { __typename: 'UpdateMaximumEventProvidedTicketsOverridePayload' }
@@ -100,7 +101,7 @@ export const StandaloneDropEventDocument = gql`
   }
 }
     `;
-export type StandaloneDropEventMutationFn = Apollo.MutationFunction<StandaloneDropEventMutation, StandaloneDropEventMutationVariables>;
+export type StandaloneDropEventMutationFn = Apollo.MutationFunction<StandaloneDropEventMutationData, StandaloneDropEventMutationVariables>;
 
 /**
  * __useStandaloneDropEventMutation__
@@ -119,12 +120,13 @@ export type StandaloneDropEventMutationFn = Apollo.MutationFunction<StandaloneDr
  *   },
  * });
  */
-export function useStandaloneDropEventMutation(baseOptions?: Apollo.MutationHookOptions<StandaloneDropEventMutation, StandaloneDropEventMutationVariables>) {
-        return Apollo.useMutation<StandaloneDropEventMutation, StandaloneDropEventMutationVariables>(StandaloneDropEventDocument, baseOptions);
+export function useStandaloneDropEventMutation(baseOptions?: Apollo.MutationHookOptions<StandaloneDropEventMutationData, StandaloneDropEventMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<StandaloneDropEventMutationData, StandaloneDropEventMutationVariables>(StandaloneDropEventDocument, options);
       }
 export type StandaloneDropEventMutationHookResult = ReturnType<typeof useStandaloneDropEventMutation>;
-export type StandaloneDropEventMutationResult = Apollo.MutationResult<StandaloneDropEventMutation>;
-export type StandaloneDropEventMutationOptions = Apollo.BaseMutationOptions<StandaloneDropEventMutation, StandaloneDropEventMutationVariables>;
+export type StandaloneDropEventMutationResult = Apollo.MutationResult<StandaloneDropEventMutationData>;
+export type StandaloneDropEventMutationOptions = Apollo.BaseMutationOptions<StandaloneDropEventMutationData, StandaloneDropEventMutationVariables>;
 export const StandaloneUpdateEventDocument = gql`
     mutation StandaloneUpdateEvent($input: UpdateEventInput!) {
   updateEvent(input: $input) {
@@ -135,7 +137,7 @@ export const StandaloneUpdateEventDocument = gql`
   }
 }
     ${StandaloneEditEvent_EventFieldsFragmentDoc}`;
-export type StandaloneUpdateEventMutationFn = Apollo.MutationFunction<StandaloneUpdateEventMutation, StandaloneUpdateEventMutationVariables>;
+export type StandaloneUpdateEventMutationFn = Apollo.MutationFunction<StandaloneUpdateEventMutationData, StandaloneUpdateEventMutationVariables>;
 
 /**
  * __useStandaloneUpdateEventMutation__
@@ -154,12 +156,13 @@ export type StandaloneUpdateEventMutationFn = Apollo.MutationFunction<Standalone
  *   },
  * });
  */
-export function useStandaloneUpdateEventMutation(baseOptions?: Apollo.MutationHookOptions<StandaloneUpdateEventMutation, StandaloneUpdateEventMutationVariables>) {
-        return Apollo.useMutation<StandaloneUpdateEventMutation, StandaloneUpdateEventMutationVariables>(StandaloneUpdateEventDocument, baseOptions);
+export function useStandaloneUpdateEventMutation(baseOptions?: Apollo.MutationHookOptions<StandaloneUpdateEventMutationData, StandaloneUpdateEventMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<StandaloneUpdateEventMutationData, StandaloneUpdateEventMutationVariables>(StandaloneUpdateEventDocument, options);
       }
 export type StandaloneUpdateEventMutationHookResult = ReturnType<typeof useStandaloneUpdateEventMutation>;
-export type StandaloneUpdateEventMutationResult = Apollo.MutationResult<StandaloneUpdateEventMutation>;
-export type StandaloneUpdateEventMutationOptions = Apollo.BaseMutationOptions<StandaloneUpdateEventMutation, StandaloneUpdateEventMutationVariables>;
+export type StandaloneUpdateEventMutationResult = Apollo.MutationResult<StandaloneUpdateEventMutationData>;
+export type StandaloneUpdateEventMutationOptions = Apollo.BaseMutationOptions<StandaloneUpdateEventMutationData, StandaloneUpdateEventMutationVariables>;
 export const StandaloneCreateMaximumEventProvidedTicketsOverrideDocument = gql`
     mutation StandaloneCreateMaximumEventProvidedTicketsOverride($input: CreateMaximumEventProvidedTicketsOverrideInput!) {
   createMaximumEventProvidedTicketsOverride(input: $input) {
@@ -170,7 +173,7 @@ export const StandaloneCreateMaximumEventProvidedTicketsOverrideDocument = gql`
   }
 }
     ${StandaloneEditEvent_MaximumEventProvidedTicketsOverrideFieldsFragmentDoc}`;
-export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<StandaloneCreateMaximumEventProvidedTicketsOverrideMutation, StandaloneCreateMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<StandaloneCreateMaximumEventProvidedTicketsOverrideMutationData, StandaloneCreateMaximumEventProvidedTicketsOverrideMutationVariables>;
 
 /**
  * __useStandaloneCreateMaximumEventProvidedTicketsOverrideMutation__
@@ -189,12 +192,13 @@ export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutationFn = Apol
  *   },
  * });
  */
-export function useStandaloneCreateMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<StandaloneCreateMaximumEventProvidedTicketsOverrideMutation, StandaloneCreateMaximumEventProvidedTicketsOverrideMutationVariables>) {
-        return Apollo.useMutation<StandaloneCreateMaximumEventProvidedTicketsOverrideMutation, StandaloneCreateMaximumEventProvidedTicketsOverrideMutationVariables>(StandaloneCreateMaximumEventProvidedTicketsOverrideDocument, baseOptions);
+export function useStandaloneCreateMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<StandaloneCreateMaximumEventProvidedTicketsOverrideMutationData, StandaloneCreateMaximumEventProvidedTicketsOverrideMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<StandaloneCreateMaximumEventProvidedTicketsOverrideMutationData, StandaloneCreateMaximumEventProvidedTicketsOverrideMutationVariables>(StandaloneCreateMaximumEventProvidedTicketsOverrideDocument, options);
       }
 export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutationHookResult = ReturnType<typeof useStandaloneCreateMaximumEventProvidedTicketsOverrideMutation>;
-export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<StandaloneCreateMaximumEventProvidedTicketsOverrideMutation>;
-export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<StandaloneCreateMaximumEventProvidedTicketsOverrideMutation, StandaloneCreateMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<StandaloneCreateMaximumEventProvidedTicketsOverrideMutationData>;
+export type StandaloneCreateMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<StandaloneCreateMaximumEventProvidedTicketsOverrideMutationData, StandaloneCreateMaximumEventProvidedTicketsOverrideMutationVariables>;
 export const StandaloneDeleteMaximumEventProvidedTicketsOverrideDocument = gql`
     mutation StandaloneDeleteMaximumEventProvidedTicketsOverride($input: DeleteMaximumEventProvidedTicketsOverrideInput!) {
   deleteMaximumEventProvidedTicketsOverride(input: $input) {
@@ -205,7 +209,7 @@ export const StandaloneDeleteMaximumEventProvidedTicketsOverrideDocument = gql`
   }
 }
     ${StandaloneEditEvent_MaximumEventProvidedTicketsOverrideFieldsFragmentDoc}`;
-export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<StandaloneDeleteMaximumEventProvidedTicketsOverrideMutation, StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationData, StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationVariables>;
 
 /**
  * __useStandaloneDeleteMaximumEventProvidedTicketsOverrideMutation__
@@ -224,12 +228,13 @@ export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationFn = Apol
  *   },
  * });
  */
-export function useStandaloneDeleteMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<StandaloneDeleteMaximumEventProvidedTicketsOverrideMutation, StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationVariables>) {
-        return Apollo.useMutation<StandaloneDeleteMaximumEventProvidedTicketsOverrideMutation, StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationVariables>(StandaloneDeleteMaximumEventProvidedTicketsOverrideDocument, baseOptions);
+export function useStandaloneDeleteMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationData, StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationData, StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationVariables>(StandaloneDeleteMaximumEventProvidedTicketsOverrideDocument, options);
       }
 export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationHookResult = ReturnType<typeof useStandaloneDeleteMaximumEventProvidedTicketsOverrideMutation>;
-export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<StandaloneDeleteMaximumEventProvidedTicketsOverrideMutation>;
-export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<StandaloneDeleteMaximumEventProvidedTicketsOverrideMutation, StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationData>;
+export type StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationData, StandaloneDeleteMaximumEventProvidedTicketsOverrideMutationVariables>;
 export const StandaloneUpdateMaximumEventProvidedTicketsOverrideDocument = gql`
     mutation StandaloneUpdateMaximumEventProvidedTicketsOverride($input: UpdateMaximumEventProvidedTicketsOverrideInput!) {
   updateMaximumEventProvidedTicketsOverride(input: $input) {
@@ -240,7 +245,7 @@ export const StandaloneUpdateMaximumEventProvidedTicketsOverrideDocument = gql`
   }
 }
     ${StandaloneEditEvent_MaximumEventProvidedTicketsOverrideFieldsFragmentDoc}`;
-export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<StandaloneUpdateMaximumEventProvidedTicketsOverrideMutation, StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationFn = Apollo.MutationFunction<StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationData, StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationVariables>;
 
 /**
  * __useStandaloneUpdateMaximumEventProvidedTicketsOverrideMutation__
@@ -259,9 +264,10 @@ export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationFn = Apol
  *   },
  * });
  */
-export function useStandaloneUpdateMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<StandaloneUpdateMaximumEventProvidedTicketsOverrideMutation, StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationVariables>) {
-        return Apollo.useMutation<StandaloneUpdateMaximumEventProvidedTicketsOverrideMutation, StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationVariables>(StandaloneUpdateMaximumEventProvidedTicketsOverrideDocument, baseOptions);
+export function useStandaloneUpdateMaximumEventProvidedTicketsOverrideMutation(baseOptions?: Apollo.MutationHookOptions<StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationData, StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationData, StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationVariables>(StandaloneUpdateMaximumEventProvidedTicketsOverrideDocument, options);
       }
 export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationHookResult = ReturnType<typeof useStandaloneUpdateMaximumEventProvidedTicketsOverrideMutation>;
-export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<StandaloneUpdateMaximumEventProvidedTicketsOverrideMutation>;
-export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<StandaloneUpdateMaximumEventProvidedTicketsOverrideMutation, StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationVariables>;
+export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationResult = Apollo.MutationResult<StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationData>;
+export type StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationOptions = Apollo.BaseMutationOptions<StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationData, StandaloneUpdateMaximumEventProvidedTicketsOverrideMutationVariables>;

--- a/app/javascript/EventsApp/StandaloneEditEvent/queries.generated.ts
+++ b/app/javascript/EventsApp/StandaloneEditEvent/queries.generated.ts
@@ -7,6 +7,7 @@ import { gql } from '@apollo/client';
 import { CommonFormFieldsFragmentDoc, CommonFormSectionFieldsFragmentDoc, CommonFormItemFieldsFragmentDoc } from '../../Models/commonFormFragments.generated';
 import { CommonConventionDataFragmentDoc } from '../queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type StandaloneEditEvent_TicketTypeFieldsFragment = (
   { __typename: 'TicketType' }
   & Pick<Types.TicketType, 'id' | 'description' | 'maximum_event_provided_tickets'>
@@ -40,12 +41,12 @@ export type StandaloneEditEvent_EventFieldsFragment = (
   )> }
 );
 
-export type StandaloneEditEventQueryQueryVariables = Types.Exact<{
+export type StandaloneEditEventQueryVariables = Types.Exact<{
   eventId: Types.Scalars['Int'];
 }>;
 
 
-export type StandaloneEditEventQueryQuery = (
+export type StandaloneEditEventQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -130,27 +131,29 @@ ${StandaloneEditEvent_TicketTypeFieldsFragmentDoc}
 ${StandaloneEditEvent_EventFieldsFragmentDoc}`;
 
 /**
- * __useStandaloneEditEventQueryQuery__
+ * __useStandaloneEditEventQuery__
  *
- * To run a query within a React component, call `useStandaloneEditEventQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useStandaloneEditEventQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useStandaloneEditEventQuery` and pass it any options that fit your needs.
+ * When your component renders, `useStandaloneEditEventQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useStandaloneEditEventQueryQuery({
+ * const { data, loading, error } = useStandaloneEditEventQuery({
  *   variables: {
  *      eventId: // value for 'eventId'
  *   },
  * });
  */
-export function useStandaloneEditEventQueryQuery(baseOptions: Apollo.QueryHookOptions<StandaloneEditEventQueryQuery, StandaloneEditEventQueryQueryVariables>) {
-        return Apollo.useQuery<StandaloneEditEventQueryQuery, StandaloneEditEventQueryQueryVariables>(StandaloneEditEventQueryDocument, baseOptions);
+export function useStandaloneEditEventQuery(baseOptions: Apollo.QueryHookOptions<StandaloneEditEventQueryData, StandaloneEditEventQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<StandaloneEditEventQueryData, StandaloneEditEventQueryVariables>(StandaloneEditEventQueryDocument, options);
       }
-export function useStandaloneEditEventQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<StandaloneEditEventQueryQuery, StandaloneEditEventQueryQueryVariables>) {
-          return Apollo.useLazyQuery<StandaloneEditEventQueryQuery, StandaloneEditEventQueryQueryVariables>(StandaloneEditEventQueryDocument, baseOptions);
+export function useStandaloneEditEventQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<StandaloneEditEventQueryData, StandaloneEditEventQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<StandaloneEditEventQueryData, StandaloneEditEventQueryVariables>(StandaloneEditEventQueryDocument, options);
         }
-export type StandaloneEditEventQueryQueryHookResult = ReturnType<typeof useStandaloneEditEventQueryQuery>;
+export type StandaloneEditEventQueryHookResult = ReturnType<typeof useStandaloneEditEventQuery>;
 export type StandaloneEditEventQueryLazyQueryHookResult = ReturnType<typeof useStandaloneEditEventQueryLazyQuery>;
-export type StandaloneEditEventQueryQueryResult = Apollo.QueryResult<StandaloneEditEventQueryQuery, StandaloneEditEventQueryQueryVariables>;
+export type StandaloneEditEventQueryDataResult = Apollo.QueryResult<StandaloneEditEventQueryData, StandaloneEditEventQueryVariables>;

--- a/app/javascript/EventsApp/TeamMemberAdmin/EditTeamMember.tsx
+++ b/app/javascript/EventsApp/TeamMemberAdmin/EditTeamMember.tsx
@@ -9,11 +9,11 @@ import ErrorDisplay from '../../ErrorDisplay';
 import TeamMemberForm from './TeamMemberForm';
 import useAsyncFunction from '../../useAsyncFunction';
 import usePageTitle from '../../usePageTitle';
-import { TeamMembersQueryQuery } from './queries.generated';
+import { TeamMembersQueryData } from './queries.generated';
 import { useUpdateTeamMemberMutation } from './mutations.generated';
 
 export type EditTeamMemberProps = {
-  event: TeamMembersQueryQuery['event'];
+  event: TeamMembersQueryData['event'];
   eventPath: string;
 };
 
@@ -81,7 +81,7 @@ function EditTeamMember({ event, eventPath }: EditTeamMemberProps) {
         event={event}
         value={teamMember}
         onChange={(newValue) =>
-          setTeamMember(newValue as TeamMembersQueryQuery['event']['team_members'][0])
+          setTeamMember(newValue as TeamMembersQueryData['event']['team_members'][0])
         }
         disabled={updateInProgress}
       />

--- a/app/javascript/EventsApp/TeamMemberAdmin/NewTeamMember.tsx
+++ b/app/javascript/EventsApp/TeamMemberAdmin/NewTeamMember.tsx
@@ -14,11 +14,11 @@ import useUniqueId from '../../useUniqueId';
 import useAsyncFunction from '../../useAsyncFunction';
 import { useCreateMutation } from '../../MutationUtils';
 import usePageTitle from '../../usePageTitle';
-import { TeamMembersQueryQuery } from './queries.generated';
+import { TeamMembersQueryData } from './queries.generated';
 import { ReceiveSignupEmail } from '../../graphqlTypes.generated';
 
 export type NewTeamMemberProps = {
-  event: TeamMembersQueryQuery['event'];
+  event: TeamMembersQueryData['event'];
   eventPath: string;
 };
 
@@ -26,7 +26,7 @@ function NewTeamMember({ event, eventPath }: NewTeamMemberProps) {
   const { t } = useTranslation();
   const history = useHistory();
   const [teamMember, setTeamMember] = useState<
-    Partial<TeamMembersQueryQuery['event']['team_members'][0]>
+    Partial<TeamMembersQueryData['event']['team_members'][0]>
   >({
     user_con_profile: undefined,
     display_team_member: true,
@@ -63,7 +63,7 @@ function NewTeamMember({ event, eventPath }: NewTeamMemberProps) {
         input: {
           event_id: event.id,
           team_member: buildTeamMemberInput(
-            teamMember as TeamMembersQueryQuery['event']['team_members'][0],
+            teamMember as TeamMembersQueryData['event']['team_members'][0],
           ),
           user_con_profile_id: teamMember.user_con_profile!.id,
         },

--- a/app/javascript/EventsApp/TeamMemberAdmin/ProvidableTicketTypeSelection.tsx
+++ b/app/javascript/EventsApp/TeamMemberAdmin/ProvidableTicketTypeSelection.tsx
@@ -6,15 +6,12 @@ import { pluralize, humanize } from 'inflected';
 import MultipleChoiceInput from '../../BuiltInFormControls/MultipleChoiceInput';
 
 import { getProvidableTicketTypes, getRemainingTicketCountByType } from './ProvideTicketUtils';
-import { TeamMembersQueryQuery } from './queries.generated';
+import { TeamMembersQueryData } from './queries.generated';
 
 export type ProvidableTicketTypeSelectionProps = {
-  convention: Pick<
-    NonNullable<TeamMembersQueryQuery['convention']>,
-    'ticket_types' | 'ticket_name'
-  >;
-  event: Pick<TeamMembersQueryQuery['event'], 'title'> & {
-    provided_tickets: Pick<TeamMembersQueryQuery['event']['provided_tickets'][0], 'ticket_type'>[];
+  convention: Pick<NonNullable<TeamMembersQueryData['convention']>, 'ticket_types' | 'ticket_name'>;
+  event: Pick<TeamMembersQueryData['event'], 'title'> & {
+    provided_tickets: Pick<TeamMembersQueryData['event']['provided_tickets'][0], 'ticket_type'>[];
   };
   value?: number;
   onChange: React.Dispatch<number>;

--- a/app/javascript/EventsApp/TeamMemberAdmin/ProvideTicketModal.tsx
+++ b/app/javascript/EventsApp/TeamMemberAdmin/ProvideTicketModal.tsx
@@ -11,14 +11,14 @@ import ProvidableTicketTypeSelection from './ProvidableTicketTypeSelection';
 import { TeamMembersQuery } from './queries';
 import TicketingStatusDescription from './TicketingStatusDescription';
 import useAsyncFunction from '../../useAsyncFunction';
-import { TeamMembersQueryQuery, TeamMembersQueryQueryVariables } from './queries.generated';
+import { TeamMembersQueryData, TeamMembersQueryVariables } from './queries.generated';
 import { useProvideEventTicketMutation } from './mutations.generated';
 
 export type ProvideTicketModalProps = {
-  event: TeamMembersQueryQuery['event'];
-  convention: NonNullable<TeamMembersQueryQuery['convention']>;
+  event: TeamMembersQueryData['event'];
+  convention: NonNullable<TeamMembersQueryData['convention']>;
   onClose: () => void;
-  teamMember?: TeamMembersQueryQuery['event']['team_members'][0];
+  teamMember?: TeamMembersQueryData['event']['team_members'][0];
   visible: boolean;
 };
 
@@ -39,7 +39,7 @@ function ProvideTicketModal({
       provideTicketAsync({
         ...args,
         update: (store, result) => {
-          const data = store.readQuery<TeamMembersQueryQuery, TeamMembersQueryQueryVariables>({
+          const data = store.readQuery<TeamMembersQueryData, TeamMembersQueryVariables>({
             query: TeamMembersQuery,
             variables: { eventId: event.id },
           });

--- a/app/javascript/EventsApp/TeamMemberAdmin/ProvideTicketUtils.ts
+++ b/app/javascript/EventsApp/TeamMemberAdmin/ProvideTicketUtils.ts
@@ -1,8 +1,8 @@
-import { TeamMembersQueryQuery } from './queries.generated';
+import { TeamMembersQueryData } from './queries.generated';
 
-type ConventionType = Pick<NonNullable<TeamMembersQueryQuery['convention']>, 'ticket_types'>;
+type ConventionType = Pick<NonNullable<TeamMembersQueryData['convention']>, 'ticket_types'>;
 type EventType = {
-  provided_tickets: Pick<TeamMembersQueryQuery['event']['provided_tickets'][0], 'ticket_type'>[];
+  provided_tickets: Pick<TeamMembersQueryData['event']['provided_tickets'][0], 'ticket_type'>[];
 };
 
 export function getProvidableTicketTypes(convention: ConventionType) {

--- a/app/javascript/EventsApp/TeamMemberAdmin/TeamMemberForm.tsx
+++ b/app/javascript/EventsApp/TeamMemberAdmin/TeamMemberForm.tsx
@@ -6,13 +6,13 @@ import MultipleChoiceInput from '../../BuiltInFormControls/MultipleChoiceInput';
 import { ReceiveSignupEmail } from '../../graphqlTypes.generated';
 import HelpPopover from '../../UIComponents/HelpPopover';
 import { usePropertySetters, useFunctionalStateUpdater } from '../../usePropertySetters';
-import { TeamMembersQueryQuery } from './queries.generated';
+import { TeamMembersQueryData } from './queries.generated';
 
 export type TeamMemberFormProps = {
-  event: TeamMembersQueryQuery['event'];
+  event: TeamMembersQueryData['event'];
   disabled?: boolean;
-  value: Partial<TeamMembersQueryQuery['event']['team_members'][0]>;
-  onChange: React.Dispatch<Partial<TeamMembersQueryQuery['event']['team_members'][0]>>;
+  value: Partial<TeamMembersQueryData['event']['team_members'][0]>;
+  onChange: React.Dispatch<Partial<TeamMembersQueryData['event']['team_members'][0]>>;
 };
 
 function TeamMemberForm({ event, disabled, value, onChange }: TeamMemberFormProps) {

--- a/app/javascript/EventsApp/TeamMemberAdmin/TeamMembersIndex.tsx
+++ b/app/javascript/EventsApp/TeamMemberAdmin/TeamMembersIndex.tsx
@@ -15,10 +15,10 @@ import ErrorDisplay from '../../ErrorDisplay';
 import { useDeleteMutation } from '../../MutationUtils';
 import { DeleteTeamMember } from './mutations';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
-import { TeamMembersQueryQuery, useTeamMembersQueryQuery } from './queries.generated';
+import { TeamMembersQueryData, useTeamMembersQuery } from './queries.generated';
 import { DropdownMenu } from '../../UIComponents/DropdownMenu';
 
-function sortTeamMembers(teamMembers: TeamMembersQueryQuery['event']['team_members']) {
+function sortTeamMembers(teamMembers: TeamMembersQueryData['event']['team_members']) {
   return sortByLocaleString(
     teamMembers,
     (teamMember) => teamMember.user_con_profile.name_inverted ?? '',
@@ -26,9 +26,9 @@ function sortTeamMembers(teamMembers: TeamMembersQueryQuery['event']['team_membe
 }
 
 type TeamMemberActionMenuProps = {
-  event: TeamMembersQueryQuery['event'];
-  convention: NonNullable<TeamMembersQueryQuery['convention']>;
-  teamMember: TeamMembersQueryQuery['event']['team_members'][0];
+  event: TeamMembersQueryData['event'];
+  convention: NonNullable<TeamMembersQueryData['convention']>;
+  teamMember: TeamMembersQueryData['event']['team_members'][0];
   openProvideTicketModal: () => void;
   eventPath: string;
 };
@@ -112,8 +112,8 @@ export type TeamMembersIndexProps = {
 
 function TeamMembersIndex({ eventId, eventPath }: TeamMembersIndexProps) {
   const { t } = useTranslation();
-  const { data, loading, error } = useTeamMembersQueryQuery({ variables: { eventId } });
-  const modal = useModal<{ teamMember: TeamMembersQueryQuery['event']['team_members'][0] }>();
+  const { data, loading, error } = useTeamMembersQuery({ variables: { eventId } });
+  const modal = useModal<{ teamMember: TeamMembersQueryData['event']['team_members'][0] }>();
 
   const titleizedTeamMemberName = useMemo(
     () =>

--- a/app/javascript/EventsApp/TeamMemberAdmin/TicketingStatusDescription.tsx
+++ b/app/javascript/EventsApp/TeamMemberAdmin/TicketingStatusDescription.tsx
@@ -1,10 +1,10 @@
 import { Trans, useTranslation } from 'react-i18next';
 import { humanize } from 'inflected';
-import { TeamMembersQueryQuery } from './queries.generated';
+import { TeamMembersQueryData } from './queries.generated';
 
 export type TicketingStatusDescriptionProps = {
-  userConProfile: TeamMembersQueryQuery['event']['team_members'][0]['user_con_profile'];
-  convention: NonNullable<TeamMembersQueryQuery['convention']>;
+  userConProfile: TeamMembersQueryData['event']['team_members'][0]['user_con_profile'];
+  convention: NonNullable<TeamMembersQueryData['convention']>;
 };
 
 function TicketingStatusDescription({

--- a/app/javascript/EventsApp/TeamMemberAdmin/buildTeamMemberInput.ts
+++ b/app/javascript/EventsApp/TeamMemberAdmin/buildTeamMemberInput.ts
@@ -1,8 +1,8 @@
 import { TeamMemberInput } from '../../graphqlTypes.generated';
-import { TeamMembersQueryQuery } from './queries.generated';
+import { TeamMembersQueryData } from './queries.generated';
 
 function buildTeamMemberInput(
-  teamMember: TeamMembersQueryQuery['event']['team_members'][0],
+  teamMember: TeamMembersQueryData['event']['team_members'][0],
 ): TeamMemberInput {
   return {
     display_team_member: teamMember.display_team_member,

--- a/app/javascript/EventsApp/TeamMemberAdmin/index.tsx
+++ b/app/javascript/EventsApp/TeamMemberAdmin/index.tsx
@@ -9,7 +9,7 @@ import ErrorDisplay from '../../ErrorDisplay';
 import PageLoadingIndicator from '../../PageLoadingIndicator';
 import BreadcrumbItem from '../../Breadcrumbs/BreadcrumbItem';
 import RouteActivatedBreadcrumbItem from '../../Breadcrumbs/RouteActivatedBreadcrumbItem';
-import { useTeamMembersQueryQuery } from './queries.generated';
+import { useTeamMembersQuery } from './queries.generated';
 
 export type TeamMemberAdminProps = {
   eventId: number;
@@ -17,7 +17,7 @@ export type TeamMemberAdminProps = {
 };
 
 function TeamMemberAdmin({ eventId, eventPath }: TeamMemberAdminProps) {
-  const { data, loading, error } = useTeamMembersQueryQuery({ variables: { eventId } });
+  const { data, loading, error } = useTeamMembersQuery({ variables: { eventId } });
   const teamMemberMatch = useRouteMatch<{ teamMemberId: string }>(
     `${eventPath}/team_members/:teamMemberId(\\d+)`,
   );

--- a/app/javascript/EventsApp/TeamMemberAdmin/mutations.generated.ts
+++ b/app/javascript/EventsApp/TeamMemberAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { TeamMemberFieldsFragment, TeamMemberTicketFieldsFragment, TeamMemberFie
 import { gql } from '@apollo/client';
 import { TeamMemberFieldsFragmentDoc, TeamMemberTicketFieldsFragmentDoc, TeamMemberFieldsWithoutPersonalInfoFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateTeamMemberMutationVariables = Types.Exact<{
   input: Types.CreateTeamMemberInput;
 }>;
 
 
-export type CreateTeamMemberMutation = (
+export type CreateTeamMemberMutationData = (
   { __typename: 'Mutation' }
   & { createTeamMember?: Types.Maybe<(
     { __typename: 'CreateTeamMemberPayload' }
@@ -27,7 +28,7 @@ export type DeleteTeamMemberMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteTeamMemberMutation = (
+export type DeleteTeamMemberMutationData = (
   { __typename: 'Mutation' }
   & { deleteTeamMember?: Types.Maybe<(
     { __typename: 'DeleteTeamMemberPayload' }
@@ -44,7 +45,7 @@ export type UpdateTeamMemberMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateTeamMemberMutation = (
+export type UpdateTeamMemberMutationData = (
   { __typename: 'Mutation' }
   & { updateTeamMember?: Types.Maybe<(
     { __typename: 'UpdateTeamMemberPayload' }
@@ -63,7 +64,7 @@ export type ProvideEventTicketMutationVariables = Types.Exact<{
 }>;
 
 
-export type ProvideEventTicketMutation = (
+export type ProvideEventTicketMutationData = (
   { __typename: 'Mutation' }
   & { provideEventTicket?: Types.Maybe<(
     { __typename: 'ProvideEventTicketPayload' }
@@ -86,7 +87,7 @@ export const CreateTeamMemberDocument = gql`
   }
 }
     ${TeamMemberFieldsFragmentDoc}`;
-export type CreateTeamMemberMutationFn = Apollo.MutationFunction<CreateTeamMemberMutation, CreateTeamMemberMutationVariables>;
+export type CreateTeamMemberMutationFn = Apollo.MutationFunction<CreateTeamMemberMutationData, CreateTeamMemberMutationVariables>;
 
 /**
  * __useCreateTeamMemberMutation__
@@ -105,12 +106,13 @@ export type CreateTeamMemberMutationFn = Apollo.MutationFunction<CreateTeamMembe
  *   },
  * });
  */
-export function useCreateTeamMemberMutation(baseOptions?: Apollo.MutationHookOptions<CreateTeamMemberMutation, CreateTeamMemberMutationVariables>) {
-        return Apollo.useMutation<CreateTeamMemberMutation, CreateTeamMemberMutationVariables>(CreateTeamMemberDocument, baseOptions);
+export function useCreateTeamMemberMutation(baseOptions?: Apollo.MutationHookOptions<CreateTeamMemberMutationData, CreateTeamMemberMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateTeamMemberMutationData, CreateTeamMemberMutationVariables>(CreateTeamMemberDocument, options);
       }
 export type CreateTeamMemberMutationHookResult = ReturnType<typeof useCreateTeamMemberMutation>;
-export type CreateTeamMemberMutationResult = Apollo.MutationResult<CreateTeamMemberMutation>;
-export type CreateTeamMemberMutationOptions = Apollo.BaseMutationOptions<CreateTeamMemberMutation, CreateTeamMemberMutationVariables>;
+export type CreateTeamMemberMutationResult = Apollo.MutationResult<CreateTeamMemberMutationData>;
+export type CreateTeamMemberMutationOptions = Apollo.BaseMutationOptions<CreateTeamMemberMutationData, CreateTeamMemberMutationVariables>;
 export const DeleteTeamMemberDocument = gql`
     mutation DeleteTeamMember($input: DeleteTeamMemberInput!) {
   deleteTeamMember(input: $input) {
@@ -121,7 +123,7 @@ export const DeleteTeamMemberDocument = gql`
   }
 }
     ${TeamMemberFieldsWithoutPersonalInfoFragmentDoc}`;
-export type DeleteTeamMemberMutationFn = Apollo.MutationFunction<DeleteTeamMemberMutation, DeleteTeamMemberMutationVariables>;
+export type DeleteTeamMemberMutationFn = Apollo.MutationFunction<DeleteTeamMemberMutationData, DeleteTeamMemberMutationVariables>;
 
 /**
  * __useDeleteTeamMemberMutation__
@@ -140,12 +142,13 @@ export type DeleteTeamMemberMutationFn = Apollo.MutationFunction<DeleteTeamMembe
  *   },
  * });
  */
-export function useDeleteTeamMemberMutation(baseOptions?: Apollo.MutationHookOptions<DeleteTeamMemberMutation, DeleteTeamMemberMutationVariables>) {
-        return Apollo.useMutation<DeleteTeamMemberMutation, DeleteTeamMemberMutationVariables>(DeleteTeamMemberDocument, baseOptions);
+export function useDeleteTeamMemberMutation(baseOptions?: Apollo.MutationHookOptions<DeleteTeamMemberMutationData, DeleteTeamMemberMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteTeamMemberMutationData, DeleteTeamMemberMutationVariables>(DeleteTeamMemberDocument, options);
       }
 export type DeleteTeamMemberMutationHookResult = ReturnType<typeof useDeleteTeamMemberMutation>;
-export type DeleteTeamMemberMutationResult = Apollo.MutationResult<DeleteTeamMemberMutation>;
-export type DeleteTeamMemberMutationOptions = Apollo.BaseMutationOptions<DeleteTeamMemberMutation, DeleteTeamMemberMutationVariables>;
+export type DeleteTeamMemberMutationResult = Apollo.MutationResult<DeleteTeamMemberMutationData>;
+export type DeleteTeamMemberMutationOptions = Apollo.BaseMutationOptions<DeleteTeamMemberMutationData, DeleteTeamMemberMutationVariables>;
 export const UpdateTeamMemberDocument = gql`
     mutation UpdateTeamMember($input: UpdateTeamMemberInput!) {
   updateTeamMember(input: $input) {
@@ -156,7 +159,7 @@ export const UpdateTeamMemberDocument = gql`
   }
 }
     ${TeamMemberFieldsWithoutPersonalInfoFragmentDoc}`;
-export type UpdateTeamMemberMutationFn = Apollo.MutationFunction<UpdateTeamMemberMutation, UpdateTeamMemberMutationVariables>;
+export type UpdateTeamMemberMutationFn = Apollo.MutationFunction<UpdateTeamMemberMutationData, UpdateTeamMemberMutationVariables>;
 
 /**
  * __useUpdateTeamMemberMutation__
@@ -175,12 +178,13 @@ export type UpdateTeamMemberMutationFn = Apollo.MutationFunction<UpdateTeamMembe
  *   },
  * });
  */
-export function useUpdateTeamMemberMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTeamMemberMutation, UpdateTeamMemberMutationVariables>) {
-        return Apollo.useMutation<UpdateTeamMemberMutation, UpdateTeamMemberMutationVariables>(UpdateTeamMemberDocument, baseOptions);
+export function useUpdateTeamMemberMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTeamMemberMutationData, UpdateTeamMemberMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateTeamMemberMutationData, UpdateTeamMemberMutationVariables>(UpdateTeamMemberDocument, options);
       }
 export type UpdateTeamMemberMutationHookResult = ReturnType<typeof useUpdateTeamMemberMutation>;
-export type UpdateTeamMemberMutationResult = Apollo.MutationResult<UpdateTeamMemberMutation>;
-export type UpdateTeamMemberMutationOptions = Apollo.BaseMutationOptions<UpdateTeamMemberMutation, UpdateTeamMemberMutationVariables>;
+export type UpdateTeamMemberMutationResult = Apollo.MutationResult<UpdateTeamMemberMutationData>;
+export type UpdateTeamMemberMutationOptions = Apollo.BaseMutationOptions<UpdateTeamMemberMutationData, UpdateTeamMemberMutationVariables>;
 export const ProvideEventTicketDocument = gql`
     mutation ProvideEventTicket($eventId: Int!, $userConProfileId: Int!, $ticketTypeId: Int!) {
   provideEventTicket(
@@ -193,7 +197,7 @@ export const ProvideEventTicketDocument = gql`
   }
 }
     ${TeamMemberTicketFieldsFragmentDoc}`;
-export type ProvideEventTicketMutationFn = Apollo.MutationFunction<ProvideEventTicketMutation, ProvideEventTicketMutationVariables>;
+export type ProvideEventTicketMutationFn = Apollo.MutationFunction<ProvideEventTicketMutationData, ProvideEventTicketMutationVariables>;
 
 /**
  * __useProvideEventTicketMutation__
@@ -214,9 +218,10 @@ export type ProvideEventTicketMutationFn = Apollo.MutationFunction<ProvideEventT
  *   },
  * });
  */
-export function useProvideEventTicketMutation(baseOptions?: Apollo.MutationHookOptions<ProvideEventTicketMutation, ProvideEventTicketMutationVariables>) {
-        return Apollo.useMutation<ProvideEventTicketMutation, ProvideEventTicketMutationVariables>(ProvideEventTicketDocument, baseOptions);
+export function useProvideEventTicketMutation(baseOptions?: Apollo.MutationHookOptions<ProvideEventTicketMutationData, ProvideEventTicketMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ProvideEventTicketMutationData, ProvideEventTicketMutationVariables>(ProvideEventTicketDocument, options);
       }
 export type ProvideEventTicketMutationHookResult = ReturnType<typeof useProvideEventTicketMutation>;
-export type ProvideEventTicketMutationResult = Apollo.MutationResult<ProvideEventTicketMutation>;
-export type ProvideEventTicketMutationOptions = Apollo.BaseMutationOptions<ProvideEventTicketMutation, ProvideEventTicketMutationVariables>;
+export type ProvideEventTicketMutationResult = Apollo.MutationResult<ProvideEventTicketMutationData>;
+export type ProvideEventTicketMutationOptions = Apollo.BaseMutationOptions<ProvideEventTicketMutationData, ProvideEventTicketMutationVariables>;

--- a/app/javascript/EventsApp/TeamMemberAdmin/queries.generated.ts
+++ b/app/javascript/EventsApp/TeamMemberAdmin/queries.generated.ts
@@ -5,6 +5,7 @@ import { CommonConventionDataFragment } from '../queries.generated';
 import { gql } from '@apollo/client';
 import { CommonConventionDataFragmentDoc } from '../queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type TeamMemberTicketFieldsFragment = (
   { __typename: 'Ticket' }
   & Pick<Types.Ticket, 'id'>
@@ -60,12 +61,12 @@ export type TeamMemberFieldsWithoutPersonalInfoFragment = (
   ) }
 );
 
-export type TeamMembersQueryQueryVariables = Types.Exact<{
+export type TeamMembersQueryVariables = Types.Exact<{
   eventId: Types.Scalars['Int'];
 }>;
 
 
-export type TeamMembersQueryQuery = (
+export type TeamMembersQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -93,12 +94,12 @@ export type TeamMembersQueryQuery = (
   ) }
 );
 
-export type TeamMemberUserConProfilesQueryQueryVariables = Types.Exact<{
+export type TeamMemberUserConProfilesQueryVariables = Types.Exact<{
   name?: Types.Maybe<Types.Scalars['String']>;
 }>;
 
 
-export type TeamMemberUserConProfilesQueryQuery = (
+export type TeamMemberUserConProfilesQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -217,30 +218,32 @@ ${TeamMemberTicketFieldsFragmentDoc}
 ${TeamMemberFieldsFragmentDoc}`;
 
 /**
- * __useTeamMembersQueryQuery__
+ * __useTeamMembersQuery__
  *
- * To run a query within a React component, call `useTeamMembersQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useTeamMembersQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useTeamMembersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTeamMembersQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useTeamMembersQueryQuery({
+ * const { data, loading, error } = useTeamMembersQuery({
  *   variables: {
  *      eventId: // value for 'eventId'
  *   },
  * });
  */
-export function useTeamMembersQueryQuery(baseOptions: Apollo.QueryHookOptions<TeamMembersQueryQuery, TeamMembersQueryQueryVariables>) {
-        return Apollo.useQuery<TeamMembersQueryQuery, TeamMembersQueryQueryVariables>(TeamMembersQueryDocument, baseOptions);
+export function useTeamMembersQuery(baseOptions: Apollo.QueryHookOptions<TeamMembersQueryData, TeamMembersQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TeamMembersQueryData, TeamMembersQueryVariables>(TeamMembersQueryDocument, options);
       }
-export function useTeamMembersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TeamMembersQueryQuery, TeamMembersQueryQueryVariables>) {
-          return Apollo.useLazyQuery<TeamMembersQueryQuery, TeamMembersQueryQueryVariables>(TeamMembersQueryDocument, baseOptions);
+export function useTeamMembersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TeamMembersQueryData, TeamMembersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TeamMembersQueryData, TeamMembersQueryVariables>(TeamMembersQueryDocument, options);
         }
-export type TeamMembersQueryQueryHookResult = ReturnType<typeof useTeamMembersQueryQuery>;
+export type TeamMembersQueryHookResult = ReturnType<typeof useTeamMembersQuery>;
 export type TeamMembersQueryLazyQueryHookResult = ReturnType<typeof useTeamMembersQueryLazyQuery>;
-export type TeamMembersQueryQueryResult = Apollo.QueryResult<TeamMembersQueryQuery, TeamMembersQueryQueryVariables>;
+export type TeamMembersQueryDataResult = Apollo.QueryResult<TeamMembersQueryData, TeamMembersQueryVariables>;
 export const TeamMemberUserConProfilesQueryDocument = gql`
     query TeamMemberUserConProfilesQuery($name: String) {
   convention {
@@ -256,27 +259,29 @@ export const TeamMemberUserConProfilesQueryDocument = gql`
     ${TeamMemberUserConProfileSearchFieldsFragmentDoc}`;
 
 /**
- * __useTeamMemberUserConProfilesQueryQuery__
+ * __useTeamMemberUserConProfilesQuery__
  *
- * To run a query within a React component, call `useTeamMemberUserConProfilesQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useTeamMemberUserConProfilesQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useTeamMemberUserConProfilesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTeamMemberUserConProfilesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useTeamMemberUserConProfilesQueryQuery({
+ * const { data, loading, error } = useTeamMemberUserConProfilesQuery({
  *   variables: {
  *      name: // value for 'name'
  *   },
  * });
  */
-export function useTeamMemberUserConProfilesQueryQuery(baseOptions?: Apollo.QueryHookOptions<TeamMemberUserConProfilesQueryQuery, TeamMemberUserConProfilesQueryQueryVariables>) {
-        return Apollo.useQuery<TeamMemberUserConProfilesQueryQuery, TeamMemberUserConProfilesQueryQueryVariables>(TeamMemberUserConProfilesQueryDocument, baseOptions);
+export function useTeamMemberUserConProfilesQuery(baseOptions?: Apollo.QueryHookOptions<TeamMemberUserConProfilesQueryData, TeamMemberUserConProfilesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TeamMemberUserConProfilesQueryData, TeamMemberUserConProfilesQueryVariables>(TeamMemberUserConProfilesQueryDocument, options);
       }
-export function useTeamMemberUserConProfilesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TeamMemberUserConProfilesQueryQuery, TeamMemberUserConProfilesQueryQueryVariables>) {
-          return Apollo.useLazyQuery<TeamMemberUserConProfilesQueryQuery, TeamMemberUserConProfilesQueryQueryVariables>(TeamMemberUserConProfilesQueryDocument, baseOptions);
+export function useTeamMemberUserConProfilesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TeamMemberUserConProfilesQueryData, TeamMemberUserConProfilesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TeamMemberUserConProfilesQueryData, TeamMemberUserConProfilesQueryVariables>(TeamMemberUserConProfilesQueryDocument, options);
         }
-export type TeamMemberUserConProfilesQueryQueryHookResult = ReturnType<typeof useTeamMemberUserConProfilesQueryQuery>;
+export type TeamMemberUserConProfilesQueryHookResult = ReturnType<typeof useTeamMemberUserConProfilesQuery>;
 export type TeamMemberUserConProfilesQueryLazyQueryHookResult = ReturnType<typeof useTeamMemberUserConProfilesQueryLazyQuery>;
-export type TeamMemberUserConProfilesQueryQueryResult = Apollo.QueryResult<TeamMemberUserConProfilesQueryQuery, TeamMemberUserConProfilesQueryQueryVariables>;
+export type TeamMemberUserConProfilesQueryDataResult = Apollo.QueryResult<TeamMemberUserConProfilesQueryData, TeamMemberUserConProfilesQueryVariables>;

--- a/app/javascript/EventsApp/queries.generated.ts
+++ b/app/javascript/EventsApp/queries.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CommonConventionDataFragment = (
   { __typename: 'Convention' }
   & Pick<Types.Convention, 'id' | 'name' | 'starts_at' | 'ends_at' | 'site_mode' | 'timezone_name' | 'timezone_mode' | 'ticket_name' | 'ticket_mode'>
@@ -24,10 +25,10 @@ export type RunBasicSignupDataFragment = (
   )> }
 );
 
-export type CommonConventionDataQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CommonConventionDataQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CommonConventionDataQueryQuery = (
+export type CommonConventionDataQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -81,26 +82,28 @@ export const CommonConventionDataQueryDocument = gql`
     ${CommonConventionDataFragmentDoc}`;
 
 /**
- * __useCommonConventionDataQueryQuery__
+ * __useCommonConventionDataQuery__
  *
- * To run a query within a React component, call `useCommonConventionDataQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCommonConventionDataQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCommonConventionDataQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCommonConventionDataQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCommonConventionDataQueryQuery({
+ * const { data, loading, error } = useCommonConventionDataQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCommonConventionDataQueryQuery(baseOptions?: Apollo.QueryHookOptions<CommonConventionDataQueryQuery, CommonConventionDataQueryQueryVariables>) {
-        return Apollo.useQuery<CommonConventionDataQueryQuery, CommonConventionDataQueryQueryVariables>(CommonConventionDataQueryDocument, baseOptions);
+export function useCommonConventionDataQuery(baseOptions?: Apollo.QueryHookOptions<CommonConventionDataQueryData, CommonConventionDataQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CommonConventionDataQueryData, CommonConventionDataQueryVariables>(CommonConventionDataQueryDocument, options);
       }
-export function useCommonConventionDataQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CommonConventionDataQueryQuery, CommonConventionDataQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CommonConventionDataQueryQuery, CommonConventionDataQueryQueryVariables>(CommonConventionDataQueryDocument, baseOptions);
+export function useCommonConventionDataQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CommonConventionDataQueryData, CommonConventionDataQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CommonConventionDataQueryData, CommonConventionDataQueryVariables>(CommonConventionDataQueryDocument, options);
         }
-export type CommonConventionDataQueryQueryHookResult = ReturnType<typeof useCommonConventionDataQueryQuery>;
+export type CommonConventionDataQueryHookResult = ReturnType<typeof useCommonConventionDataQuery>;
 export type CommonConventionDataQueryLazyQueryHookResult = ReturnType<typeof useCommonConventionDataQueryLazyQuery>;
-export type CommonConventionDataQueryQueryResult = Apollo.QueryResult<CommonConventionDataQueryQuery, CommonConventionDataQueryQueryVariables>;
+export type CommonConventionDataQueryDataResult = Apollo.QueryResult<CommonConventionDataQueryData, CommonConventionDataQueryVariables>;

--- a/app/javascript/FormAdmin/FormAdminIndex.tsx
+++ b/app/javascript/FormAdmin/FormAdminIndex.tsx
@@ -12,9 +12,9 @@ import { useDeleteMutation } from '../MutationUtils';
 import useModal from '../ModalDialogs/useModal';
 import NewFormModal from './NewFormModal';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { FormAdminQueryQuery, useFormAdminQueryQuery } from './queries.generated';
+import { FormAdminQueryData, useFormAdminQuery } from './queries.generated';
 
-function describeFormUsers(form: FormAdminQueryQuery['convention']['forms'][0]) {
+function describeFormUsers(form: FormAdminQueryData['convention']['forms'][0]) {
   return [
     ...form.user_con_profile_conventions
       .map((convention) => `User profile form for ${convention.name}`)
@@ -28,7 +28,7 @@ function describeFormUsers(form: FormAdminQueryQuery['convention']['forms'][0]) 
   ];
 }
 
-export default LoadQueryWrapper(useFormAdminQueryQuery, function FormAdminIndex({ data }) {
+export default LoadQueryWrapper(useFormAdminQuery, function FormAdminIndex({ data }) {
   const confirm = useConfirm();
   const deleteForm = useDeleteMutation(DeleteForm, {
     query: FormAdminQuery,

--- a/app/javascript/FormAdmin/FormEditor.tsx
+++ b/app/javascript/FormAdmin/FormEditor.tsx
@@ -12,7 +12,7 @@ import InPlaceEditor from '../BuiltInFormControls/InPlaceEditor';
 import PageLoadingIndicator from '../PageLoadingIndicator';
 import { parseTypedFormItemObject } from './FormItemUtils';
 import usePageTitle from '../usePageTitle';
-import { useFormEditorQueryQuery } from './queries.generated';
+import { useFormEditorQuery } from './queries.generated';
 import { FormType } from '../graphqlTypes.generated';
 import { useUpdateFormMutation } from './mutations.generated';
 import { notEmpty } from '../ValueUtils';
@@ -20,7 +20,7 @@ import DndWrapper from '../DndWrapper';
 
 function FormEditor() {
   const match = useRouteMatch<{ id: string; sectionId?: string; itemId?: string }>();
-  const { data, error, loading } = useFormEditorQueryQuery({
+  const { data, error, loading } = useFormEditorQuery({
     variables: {
       id: Number.parseInt(match.params.id, 10),
     },

--- a/app/javascript/FormAdmin/FormEditorContexts.ts
+++ b/app/javascript/FormAdmin/FormEditorContexts.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormEditorQueryQuery } from './queries.generated';
+import { FormEditorQueryData } from './queries.generated';
 import { FormType, TimezoneMode } from '../graphqlTypes.generated';
 import type {
   AgeRestrictionsFormItem,
@@ -18,8 +18,8 @@ import type {
 } from './FormItemUtils';
 import FormTypes from '../../../config/form_types.json';
 
-export type FormEditorForm = Omit<FormEditorQueryQuery['form'], 'form_sections'> & {
-  form_sections: (Omit<FormEditorQueryQuery['form']['form_sections'][0], 'form_items'> & {
+export type FormEditorForm = Omit<FormEditorQueryData['form'], 'form_sections'> & {
+  form_sections: (Omit<FormEditorQueryData['form']['form_sections'][0], 'form_items'> & {
     form_items: TypedFormItem[];
   })[];
 };
@@ -36,7 +36,7 @@ export type FormEditorFormItem =
   | ParsedFormItemWithGeneratedIds<WithRequiredProperties<TimespanFormItem>>;
 
 export type FormEditorContextValue = {
-  convention: NonNullable<FormEditorQueryQuery['convention']>;
+  convention: NonNullable<FormEditorQueryData['convention']>;
   currentSection?: FormEditorForm['form_sections'][0];
   form: FormEditorForm;
   formType: FormTypeDefinition;

--- a/app/javascript/FormAdmin/FormItemUtils.ts
+++ b/app/javascript/FormAdmin/FormItemUtils.ts
@@ -8,7 +8,7 @@ import {
   CommonFormSectionFieldsFragment,
   CommonFormItemFieldsFragment,
 } from '../Models/commonFormFragments.generated';
-import { FormEditorQueryQuery, FormEditorFormItemFieldsFragment } from './queries.generated';
+import { FormEditorQueryData, FormEditorFormItemFieldsFragment } from './queries.generated';
 import {
   TimeblockDefinition,
   TimeblockOmission,
@@ -382,7 +382,7 @@ export function mutationUpdaterForFormSection<ResultDataType>(
   updater: (section: CommonFormSectionFieldsFragment, mutationResultData: ResultDataType) => void,
 ) {
   return (proxy: ApolloCache<any>, mutationResultData: ResultDataType) => {
-    const data = proxy.readQuery<FormEditorQueryQuery>({
+    const data = proxy.readQuery<FormEditorQueryData>({
       query: FormEditorQuery,
       variables: { id: formId },
     });

--- a/app/javascript/FormAdmin/FormJSONEditor.tsx
+++ b/app/javascript/FormAdmin/FormJSONEditor.tsx
@@ -11,7 +11,7 @@ import useAsyncFunction from '../useAsyncFunction';
 import { useCreateMutation } from '../MutationUtils';
 import usePageTitle from '../usePageTitle';
 import BootstrapFormSelect from '../BuiltInFormControls/BootstrapFormSelect';
-import { useFormAdminQueryQuery } from './queries.generated';
+import { useFormAdminQuery } from './queries.generated';
 import { LoadSingleValueFromCollectionWrapper } from '../GraphqlLoadingWrappers';
 import { useUpdateFormWithJsonMutation } from './mutations.generated';
 
@@ -30,7 +30,7 @@ function formDataFromJSON(json: string): EditingFormJSONData {
 }
 
 export default LoadSingleValueFromCollectionWrapper(
-  useFormAdminQueryQuery,
+  useFormAdminQuery,
   (data, id) => data.convention.forms.find((form) => form.id.toString(10) === id),
   function FormJSONEditor({ value: initialForm }) {
     const history = useHistory();

--- a/app/javascript/FormAdmin/FormSectionNav.tsx
+++ b/app/javascript/FormAdmin/FormSectionNav.tsx
@@ -11,13 +11,13 @@ import useUniqueId from '../useUniqueId';
 import {
   useMoveFormSectionMutation,
   CreateFormSectionDocument,
-  CreateFormSectionMutation,
+  CreateFormSectionMutationData,
   CreateFormSectionMutationVariables,
 } from './mutations.generated';
 import {
   FormEditorQueryDocument,
-  FormEditorQueryQuery,
-  FormEditorQueryQueryVariables,
+  FormEditorQueryData,
+  FormEditorQueryVariables,
 } from './queries.generated';
 
 function FormSectionNav() {
@@ -28,10 +28,10 @@ function FormSectionNav() {
   const { form } = useContext(FormEditorContext);
   const [moveFormSection] = useMoveFormSectionMutation();
   const addFormSection = useCreateMutation<
-    FormEditorQueryQuery,
-    FormEditorQueryQueryVariables,
+    FormEditorQueryData,
+    FormEditorQueryVariables,
     CreateFormSectionMutationVariables,
-    CreateFormSectionMutation
+    CreateFormSectionMutationData
   >(CreateFormSectionDocument, {
     query: FormEditorQueryDocument,
     queryVariables: { id: form.id },

--- a/app/javascript/FormAdmin/NewFormModal.tsx
+++ b/app/javascript/FormAdmin/NewFormModal.tsx
@@ -13,8 +13,8 @@ import FormTypes from '../../../config/form_types.json';
 import ErrorDisplay from '../ErrorDisplay';
 import useAsyncFunction from '../useAsyncFunction';
 import { useCreateMutation } from '../MutationUtils';
-import { FormAdminQueryQuery, FormAdminQueryQueryVariables } from './queries.generated';
-import { CreateFormMutation, CreateFormMutationVariables } from './mutations.generated';
+import { FormAdminQueryData, FormAdminQueryVariables } from './queries.generated';
+import { CreateFormMutationData, CreateFormMutationVariables } from './mutations.generated';
 
 export type NewFormModalProps = {
   visible: boolean;
@@ -26,10 +26,10 @@ function NewFormModal({ visible, close }: NewFormModalProps) {
   const [title, setTitle] = useState('');
   const [formType, setFormType] = useState('');
   const createFormMutate = useCreateMutation<
-    FormAdminQueryQuery,
-    FormAdminQueryQueryVariables,
+    FormAdminQueryData,
+    FormAdminQueryVariables,
     CreateFormMutationVariables,
-    CreateFormMutation
+    CreateFormMutationData
   >(CreateForm, {
     query: FormAdminQuery,
     arrayPath: ['convention', 'forms'],

--- a/app/javascript/FormAdmin/mutations.generated.ts
+++ b/app/javascript/FormAdmin/mutations.generated.ts
@@ -7,13 +7,14 @@ import { gql } from '@apollo/client';
 import { FormFieldsFragmentDoc, FormEditorDataFragmentDoc, FormEditorFormItemFieldsFragmentDoc } from './queries.generated';
 import { CommonFormSectionFieldsFragmentDoc } from '../Models/commonFormFragments.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateFormWithJsonMutationVariables = Types.Exact<{
   formJSON: Types.Scalars['String'];
   formType: Types.FormType;
 }>;
 
 
-export type CreateFormWithJsonMutation = (
+export type CreateFormWithJsonMutationData = (
   { __typename: 'Mutation' }
   & { createFormWithJSON?: Types.Maybe<(
     { __typename: 'CreateFormWithJSONPayload' }
@@ -31,7 +32,7 @@ export type UpdateFormWithJsonMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateFormWithJsonMutation = (
+export type UpdateFormWithJsonMutationData = (
   { __typename: 'Mutation' }
   & { updateFormWithJSON?: Types.Maybe<(
     { __typename: 'UpdateFormWithJSONPayload' }
@@ -49,7 +50,7 @@ export type CreateFormMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateFormMutation = (
+export type CreateFormMutationData = (
   { __typename: 'Mutation' }
   & { createForm?: Types.Maybe<(
     { __typename: 'CreateFormPayload' }
@@ -67,7 +68,7 @@ export type UpdateFormMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateFormMutation = (
+export type UpdateFormMutationData = (
   { __typename: 'Mutation' }
   & { updateForm?: Types.Maybe<(
     { __typename: 'UpdateFormPayload' }
@@ -84,7 +85,7 @@ export type DeleteFormMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteFormMutation = (
+export type DeleteFormMutationData = (
   { __typename: 'Mutation' }
   & { deleteForm?: Types.Maybe<(
     { __typename: 'DeleteFormPayload' }
@@ -98,7 +99,7 @@ export type CreateFormSectionMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateFormSectionMutation = (
+export type CreateFormSectionMutationData = (
   { __typename: 'Mutation' }
   & { createFormSection?: Types.Maybe<(
     { __typename: 'CreateFormSectionPayload' }
@@ -121,7 +122,7 @@ export type UpdateFormSectionMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateFormSectionMutation = (
+export type UpdateFormSectionMutationData = (
   { __typename: 'Mutation' }
   & { updateFormSection?: Types.Maybe<(
     { __typename: 'UpdateFormSectionPayload' }
@@ -143,7 +144,7 @@ export type DeleteFormSectionMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteFormSectionMutation = (
+export type DeleteFormSectionMutationData = (
   { __typename: 'Mutation' }
   & { deleteFormSection?: Types.Maybe<(
     { __typename: 'DeleteFormSectionPayload' }
@@ -157,7 +158,7 @@ export type MoveFormSectionMutationVariables = Types.Exact<{
 }>;
 
 
-export type MoveFormSectionMutation = (
+export type MoveFormSectionMutationData = (
   { __typename: 'Mutation' }
   & { moveFormSection?: Types.Maybe<(
     { __typename: 'MoveFormSectionPayload' }
@@ -175,7 +176,7 @@ export type CreateFormItemMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateFormItemMutation = (
+export type CreateFormItemMutationData = (
   { __typename: 'Mutation' }
   & { createFormItem?: Types.Maybe<(
     { __typename: 'CreateFormItemPayload' }
@@ -193,7 +194,7 @@ export type UpdateFormItemMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateFormItemMutation = (
+export type UpdateFormItemMutationData = (
   { __typename: 'Mutation' }
   & { updateFormItem?: Types.Maybe<(
     { __typename: 'UpdateFormItemPayload' }
@@ -210,7 +211,7 @@ export type DeleteFormItemMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteFormItemMutation = (
+export type DeleteFormItemMutationData = (
   { __typename: 'Mutation' }
   & { deleteFormItem?: Types.Maybe<(
     { __typename: 'DeleteFormItemPayload' }
@@ -225,7 +226,7 @@ export type MoveFormItemMutationVariables = Types.Exact<{
 }>;
 
 
-export type MoveFormItemMutation = (
+export type MoveFormItemMutationData = (
   { __typename: 'Mutation' }
   & { moveFormItem?: Types.Maybe<(
     { __typename: 'MoveFormItemPayload' }
@@ -252,7 +253,7 @@ export const CreateFormWithJsonDocument = gql`
   }
 }
     ${FormFieldsFragmentDoc}`;
-export type CreateFormWithJsonMutationFn = Apollo.MutationFunction<CreateFormWithJsonMutation, CreateFormWithJsonMutationVariables>;
+export type CreateFormWithJsonMutationFn = Apollo.MutationFunction<CreateFormWithJsonMutationData, CreateFormWithJsonMutationVariables>;
 
 /**
  * __useCreateFormWithJsonMutation__
@@ -272,12 +273,13 @@ export type CreateFormWithJsonMutationFn = Apollo.MutationFunction<CreateFormWit
  *   },
  * });
  */
-export function useCreateFormWithJsonMutation(baseOptions?: Apollo.MutationHookOptions<CreateFormWithJsonMutation, CreateFormWithJsonMutationVariables>) {
-        return Apollo.useMutation<CreateFormWithJsonMutation, CreateFormWithJsonMutationVariables>(CreateFormWithJsonDocument, baseOptions);
+export function useCreateFormWithJsonMutation(baseOptions?: Apollo.MutationHookOptions<CreateFormWithJsonMutationData, CreateFormWithJsonMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateFormWithJsonMutationData, CreateFormWithJsonMutationVariables>(CreateFormWithJsonDocument, options);
       }
 export type CreateFormWithJsonMutationHookResult = ReturnType<typeof useCreateFormWithJsonMutation>;
-export type CreateFormWithJsonMutationResult = Apollo.MutationResult<CreateFormWithJsonMutation>;
-export type CreateFormWithJsonMutationOptions = Apollo.BaseMutationOptions<CreateFormWithJsonMutation, CreateFormWithJsonMutationVariables>;
+export type CreateFormWithJsonMutationResult = Apollo.MutationResult<CreateFormWithJsonMutationData>;
+export type CreateFormWithJsonMutationOptions = Apollo.BaseMutationOptions<CreateFormWithJsonMutationData, CreateFormWithJsonMutationVariables>;
 export const UpdateFormWithJsonDocument = gql`
     mutation UpdateFormWithJSON($id: Int!, $formJSON: String!) {
   updateFormWithJSON(input: {id: $id, form_json: $formJSON}) {
@@ -288,7 +290,7 @@ export const UpdateFormWithJsonDocument = gql`
   }
 }
     ${FormFieldsFragmentDoc}`;
-export type UpdateFormWithJsonMutationFn = Apollo.MutationFunction<UpdateFormWithJsonMutation, UpdateFormWithJsonMutationVariables>;
+export type UpdateFormWithJsonMutationFn = Apollo.MutationFunction<UpdateFormWithJsonMutationData, UpdateFormWithJsonMutationVariables>;
 
 /**
  * __useUpdateFormWithJsonMutation__
@@ -308,12 +310,13 @@ export type UpdateFormWithJsonMutationFn = Apollo.MutationFunction<UpdateFormWit
  *   },
  * });
  */
-export function useUpdateFormWithJsonMutation(baseOptions?: Apollo.MutationHookOptions<UpdateFormWithJsonMutation, UpdateFormWithJsonMutationVariables>) {
-        return Apollo.useMutation<UpdateFormWithJsonMutation, UpdateFormWithJsonMutationVariables>(UpdateFormWithJsonDocument, baseOptions);
+export function useUpdateFormWithJsonMutation(baseOptions?: Apollo.MutationHookOptions<UpdateFormWithJsonMutationData, UpdateFormWithJsonMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateFormWithJsonMutationData, UpdateFormWithJsonMutationVariables>(UpdateFormWithJsonDocument, options);
       }
 export type UpdateFormWithJsonMutationHookResult = ReturnType<typeof useUpdateFormWithJsonMutation>;
-export type UpdateFormWithJsonMutationResult = Apollo.MutationResult<UpdateFormWithJsonMutation>;
-export type UpdateFormWithJsonMutationOptions = Apollo.BaseMutationOptions<UpdateFormWithJsonMutation, UpdateFormWithJsonMutationVariables>;
+export type UpdateFormWithJsonMutationResult = Apollo.MutationResult<UpdateFormWithJsonMutationData>;
+export type UpdateFormWithJsonMutationOptions = Apollo.BaseMutationOptions<UpdateFormWithJsonMutationData, UpdateFormWithJsonMutationVariables>;
 export const CreateFormDocument = gql`
     mutation CreateForm($form: FormInput!, $formType: FormType!) {
   createForm(input: {form: $form, form_type: $formType}) {
@@ -324,7 +327,7 @@ export const CreateFormDocument = gql`
   }
 }
     ${FormFieldsFragmentDoc}`;
-export type CreateFormMutationFn = Apollo.MutationFunction<CreateFormMutation, CreateFormMutationVariables>;
+export type CreateFormMutationFn = Apollo.MutationFunction<CreateFormMutationData, CreateFormMutationVariables>;
 
 /**
  * __useCreateFormMutation__
@@ -344,12 +347,13 @@ export type CreateFormMutationFn = Apollo.MutationFunction<CreateFormMutation, C
  *   },
  * });
  */
-export function useCreateFormMutation(baseOptions?: Apollo.MutationHookOptions<CreateFormMutation, CreateFormMutationVariables>) {
-        return Apollo.useMutation<CreateFormMutation, CreateFormMutationVariables>(CreateFormDocument, baseOptions);
+export function useCreateFormMutation(baseOptions?: Apollo.MutationHookOptions<CreateFormMutationData, CreateFormMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateFormMutationData, CreateFormMutationVariables>(CreateFormDocument, options);
       }
 export type CreateFormMutationHookResult = ReturnType<typeof useCreateFormMutation>;
-export type CreateFormMutationResult = Apollo.MutationResult<CreateFormMutation>;
-export type CreateFormMutationOptions = Apollo.BaseMutationOptions<CreateFormMutation, CreateFormMutationVariables>;
+export type CreateFormMutationResult = Apollo.MutationResult<CreateFormMutationData>;
+export type CreateFormMutationOptions = Apollo.BaseMutationOptions<CreateFormMutationData, CreateFormMutationVariables>;
 export const UpdateFormDocument = gql`
     mutation UpdateForm($id: Int!, $form: FormInput!) {
   updateForm(input: {id: $id, form: $form}) {
@@ -360,7 +364,7 @@ export const UpdateFormDocument = gql`
   }
 }
     ${FormEditorDataFragmentDoc}`;
-export type UpdateFormMutationFn = Apollo.MutationFunction<UpdateFormMutation, UpdateFormMutationVariables>;
+export type UpdateFormMutationFn = Apollo.MutationFunction<UpdateFormMutationData, UpdateFormMutationVariables>;
 
 /**
  * __useUpdateFormMutation__
@@ -380,12 +384,13 @@ export type UpdateFormMutationFn = Apollo.MutationFunction<UpdateFormMutation, U
  *   },
  * });
  */
-export function useUpdateFormMutation(baseOptions?: Apollo.MutationHookOptions<UpdateFormMutation, UpdateFormMutationVariables>) {
-        return Apollo.useMutation<UpdateFormMutation, UpdateFormMutationVariables>(UpdateFormDocument, baseOptions);
+export function useUpdateFormMutation(baseOptions?: Apollo.MutationHookOptions<UpdateFormMutationData, UpdateFormMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateFormMutationData, UpdateFormMutationVariables>(UpdateFormDocument, options);
       }
 export type UpdateFormMutationHookResult = ReturnType<typeof useUpdateFormMutation>;
-export type UpdateFormMutationResult = Apollo.MutationResult<UpdateFormMutation>;
-export type UpdateFormMutationOptions = Apollo.BaseMutationOptions<UpdateFormMutation, UpdateFormMutationVariables>;
+export type UpdateFormMutationResult = Apollo.MutationResult<UpdateFormMutationData>;
+export type UpdateFormMutationOptions = Apollo.BaseMutationOptions<UpdateFormMutationData, UpdateFormMutationVariables>;
 export const DeleteFormDocument = gql`
     mutation DeleteForm($id: Int!) {
   deleteForm(input: {id: $id}) {
@@ -393,7 +398,7 @@ export const DeleteFormDocument = gql`
   }
 }
     `;
-export type DeleteFormMutationFn = Apollo.MutationFunction<DeleteFormMutation, DeleteFormMutationVariables>;
+export type DeleteFormMutationFn = Apollo.MutationFunction<DeleteFormMutationData, DeleteFormMutationVariables>;
 
 /**
  * __useDeleteFormMutation__
@@ -412,12 +417,13 @@ export type DeleteFormMutationFn = Apollo.MutationFunction<DeleteFormMutation, D
  *   },
  * });
  */
-export function useDeleteFormMutation(baseOptions?: Apollo.MutationHookOptions<DeleteFormMutation, DeleteFormMutationVariables>) {
-        return Apollo.useMutation<DeleteFormMutation, DeleteFormMutationVariables>(DeleteFormDocument, baseOptions);
+export function useDeleteFormMutation(baseOptions?: Apollo.MutationHookOptions<DeleteFormMutationData, DeleteFormMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteFormMutationData, DeleteFormMutationVariables>(DeleteFormDocument, options);
       }
 export type DeleteFormMutationHookResult = ReturnType<typeof useDeleteFormMutation>;
-export type DeleteFormMutationResult = Apollo.MutationResult<DeleteFormMutation>;
-export type DeleteFormMutationOptions = Apollo.BaseMutationOptions<DeleteFormMutation, DeleteFormMutationVariables>;
+export type DeleteFormMutationResult = Apollo.MutationResult<DeleteFormMutationData>;
+export type DeleteFormMutationOptions = Apollo.BaseMutationOptions<DeleteFormMutationData, DeleteFormMutationVariables>;
 export const CreateFormSectionDocument = gql`
     mutation CreateFormSection($formId: Int!, $formSection: FormSectionInput!) {
   createFormSection(input: {form_id: $formId, form_section: $formSection}) {
@@ -433,7 +439,7 @@ export const CreateFormSectionDocument = gql`
 }
     ${CommonFormSectionFieldsFragmentDoc}
 ${FormEditorFormItemFieldsFragmentDoc}`;
-export type CreateFormSectionMutationFn = Apollo.MutationFunction<CreateFormSectionMutation, CreateFormSectionMutationVariables>;
+export type CreateFormSectionMutationFn = Apollo.MutationFunction<CreateFormSectionMutationData, CreateFormSectionMutationVariables>;
 
 /**
  * __useCreateFormSectionMutation__
@@ -453,12 +459,13 @@ export type CreateFormSectionMutationFn = Apollo.MutationFunction<CreateFormSect
  *   },
  * });
  */
-export function useCreateFormSectionMutation(baseOptions?: Apollo.MutationHookOptions<CreateFormSectionMutation, CreateFormSectionMutationVariables>) {
-        return Apollo.useMutation<CreateFormSectionMutation, CreateFormSectionMutationVariables>(CreateFormSectionDocument, baseOptions);
+export function useCreateFormSectionMutation(baseOptions?: Apollo.MutationHookOptions<CreateFormSectionMutationData, CreateFormSectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateFormSectionMutationData, CreateFormSectionMutationVariables>(CreateFormSectionDocument, options);
       }
 export type CreateFormSectionMutationHookResult = ReturnType<typeof useCreateFormSectionMutation>;
-export type CreateFormSectionMutationResult = Apollo.MutationResult<CreateFormSectionMutation>;
-export type CreateFormSectionMutationOptions = Apollo.BaseMutationOptions<CreateFormSectionMutation, CreateFormSectionMutationVariables>;
+export type CreateFormSectionMutationResult = Apollo.MutationResult<CreateFormSectionMutationData>;
+export type CreateFormSectionMutationOptions = Apollo.BaseMutationOptions<CreateFormSectionMutationData, CreateFormSectionMutationVariables>;
 export const UpdateFormSectionDocument = gql`
     mutation UpdateFormSection($id: Int!, $formSection: FormSectionInput!) {
   updateFormSection(input: {id: $id, form_section: $formSection}) {
@@ -474,7 +481,7 @@ export const UpdateFormSectionDocument = gql`
 }
     ${CommonFormSectionFieldsFragmentDoc}
 ${FormEditorFormItemFieldsFragmentDoc}`;
-export type UpdateFormSectionMutationFn = Apollo.MutationFunction<UpdateFormSectionMutation, UpdateFormSectionMutationVariables>;
+export type UpdateFormSectionMutationFn = Apollo.MutationFunction<UpdateFormSectionMutationData, UpdateFormSectionMutationVariables>;
 
 /**
  * __useUpdateFormSectionMutation__
@@ -494,12 +501,13 @@ export type UpdateFormSectionMutationFn = Apollo.MutationFunction<UpdateFormSect
  *   },
  * });
  */
-export function useUpdateFormSectionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateFormSectionMutation, UpdateFormSectionMutationVariables>) {
-        return Apollo.useMutation<UpdateFormSectionMutation, UpdateFormSectionMutationVariables>(UpdateFormSectionDocument, baseOptions);
+export function useUpdateFormSectionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateFormSectionMutationData, UpdateFormSectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateFormSectionMutationData, UpdateFormSectionMutationVariables>(UpdateFormSectionDocument, options);
       }
 export type UpdateFormSectionMutationHookResult = ReturnType<typeof useUpdateFormSectionMutation>;
-export type UpdateFormSectionMutationResult = Apollo.MutationResult<UpdateFormSectionMutation>;
-export type UpdateFormSectionMutationOptions = Apollo.BaseMutationOptions<UpdateFormSectionMutation, UpdateFormSectionMutationVariables>;
+export type UpdateFormSectionMutationResult = Apollo.MutationResult<UpdateFormSectionMutationData>;
+export type UpdateFormSectionMutationOptions = Apollo.BaseMutationOptions<UpdateFormSectionMutationData, UpdateFormSectionMutationVariables>;
 export const DeleteFormSectionDocument = gql`
     mutation DeleteFormSection($id: Int!) {
   deleteFormSection(input: {id: $id}) {
@@ -507,7 +515,7 @@ export const DeleteFormSectionDocument = gql`
   }
 }
     `;
-export type DeleteFormSectionMutationFn = Apollo.MutationFunction<DeleteFormSectionMutation, DeleteFormSectionMutationVariables>;
+export type DeleteFormSectionMutationFn = Apollo.MutationFunction<DeleteFormSectionMutationData, DeleteFormSectionMutationVariables>;
 
 /**
  * __useDeleteFormSectionMutation__
@@ -526,12 +534,13 @@ export type DeleteFormSectionMutationFn = Apollo.MutationFunction<DeleteFormSect
  *   },
  * });
  */
-export function useDeleteFormSectionMutation(baseOptions?: Apollo.MutationHookOptions<DeleteFormSectionMutation, DeleteFormSectionMutationVariables>) {
-        return Apollo.useMutation<DeleteFormSectionMutation, DeleteFormSectionMutationVariables>(DeleteFormSectionDocument, baseOptions);
+export function useDeleteFormSectionMutation(baseOptions?: Apollo.MutationHookOptions<DeleteFormSectionMutationData, DeleteFormSectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteFormSectionMutationData, DeleteFormSectionMutationVariables>(DeleteFormSectionDocument, options);
       }
 export type DeleteFormSectionMutationHookResult = ReturnType<typeof useDeleteFormSectionMutation>;
-export type DeleteFormSectionMutationResult = Apollo.MutationResult<DeleteFormSectionMutation>;
-export type DeleteFormSectionMutationOptions = Apollo.BaseMutationOptions<DeleteFormSectionMutation, DeleteFormSectionMutationVariables>;
+export type DeleteFormSectionMutationResult = Apollo.MutationResult<DeleteFormSectionMutationData>;
+export type DeleteFormSectionMutationOptions = Apollo.BaseMutationOptions<DeleteFormSectionMutationData, DeleteFormSectionMutationVariables>;
 export const MoveFormSectionDocument = gql`
     mutation MoveFormSection($id: Int!, $destinationIndex: Int!) {
   moveFormSection(input: {id: $id, destination_index: $destinationIndex}) {
@@ -542,7 +551,7 @@ export const MoveFormSectionDocument = gql`
   }
 }
     ${FormEditorDataFragmentDoc}`;
-export type MoveFormSectionMutationFn = Apollo.MutationFunction<MoveFormSectionMutation, MoveFormSectionMutationVariables>;
+export type MoveFormSectionMutationFn = Apollo.MutationFunction<MoveFormSectionMutationData, MoveFormSectionMutationVariables>;
 
 /**
  * __useMoveFormSectionMutation__
@@ -562,12 +571,13 @@ export type MoveFormSectionMutationFn = Apollo.MutationFunction<MoveFormSectionM
  *   },
  * });
  */
-export function useMoveFormSectionMutation(baseOptions?: Apollo.MutationHookOptions<MoveFormSectionMutation, MoveFormSectionMutationVariables>) {
-        return Apollo.useMutation<MoveFormSectionMutation, MoveFormSectionMutationVariables>(MoveFormSectionDocument, baseOptions);
+export function useMoveFormSectionMutation(baseOptions?: Apollo.MutationHookOptions<MoveFormSectionMutationData, MoveFormSectionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<MoveFormSectionMutationData, MoveFormSectionMutationVariables>(MoveFormSectionDocument, options);
       }
 export type MoveFormSectionMutationHookResult = ReturnType<typeof useMoveFormSectionMutation>;
-export type MoveFormSectionMutationResult = Apollo.MutationResult<MoveFormSectionMutation>;
-export type MoveFormSectionMutationOptions = Apollo.BaseMutationOptions<MoveFormSectionMutation, MoveFormSectionMutationVariables>;
+export type MoveFormSectionMutationResult = Apollo.MutationResult<MoveFormSectionMutationData>;
+export type MoveFormSectionMutationOptions = Apollo.BaseMutationOptions<MoveFormSectionMutationData, MoveFormSectionMutationVariables>;
 export const CreateFormItemDocument = gql`
     mutation CreateFormItem($formSectionId: Int!, $formItem: FormItemInput!) {
   createFormItem(input: {form_section_id: $formSectionId, form_item: $formItem}) {
@@ -578,7 +588,7 @@ export const CreateFormItemDocument = gql`
   }
 }
     ${FormEditorFormItemFieldsFragmentDoc}`;
-export type CreateFormItemMutationFn = Apollo.MutationFunction<CreateFormItemMutation, CreateFormItemMutationVariables>;
+export type CreateFormItemMutationFn = Apollo.MutationFunction<CreateFormItemMutationData, CreateFormItemMutationVariables>;
 
 /**
  * __useCreateFormItemMutation__
@@ -598,12 +608,13 @@ export type CreateFormItemMutationFn = Apollo.MutationFunction<CreateFormItemMut
  *   },
  * });
  */
-export function useCreateFormItemMutation(baseOptions?: Apollo.MutationHookOptions<CreateFormItemMutation, CreateFormItemMutationVariables>) {
-        return Apollo.useMutation<CreateFormItemMutation, CreateFormItemMutationVariables>(CreateFormItemDocument, baseOptions);
+export function useCreateFormItemMutation(baseOptions?: Apollo.MutationHookOptions<CreateFormItemMutationData, CreateFormItemMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateFormItemMutationData, CreateFormItemMutationVariables>(CreateFormItemDocument, options);
       }
 export type CreateFormItemMutationHookResult = ReturnType<typeof useCreateFormItemMutation>;
-export type CreateFormItemMutationResult = Apollo.MutationResult<CreateFormItemMutation>;
-export type CreateFormItemMutationOptions = Apollo.BaseMutationOptions<CreateFormItemMutation, CreateFormItemMutationVariables>;
+export type CreateFormItemMutationResult = Apollo.MutationResult<CreateFormItemMutationData>;
+export type CreateFormItemMutationOptions = Apollo.BaseMutationOptions<CreateFormItemMutationData, CreateFormItemMutationVariables>;
 export const UpdateFormItemDocument = gql`
     mutation UpdateFormItem($id: Int!, $formItem: FormItemInput!) {
   updateFormItem(input: {id: $id, form_item: $formItem}) {
@@ -614,7 +625,7 @@ export const UpdateFormItemDocument = gql`
   }
 }
     ${FormEditorFormItemFieldsFragmentDoc}`;
-export type UpdateFormItemMutationFn = Apollo.MutationFunction<UpdateFormItemMutation, UpdateFormItemMutationVariables>;
+export type UpdateFormItemMutationFn = Apollo.MutationFunction<UpdateFormItemMutationData, UpdateFormItemMutationVariables>;
 
 /**
  * __useUpdateFormItemMutation__
@@ -634,12 +645,13 @@ export type UpdateFormItemMutationFn = Apollo.MutationFunction<UpdateFormItemMut
  *   },
  * });
  */
-export function useUpdateFormItemMutation(baseOptions?: Apollo.MutationHookOptions<UpdateFormItemMutation, UpdateFormItemMutationVariables>) {
-        return Apollo.useMutation<UpdateFormItemMutation, UpdateFormItemMutationVariables>(UpdateFormItemDocument, baseOptions);
+export function useUpdateFormItemMutation(baseOptions?: Apollo.MutationHookOptions<UpdateFormItemMutationData, UpdateFormItemMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateFormItemMutationData, UpdateFormItemMutationVariables>(UpdateFormItemDocument, options);
       }
 export type UpdateFormItemMutationHookResult = ReturnType<typeof useUpdateFormItemMutation>;
-export type UpdateFormItemMutationResult = Apollo.MutationResult<UpdateFormItemMutation>;
-export type UpdateFormItemMutationOptions = Apollo.BaseMutationOptions<UpdateFormItemMutation, UpdateFormItemMutationVariables>;
+export type UpdateFormItemMutationResult = Apollo.MutationResult<UpdateFormItemMutationData>;
+export type UpdateFormItemMutationOptions = Apollo.BaseMutationOptions<UpdateFormItemMutationData, UpdateFormItemMutationVariables>;
 export const DeleteFormItemDocument = gql`
     mutation DeleteFormItem($id: Int!) {
   deleteFormItem(input: {id: $id}) {
@@ -647,7 +659,7 @@ export const DeleteFormItemDocument = gql`
   }
 }
     `;
-export type DeleteFormItemMutationFn = Apollo.MutationFunction<DeleteFormItemMutation, DeleteFormItemMutationVariables>;
+export type DeleteFormItemMutationFn = Apollo.MutationFunction<DeleteFormItemMutationData, DeleteFormItemMutationVariables>;
 
 /**
  * __useDeleteFormItemMutation__
@@ -666,12 +678,13 @@ export type DeleteFormItemMutationFn = Apollo.MutationFunction<DeleteFormItemMut
  *   },
  * });
  */
-export function useDeleteFormItemMutation(baseOptions?: Apollo.MutationHookOptions<DeleteFormItemMutation, DeleteFormItemMutationVariables>) {
-        return Apollo.useMutation<DeleteFormItemMutation, DeleteFormItemMutationVariables>(DeleteFormItemDocument, baseOptions);
+export function useDeleteFormItemMutation(baseOptions?: Apollo.MutationHookOptions<DeleteFormItemMutationData, DeleteFormItemMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteFormItemMutationData, DeleteFormItemMutationVariables>(DeleteFormItemDocument, options);
       }
 export type DeleteFormItemMutationHookResult = ReturnType<typeof useDeleteFormItemMutation>;
-export type DeleteFormItemMutationResult = Apollo.MutationResult<DeleteFormItemMutation>;
-export type DeleteFormItemMutationOptions = Apollo.BaseMutationOptions<DeleteFormItemMutation, DeleteFormItemMutationVariables>;
+export type DeleteFormItemMutationResult = Apollo.MutationResult<DeleteFormItemMutationData>;
+export type DeleteFormItemMutationOptions = Apollo.BaseMutationOptions<DeleteFormItemMutationData, DeleteFormItemMutationVariables>;
 export const MoveFormItemDocument = gql`
     mutation MoveFormItem($id: Int!, $formSectionId: Int!, $destinationIndex: Int) {
   moveFormItem(
@@ -687,7 +700,7 @@ export const MoveFormItemDocument = gql`
   }
 }
     ${FormEditorFormItemFieldsFragmentDoc}`;
-export type MoveFormItemMutationFn = Apollo.MutationFunction<MoveFormItemMutation, MoveFormItemMutationVariables>;
+export type MoveFormItemMutationFn = Apollo.MutationFunction<MoveFormItemMutationData, MoveFormItemMutationVariables>;
 
 /**
  * __useMoveFormItemMutation__
@@ -708,9 +721,10 @@ export type MoveFormItemMutationFn = Apollo.MutationFunction<MoveFormItemMutatio
  *   },
  * });
  */
-export function useMoveFormItemMutation(baseOptions?: Apollo.MutationHookOptions<MoveFormItemMutation, MoveFormItemMutationVariables>) {
-        return Apollo.useMutation<MoveFormItemMutation, MoveFormItemMutationVariables>(MoveFormItemDocument, baseOptions);
+export function useMoveFormItemMutation(baseOptions?: Apollo.MutationHookOptions<MoveFormItemMutationData, MoveFormItemMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<MoveFormItemMutationData, MoveFormItemMutationVariables>(MoveFormItemDocument, options);
       }
 export type MoveFormItemMutationHookResult = ReturnType<typeof useMoveFormItemMutation>;
-export type MoveFormItemMutationResult = Apollo.MutationResult<MoveFormItemMutation>;
-export type MoveFormItemMutationOptions = Apollo.BaseMutationOptions<MoveFormItemMutation, MoveFormItemMutationVariables>;
+export type MoveFormItemMutationResult = Apollo.MutationResult<MoveFormItemMutationData>;
+export type MoveFormItemMutationOptions = Apollo.BaseMutationOptions<MoveFormItemMutationData, MoveFormItemMutationVariables>;

--- a/app/javascript/FormAdmin/queries.generated.ts
+++ b/app/javascript/FormAdmin/queries.generated.ts
@@ -5,6 +5,7 @@ import { CommonFormItemFieldsFragment, CommonFormFieldsFragment, CommonFormSecti
 import { gql } from '@apollo/client';
 import { CommonFormItemFieldsFragmentDoc, CommonFormFieldsFragmentDoc, CommonFormSectionFieldsFragmentDoc } from '../Models/commonFormFragments.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type FormFieldsFragment = (
   { __typename: 'Form' }
   & Pick<Types.Form, 'id' | 'title' | 'form_type' | 'export_json'>
@@ -41,10 +42,10 @@ export type FormEditorDataFragment = (
   & CommonFormFieldsFragment
 );
 
-export type FormAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type FormAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type FormAdminQueryQuery = (
+export type FormAdminQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -57,12 +58,12 @@ export type FormAdminQueryQuery = (
   ) }
 );
 
-export type FormEditorQueryQueryVariables = Types.Exact<{
+export type FormEditorQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type FormEditorQueryQuery = (
+export type FormEditorQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -74,13 +75,13 @@ export type FormEditorQueryQuery = (
   ) }
 );
 
-export type PreviewFormItemQueryQueryVariables = Types.Exact<{
+export type PreviewFormItemQueryVariables = Types.Exact<{
   formSectionId: Types.Scalars['Int'];
   formItem: Types.FormItemInput;
 }>;
 
 
-export type PreviewFormItemQueryQuery = (
+export type PreviewFormItemQueryData = (
   { __typename: 'Query' }
   & { previewFormItem: (
     { __typename: 'FormItem' }
@@ -146,29 +147,31 @@ export const FormAdminQueryDocument = gql`
     ${FormFieldsFragmentDoc}`;
 
 /**
- * __useFormAdminQueryQuery__
+ * __useFormAdminQuery__
  *
- * To run a query within a React component, call `useFormAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useFormAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useFormAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFormAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useFormAdminQueryQuery({
+ * const { data, loading, error } = useFormAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useFormAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<FormAdminQueryQuery, FormAdminQueryQueryVariables>) {
-        return Apollo.useQuery<FormAdminQueryQuery, FormAdminQueryQueryVariables>(FormAdminQueryDocument, baseOptions);
+export function useFormAdminQuery(baseOptions?: Apollo.QueryHookOptions<FormAdminQueryData, FormAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<FormAdminQueryData, FormAdminQueryVariables>(FormAdminQueryDocument, options);
       }
-export function useFormAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FormAdminQueryQuery, FormAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<FormAdminQueryQuery, FormAdminQueryQueryVariables>(FormAdminQueryDocument, baseOptions);
+export function useFormAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FormAdminQueryData, FormAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<FormAdminQueryData, FormAdminQueryVariables>(FormAdminQueryDocument, options);
         }
-export type FormAdminQueryQueryHookResult = ReturnType<typeof useFormAdminQueryQuery>;
+export type FormAdminQueryHookResult = ReturnType<typeof useFormAdminQuery>;
 export type FormAdminQueryLazyQueryHookResult = ReturnType<typeof useFormAdminQueryLazyQuery>;
-export type FormAdminQueryQueryResult = Apollo.QueryResult<FormAdminQueryQuery, FormAdminQueryQueryVariables>;
+export type FormAdminQueryDataResult = Apollo.QueryResult<FormAdminQueryData, FormAdminQueryVariables>;
 export const FormEditorQueryDocument = gql`
     query FormEditorQuery($id: Int!) {
   convention: assertConvention {
@@ -188,30 +191,32 @@ export const FormEditorQueryDocument = gql`
     ${FormEditorDataFragmentDoc}`;
 
 /**
- * __useFormEditorQueryQuery__
+ * __useFormEditorQuery__
  *
- * To run a query within a React component, call `useFormEditorQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useFormEditorQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useFormEditorQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFormEditorQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useFormEditorQueryQuery({
+ * const { data, loading, error } = useFormEditorQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useFormEditorQueryQuery(baseOptions: Apollo.QueryHookOptions<FormEditorQueryQuery, FormEditorQueryQueryVariables>) {
-        return Apollo.useQuery<FormEditorQueryQuery, FormEditorQueryQueryVariables>(FormEditorQueryDocument, baseOptions);
+export function useFormEditorQuery(baseOptions: Apollo.QueryHookOptions<FormEditorQueryData, FormEditorQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<FormEditorQueryData, FormEditorQueryVariables>(FormEditorQueryDocument, options);
       }
-export function useFormEditorQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FormEditorQueryQuery, FormEditorQueryQueryVariables>) {
-          return Apollo.useLazyQuery<FormEditorQueryQuery, FormEditorQueryQueryVariables>(FormEditorQueryDocument, baseOptions);
+export function useFormEditorQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FormEditorQueryData, FormEditorQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<FormEditorQueryData, FormEditorQueryVariables>(FormEditorQueryDocument, options);
         }
-export type FormEditorQueryQueryHookResult = ReturnType<typeof useFormEditorQueryQuery>;
+export type FormEditorQueryHookResult = ReturnType<typeof useFormEditorQuery>;
 export type FormEditorQueryLazyQueryHookResult = ReturnType<typeof useFormEditorQueryLazyQuery>;
-export type FormEditorQueryQueryResult = Apollo.QueryResult<FormEditorQueryQuery, FormEditorQueryQueryVariables>;
+export type FormEditorQueryDataResult = Apollo.QueryResult<FormEditorQueryData, FormEditorQueryVariables>;
 export const PreviewFormItemQueryDocument = gql`
     query PreviewFormItemQuery($formSectionId: Int!, $formItem: FormItemInput!) {
   previewFormItem(formSectionId: $formSectionId, formItem: $formItem) {
@@ -222,28 +227,30 @@ export const PreviewFormItemQueryDocument = gql`
     ${FormEditorFormItemFieldsFragmentDoc}`;
 
 /**
- * __usePreviewFormItemQueryQuery__
+ * __usePreviewFormItemQuery__
  *
- * To run a query within a React component, call `usePreviewFormItemQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `usePreviewFormItemQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `usePreviewFormItemQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePreviewFormItemQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = usePreviewFormItemQueryQuery({
+ * const { data, loading, error } = usePreviewFormItemQuery({
  *   variables: {
  *      formSectionId: // value for 'formSectionId'
  *      formItem: // value for 'formItem'
  *   },
  * });
  */
-export function usePreviewFormItemQueryQuery(baseOptions: Apollo.QueryHookOptions<PreviewFormItemQueryQuery, PreviewFormItemQueryQueryVariables>) {
-        return Apollo.useQuery<PreviewFormItemQueryQuery, PreviewFormItemQueryQueryVariables>(PreviewFormItemQueryDocument, baseOptions);
+export function usePreviewFormItemQuery(baseOptions: Apollo.QueryHookOptions<PreviewFormItemQueryData, PreviewFormItemQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PreviewFormItemQueryData, PreviewFormItemQueryVariables>(PreviewFormItemQueryDocument, options);
       }
-export function usePreviewFormItemQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PreviewFormItemQueryQuery, PreviewFormItemQueryQueryVariables>) {
-          return Apollo.useLazyQuery<PreviewFormItemQueryQuery, PreviewFormItemQueryQueryVariables>(PreviewFormItemQueryDocument, baseOptions);
+export function usePreviewFormItemQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PreviewFormItemQueryData, PreviewFormItemQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PreviewFormItemQueryData, PreviewFormItemQueryVariables>(PreviewFormItemQueryDocument, options);
         }
-export type PreviewFormItemQueryQueryHookResult = ReturnType<typeof usePreviewFormItemQueryQuery>;
+export type PreviewFormItemQueryHookResult = ReturnType<typeof usePreviewFormItemQuery>;
 export type PreviewFormItemQueryLazyQueryHookResult = ReturnType<typeof usePreviewFormItemQueryLazyQuery>;
-export type PreviewFormItemQueryQueryResult = Apollo.QueryResult<PreviewFormItemQueryQuery, PreviewFormItemQueryQueryVariables>;
+export type PreviewFormItemQueryDataResult = Apollo.QueryResult<PreviewFormItemQueryData, PreviewFormItemQueryVariables>;

--- a/app/javascript/FormPresenter/ItemDisplays/MarkdownDisplay.tsx
+++ b/app/javascript/FormPresenter/ItemDisplays/MarkdownDisplay.tsx
@@ -1,13 +1,13 @@
 import LoadingIndicator from '../../LoadingIndicator';
 import ErrorDisplay from '../../ErrorDisplay';
-import { usePreviewMarkdownQueryQuery } from '../../BuiltInFormControls/previewQueries.generated';
+import { usePreviewMarkdownQuery } from '../../BuiltInFormControls/previewQueries.generated';
 
 export type MarkdownDisplayProps = {
   markdown?: string | null;
 };
 
 function MarkdownDisplay({ markdown }: MarkdownDisplayProps) {
-  const { data, loading, error } = usePreviewMarkdownQueryQuery({
+  const { data, loading, error } = usePreviewMarkdownQuery({
     variables: { markdown: markdown ?? '' },
   });
 

--- a/app/javascript/LiquidDocs/queries.generated.ts
+++ b/app/javascript/LiquidDocs/queries.generated.ts
@@ -3,15 +3,16 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type LiquidAssignFieldsFragment = (
   { __typename: 'LiquidAssign' }
   & Pick<Types.LiquidAssign, 'name' | 'drop_class_name' | 'cms_variable_value_json'>
 );
 
-export type LiquidAssignsQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type LiquidAssignsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type LiquidAssignsQueryQuery = (
+export type LiquidAssignsQueryData = (
   { __typename: 'Query' }
   & { liquidAssigns: Array<(
     { __typename: 'LiquidAssign' }
@@ -19,12 +20,12 @@ export type LiquidAssignsQueryQuery = (
   )> }
 );
 
-export type NotifierLiquidAssignsQueryQueryVariables = Types.Exact<{
+export type NotifierLiquidAssignsQueryVariables = Types.Exact<{
   eventKey: Types.Scalars['String'];
 }>;
 
 
-export type NotifierLiquidAssignsQueryQuery = (
+export type NotifierLiquidAssignsQueryData = (
   { __typename: 'Query' }
   & { liquidAssigns: Array<(
     { __typename: 'LiquidAssign' }
@@ -48,29 +49,31 @@ export const LiquidAssignsQueryDocument = gql`
     ${LiquidAssignFieldsFragmentDoc}`;
 
 /**
- * __useLiquidAssignsQueryQuery__
+ * __useLiquidAssignsQuery__
  *
- * To run a query within a React component, call `useLiquidAssignsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useLiquidAssignsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useLiquidAssignsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLiquidAssignsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useLiquidAssignsQueryQuery({
+ * const { data, loading, error } = useLiquidAssignsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useLiquidAssignsQueryQuery(baseOptions?: Apollo.QueryHookOptions<LiquidAssignsQueryQuery, LiquidAssignsQueryQueryVariables>) {
-        return Apollo.useQuery<LiquidAssignsQueryQuery, LiquidAssignsQueryQueryVariables>(LiquidAssignsQueryDocument, baseOptions);
+export function useLiquidAssignsQuery(baseOptions?: Apollo.QueryHookOptions<LiquidAssignsQueryData, LiquidAssignsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<LiquidAssignsQueryData, LiquidAssignsQueryVariables>(LiquidAssignsQueryDocument, options);
       }
-export function useLiquidAssignsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LiquidAssignsQueryQuery, LiquidAssignsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<LiquidAssignsQueryQuery, LiquidAssignsQueryQueryVariables>(LiquidAssignsQueryDocument, baseOptions);
+export function useLiquidAssignsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LiquidAssignsQueryData, LiquidAssignsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<LiquidAssignsQueryData, LiquidAssignsQueryVariables>(LiquidAssignsQueryDocument, options);
         }
-export type LiquidAssignsQueryQueryHookResult = ReturnType<typeof useLiquidAssignsQueryQuery>;
+export type LiquidAssignsQueryHookResult = ReturnType<typeof useLiquidAssignsQuery>;
 export type LiquidAssignsQueryLazyQueryHookResult = ReturnType<typeof useLiquidAssignsQueryLazyQuery>;
-export type LiquidAssignsQueryQueryResult = Apollo.QueryResult<LiquidAssignsQueryQuery, LiquidAssignsQueryQueryVariables>;
+export type LiquidAssignsQueryDataResult = Apollo.QueryResult<LiquidAssignsQueryData, LiquidAssignsQueryVariables>;
 export const NotifierLiquidAssignsQueryDocument = gql`
     query NotifierLiquidAssignsQuery($eventKey: String!) {
   liquidAssigns: notifierLiquidAssigns(eventKey: $eventKey) {
@@ -80,27 +83,29 @@ export const NotifierLiquidAssignsQueryDocument = gql`
     ${LiquidAssignFieldsFragmentDoc}`;
 
 /**
- * __useNotifierLiquidAssignsQueryQuery__
+ * __useNotifierLiquidAssignsQuery__
  *
- * To run a query within a React component, call `useNotifierLiquidAssignsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useNotifierLiquidAssignsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useNotifierLiquidAssignsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNotifierLiquidAssignsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useNotifierLiquidAssignsQueryQuery({
+ * const { data, loading, error } = useNotifierLiquidAssignsQuery({
  *   variables: {
  *      eventKey: // value for 'eventKey'
  *   },
  * });
  */
-export function useNotifierLiquidAssignsQueryQuery(baseOptions: Apollo.QueryHookOptions<NotifierLiquidAssignsQueryQuery, NotifierLiquidAssignsQueryQueryVariables>) {
-        return Apollo.useQuery<NotifierLiquidAssignsQueryQuery, NotifierLiquidAssignsQueryQueryVariables>(NotifierLiquidAssignsQueryDocument, baseOptions);
+export function useNotifierLiquidAssignsQuery(baseOptions: Apollo.QueryHookOptions<NotifierLiquidAssignsQueryData, NotifierLiquidAssignsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<NotifierLiquidAssignsQueryData, NotifierLiquidAssignsQueryVariables>(NotifierLiquidAssignsQueryDocument, options);
       }
-export function useNotifierLiquidAssignsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NotifierLiquidAssignsQueryQuery, NotifierLiquidAssignsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<NotifierLiquidAssignsQueryQuery, NotifierLiquidAssignsQueryQueryVariables>(NotifierLiquidAssignsQueryDocument, baseOptions);
+export function useNotifierLiquidAssignsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NotifierLiquidAssignsQueryData, NotifierLiquidAssignsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<NotifierLiquidAssignsQueryData, NotifierLiquidAssignsQueryVariables>(NotifierLiquidAssignsQueryDocument, options);
         }
-export type NotifierLiquidAssignsQueryQueryHookResult = ReturnType<typeof useNotifierLiquidAssignsQueryQuery>;
+export type NotifierLiquidAssignsQueryHookResult = ReturnType<typeof useNotifierLiquidAssignsQuery>;
 export type NotifierLiquidAssignsQueryLazyQueryHookResult = ReturnType<typeof useNotifierLiquidAssignsQueryLazyQuery>;
-export type NotifierLiquidAssignsQueryQueryResult = Apollo.QueryResult<NotifierLiquidAssignsQueryQuery, NotifierLiquidAssignsQueryQueryVariables>;
+export type NotifierLiquidAssignsQueryDataResult = Apollo.QueryResult<NotifierLiquidAssignsQueryData, NotifierLiquidAssignsQueryVariables>;

--- a/app/javascript/LiquidDocs/useLiquidAssignsQueryFromLocation.ts
+++ b/app/javascript/LiquidDocs/useLiquidAssignsQueryFromLocation.ts
@@ -4,10 +4,10 @@ import { useLocation } from 'react-router-dom';
 
 import { LiquidAssignsQuery, NotifierLiquidAssignsQuery } from './queries';
 import {
-  LiquidAssignsQueryQuery,
-  LiquidAssignsQueryQueryVariables,
-  NotifierLiquidAssignsQueryQuery,
-  NotifierLiquidAssignsQueryQueryVariables,
+  LiquidAssignsQueryData,
+  LiquidAssignsQueryVariables,
+  NotifierLiquidAssignsQueryData,
+  NotifierLiquidAssignsQueryVariables,
 } from './queries.generated';
 
 export default function useLiquidAssignsQueryFromLocation() {
@@ -18,8 +18,8 @@ export default function useLiquidAssignsQueryFromLocation() {
 
   return [
     useQuery<
-      NotifierLiquidAssignsQueryQuery | LiquidAssignsQueryQuery,
-      NotifierLiquidAssignsQueryQueryVariables | LiquidAssignsQueryQueryVariables
+      NotifierLiquidAssignsQueryData | LiquidAssignsQueryData,
+      NotifierLiquidAssignsQueryVariables | LiquidAssignsQueryVariables
     >(notifierEventKey ? NotifierLiquidAssignsQuery : LiquidAssignsQuery, {
       variables: notifierEventKey ? { eventKey: notifierEventKey } : {},
     }),

--- a/app/javascript/MailingLists/EventProposers.tsx
+++ b/app/javascript/MailingLists/EventProposers.tsx
@@ -1,9 +1,9 @@
 import TabbedMailingList from './TabbedMailingList';
 import usePageTitle from '../usePageTitle';
-import { useEventProposersQueryQuery } from './queries.generated';
+import { useEventProposersQuery } from './queries.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 
-export default LoadQueryWrapper(useEventProposersQueryQuery, function EventProposers({ data }) {
+export default LoadQueryWrapper(useEventProposersQuery, function EventProposers({ data }) {
   usePageTitle('Event proposers');
 
   return (

--- a/app/javascript/MailingLists/TeamMembers.tsx
+++ b/app/javascript/MailingLists/TeamMembers.tsx
@@ -1,11 +1,9 @@
 import TabbedMailingList from './TabbedMailingList';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useTeamMembersMailingListQueryQuery } from './queries.generated';
+import { useTeamMembersMailingListQuery } from './queries.generated';
 
-export default LoadQueryWrapper(useTeamMembersMailingListQueryQuery, function TeamMembers({
-  data,
-}) {
+export default LoadQueryWrapper(useTeamMembersMailingListQuery, function TeamMembers({ data }) {
   usePageTitle('Event team members');
 
   return (

--- a/app/javascript/MailingLists/TicketedAttendees.tsx
+++ b/app/javascript/MailingLists/TicketedAttendees.tsx
@@ -1,11 +1,9 @@
 import TabbedMailingList from './TabbedMailingList';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useTicketedAttendeesQueryQuery } from './queries.generated';
+import { useTicketedAttendeesQuery } from './queries.generated';
 
-export default LoadQueryWrapper(useTicketedAttendeesQueryQuery, function TicketedAttendees({
-  data,
-}) {
+export default LoadQueryWrapper(useTicketedAttendeesQuery, function TicketedAttendees({ data }) {
   usePageTitle(`All attendees with ${data.convention.ticket_name}`);
 
   return (

--- a/app/javascript/MailingLists/UsersWithPendingBio.tsx
+++ b/app/javascript/MailingLists/UsersWithPendingBio.tsx
@@ -1,22 +1,23 @@
 import TabbedMailingList from './TabbedMailingList';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useUsersWithPendingBioQueryQuery } from './queries.generated';
+import { useUsersWithPendingBioQuery } from './queries.generated';
 
-export default LoadQueryWrapper(useUsersWithPendingBioQueryQuery, function UsersWithPendingBio({
-  data,
-}) {
-  usePageTitle('Users with pending bio');
+export default LoadQueryWrapper(
+  useUsersWithPendingBioQuery,
+  function UsersWithPendingBio({ data }) {
+    usePageTitle('Users with pending bio');
 
-  return (
-    <>
-      <h1 className="mb-4">Mail to all users with pending bio</h1>
+    return (
+      <>
+        <h1 className="mb-4">Mail to all users with pending bio</h1>
 
-      <TabbedMailingList
-        emails={data.convention.mailing_lists.users_with_pending_bio.emails}
-        metadataFields={data.convention.mailing_lists.users_with_pending_bio.metadata_fields}
-        csvFilename={`Users with pending bio - ${data.convention.name}.csv`}
-      />
-    </>
-  );
-});
+        <TabbedMailingList
+          emails={data.convention.mailing_lists.users_with_pending_bio.emails}
+          metadataFields={data.convention.mailing_lists.users_with_pending_bio.metadata_fields}
+          csvFilename={`Users with pending bio - ${data.convention.name}.csv`}
+        />
+      </>
+    );
+  },
+);

--- a/app/javascript/MailingLists/WaitlistMailingLists.tsx
+++ b/app/javascript/MailingLists/WaitlistMailingLists.tsx
@@ -5,11 +5,11 @@ import TabbedMailingList from './TabbedMailingList';
 import usePageTitle from '../usePageTitle';
 import AppRootContext from '../AppRootContext';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useWaitlistMailingListsQueryQuery } from './queries.generated';
+import { useWaitlistMailingListsQuery } from './queries.generated';
 import { useAppDateTimeFormat } from '../TimeUtils';
 
 export default LoadQueryWrapper(
-  useWaitlistMailingListsQueryQuery,
+  useWaitlistMailingListsQuery,
   function WaitlistMailingLists({ data }) {
     const format = useAppDateTimeFormat();
     const { timezoneName } = useContext(AppRootContext);

--- a/app/javascript/MailingLists/WhosFree.tsx
+++ b/app/javascript/MailingLists/WhosFree.tsx
@@ -6,10 +6,10 @@ import Timespan, { FiniteTimespan } from '../Timespan';
 import WhosFreeForm from './WhosFreeForm';
 import LoadingIndicator from '../LoadingIndicator';
 import usePageTitle from '../usePageTitle';
-import { useWhosFreeQueryQuery } from './queries.generated';
+import { useWhosFreeQuery } from './queries.generated';
 
 function WhosFreeResults({ timespan }: { timespan: FiniteTimespan }) {
-  const { data, loading, error } = useWhosFreeQueryQuery({
+  const { data, loading, error } = useWhosFreeQuery({
     variables: { start: timespan.start.toISO(), finish: timespan.finish.toISO() },
   });
 

--- a/app/javascript/MailingLists/WhosFreeForm.tsx
+++ b/app/javascript/MailingLists/WhosFreeForm.tsx
@@ -6,7 +6,7 @@ import ErrorDisplay from '../ErrorDisplay';
 import TimeSelect, { TimeValues } from '../BuiltInFormControls/TimeSelect';
 import Timespan from '../Timespan';
 import LoadingIndicator from '../LoadingIndicator';
-import { useWhosFreeFormConventionQueryQuery } from './queries.generated';
+import { useWhosFreeFormConventionQuery } from './queries.generated';
 
 const dateTimeToTimeValues = (momentValue?: DateTime | null) => {
   if (momentValue == null) {
@@ -31,7 +31,7 @@ export type WhosFreeFormProps = {
 };
 
 function WhosFreeForm({ onSubmit }: WhosFreeFormProps) {
-  const { data, loading, error } = useWhosFreeFormConventionQueryQuery();
+  const { data, loading, error } = useWhosFreeFormConventionQuery();
   const [start, setStart] = useState<DateTime>();
   const [finish, setFinish] = useState<DateTime>();
   const [day, setDay] = useState<DateTime>();

--- a/app/javascript/MailingLists/index.tsx
+++ b/app/javascript/MailingLists/index.tsx
@@ -8,10 +8,10 @@ import WaitlistMailingLists from './WaitlistMailingLists';
 import WhosFree from './WhosFree';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useMailingListsMenuQueryQuery } from './queries.generated';
+import { useMailingListsMenuQuery } from './queries.generated';
 
 const MailingListsMenuWrapper = LoadQueryWrapper(
-  useMailingListsMenuQueryQuery,
+  useMailingListsMenuQuery,
   function MailingListsMenu({ data }) {
     const authorizationWarning = useAuthorizationRequired('can_read_any_mailing_list');
 

--- a/app/javascript/MailingLists/queries.generated.ts
+++ b/app/javascript/MailingLists/queries.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type ContactEmailFieldsFragment = (
   { __typename: 'ContactEmail' }
   & Pick<Types.ContactEmail, 'email' | 'formatted_address' | 'name' | 'metadata_json'>
@@ -17,10 +18,10 @@ export type MailingListsResultFieldsFragment = (
   )> }
 );
 
-export type MailingListsMenuQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type MailingListsMenuQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type MailingListsMenuQueryQuery = (
+export type MailingListsMenuQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -28,10 +29,10 @@ export type MailingListsMenuQueryQuery = (
   ) }
 );
 
-export type TicketedAttendeesQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type TicketedAttendeesQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type TicketedAttendeesQueryQuery = (
+export type TicketedAttendeesQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -46,10 +47,10 @@ export type TicketedAttendeesQueryQuery = (
   ) }
 );
 
-export type EventProposersQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type EventProposersQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type EventProposersQueryQuery = (
+export type EventProposersQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -64,10 +65,10 @@ export type EventProposersQueryQuery = (
   ) }
 );
 
-export type TeamMembersMailingListQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type TeamMembersMailingListQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type TeamMembersMailingListQueryQuery = (
+export type TeamMembersMailingListQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -82,10 +83,10 @@ export type TeamMembersMailingListQueryQuery = (
   ) }
 );
 
-export type UsersWithPendingBioQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type UsersWithPendingBioQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type UsersWithPendingBioQueryQuery = (
+export type UsersWithPendingBioQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -100,10 +101,10 @@ export type UsersWithPendingBioQueryQuery = (
   ) }
 );
 
-export type WaitlistMailingListsQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type WaitlistMailingListsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type WaitlistMailingListsQueryQuery = (
+export type WaitlistMailingListsQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -129,10 +130,10 @@ export type WaitlistMailingListsQueryQuery = (
   ) }
 );
 
-export type WhosFreeFormConventionQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type WhosFreeFormConventionQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type WhosFreeFormConventionQueryQuery = (
+export type WhosFreeFormConventionQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -140,13 +141,13 @@ export type WhosFreeFormConventionQueryQuery = (
   ) }
 );
 
-export type WhosFreeQueryQueryVariables = Types.Exact<{
+export type WhosFreeQueryVariables = Types.Exact<{
   start: Types.Scalars['Date'];
   finish: Types.Scalars['Date'];
 }>;
 
 
-export type WhosFreeQueryQuery = (
+export type WhosFreeQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -188,29 +189,31 @@ export const MailingListsMenuQueryDocument = gql`
     `;
 
 /**
- * __useMailingListsMenuQueryQuery__
+ * __useMailingListsMenuQuery__
  *
- * To run a query within a React component, call `useMailingListsMenuQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useMailingListsMenuQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useMailingListsMenuQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMailingListsMenuQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useMailingListsMenuQueryQuery({
+ * const { data, loading, error } = useMailingListsMenuQuery({
  *   variables: {
  *   },
  * });
  */
-export function useMailingListsMenuQueryQuery(baseOptions?: Apollo.QueryHookOptions<MailingListsMenuQueryQuery, MailingListsMenuQueryQueryVariables>) {
-        return Apollo.useQuery<MailingListsMenuQueryQuery, MailingListsMenuQueryQueryVariables>(MailingListsMenuQueryDocument, baseOptions);
+export function useMailingListsMenuQuery(baseOptions?: Apollo.QueryHookOptions<MailingListsMenuQueryData, MailingListsMenuQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MailingListsMenuQueryData, MailingListsMenuQueryVariables>(MailingListsMenuQueryDocument, options);
       }
-export function useMailingListsMenuQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MailingListsMenuQueryQuery, MailingListsMenuQueryQueryVariables>) {
-          return Apollo.useLazyQuery<MailingListsMenuQueryQuery, MailingListsMenuQueryQueryVariables>(MailingListsMenuQueryDocument, baseOptions);
+export function useMailingListsMenuQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MailingListsMenuQueryData, MailingListsMenuQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MailingListsMenuQueryData, MailingListsMenuQueryVariables>(MailingListsMenuQueryDocument, options);
         }
-export type MailingListsMenuQueryQueryHookResult = ReturnType<typeof useMailingListsMenuQueryQuery>;
+export type MailingListsMenuQueryHookResult = ReturnType<typeof useMailingListsMenuQuery>;
 export type MailingListsMenuQueryLazyQueryHookResult = ReturnType<typeof useMailingListsMenuQueryLazyQuery>;
-export type MailingListsMenuQueryQueryResult = Apollo.QueryResult<MailingListsMenuQueryQuery, MailingListsMenuQueryQueryVariables>;
+export type MailingListsMenuQueryDataResult = Apollo.QueryResult<MailingListsMenuQueryData, MailingListsMenuQueryVariables>;
 export const TicketedAttendeesQueryDocument = gql`
     query TicketedAttendeesQuery {
   convention: assertConvention {
@@ -227,29 +230,31 @@ export const TicketedAttendeesQueryDocument = gql`
     ${MailingListsResultFieldsFragmentDoc}`;
 
 /**
- * __useTicketedAttendeesQueryQuery__
+ * __useTicketedAttendeesQuery__
  *
- * To run a query within a React component, call `useTicketedAttendeesQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useTicketedAttendeesQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useTicketedAttendeesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTicketedAttendeesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useTicketedAttendeesQueryQuery({
+ * const { data, loading, error } = useTicketedAttendeesQuery({
  *   variables: {
  *   },
  * });
  */
-export function useTicketedAttendeesQueryQuery(baseOptions?: Apollo.QueryHookOptions<TicketedAttendeesQueryQuery, TicketedAttendeesQueryQueryVariables>) {
-        return Apollo.useQuery<TicketedAttendeesQueryQuery, TicketedAttendeesQueryQueryVariables>(TicketedAttendeesQueryDocument, baseOptions);
+export function useTicketedAttendeesQuery(baseOptions?: Apollo.QueryHookOptions<TicketedAttendeesQueryData, TicketedAttendeesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TicketedAttendeesQueryData, TicketedAttendeesQueryVariables>(TicketedAttendeesQueryDocument, options);
       }
-export function useTicketedAttendeesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TicketedAttendeesQueryQuery, TicketedAttendeesQueryQueryVariables>) {
-          return Apollo.useLazyQuery<TicketedAttendeesQueryQuery, TicketedAttendeesQueryQueryVariables>(TicketedAttendeesQueryDocument, baseOptions);
+export function useTicketedAttendeesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TicketedAttendeesQueryData, TicketedAttendeesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TicketedAttendeesQueryData, TicketedAttendeesQueryVariables>(TicketedAttendeesQueryDocument, options);
         }
-export type TicketedAttendeesQueryQueryHookResult = ReturnType<typeof useTicketedAttendeesQueryQuery>;
+export type TicketedAttendeesQueryHookResult = ReturnType<typeof useTicketedAttendeesQuery>;
 export type TicketedAttendeesQueryLazyQueryHookResult = ReturnType<typeof useTicketedAttendeesQueryLazyQuery>;
-export type TicketedAttendeesQueryQueryResult = Apollo.QueryResult<TicketedAttendeesQueryQuery, TicketedAttendeesQueryQueryVariables>;
+export type TicketedAttendeesQueryDataResult = Apollo.QueryResult<TicketedAttendeesQueryData, TicketedAttendeesQueryVariables>;
 export const EventProposersQueryDocument = gql`
     query EventProposersQuery {
   convention: assertConvention {
@@ -265,29 +270,31 @@ export const EventProposersQueryDocument = gql`
     ${MailingListsResultFieldsFragmentDoc}`;
 
 /**
- * __useEventProposersQueryQuery__
+ * __useEventProposersQuery__
  *
- * To run a query within a React component, call `useEventProposersQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventProposersQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventProposersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventProposersQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventProposersQueryQuery({
+ * const { data, loading, error } = useEventProposersQuery({
  *   variables: {
  *   },
  * });
  */
-export function useEventProposersQueryQuery(baseOptions?: Apollo.QueryHookOptions<EventProposersQueryQuery, EventProposersQueryQueryVariables>) {
-        return Apollo.useQuery<EventProposersQueryQuery, EventProposersQueryQueryVariables>(EventProposersQueryDocument, baseOptions);
+export function useEventProposersQuery(baseOptions?: Apollo.QueryHookOptions<EventProposersQueryData, EventProposersQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventProposersQueryData, EventProposersQueryVariables>(EventProposersQueryDocument, options);
       }
-export function useEventProposersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposersQueryQuery, EventProposersQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventProposersQueryQuery, EventProposersQueryQueryVariables>(EventProposersQueryDocument, baseOptions);
+export function useEventProposersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProposersQueryData, EventProposersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventProposersQueryData, EventProposersQueryVariables>(EventProposersQueryDocument, options);
         }
-export type EventProposersQueryQueryHookResult = ReturnType<typeof useEventProposersQueryQuery>;
+export type EventProposersQueryHookResult = ReturnType<typeof useEventProposersQuery>;
 export type EventProposersQueryLazyQueryHookResult = ReturnType<typeof useEventProposersQueryLazyQuery>;
-export type EventProposersQueryQueryResult = Apollo.QueryResult<EventProposersQueryQuery, EventProposersQueryQueryVariables>;
+export type EventProposersQueryDataResult = Apollo.QueryResult<EventProposersQueryData, EventProposersQueryVariables>;
 export const TeamMembersMailingListQueryDocument = gql`
     query TeamMembersMailingListQuery {
   convention: assertConvention {
@@ -303,29 +310,31 @@ export const TeamMembersMailingListQueryDocument = gql`
     ${MailingListsResultFieldsFragmentDoc}`;
 
 /**
- * __useTeamMembersMailingListQueryQuery__
+ * __useTeamMembersMailingListQuery__
  *
- * To run a query within a React component, call `useTeamMembersMailingListQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useTeamMembersMailingListQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useTeamMembersMailingListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTeamMembersMailingListQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useTeamMembersMailingListQueryQuery({
+ * const { data, loading, error } = useTeamMembersMailingListQuery({
  *   variables: {
  *   },
  * });
  */
-export function useTeamMembersMailingListQueryQuery(baseOptions?: Apollo.QueryHookOptions<TeamMembersMailingListQueryQuery, TeamMembersMailingListQueryQueryVariables>) {
-        return Apollo.useQuery<TeamMembersMailingListQueryQuery, TeamMembersMailingListQueryQueryVariables>(TeamMembersMailingListQueryDocument, baseOptions);
+export function useTeamMembersMailingListQuery(baseOptions?: Apollo.QueryHookOptions<TeamMembersMailingListQueryData, TeamMembersMailingListQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TeamMembersMailingListQueryData, TeamMembersMailingListQueryVariables>(TeamMembersMailingListQueryDocument, options);
       }
-export function useTeamMembersMailingListQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TeamMembersMailingListQueryQuery, TeamMembersMailingListQueryQueryVariables>) {
-          return Apollo.useLazyQuery<TeamMembersMailingListQueryQuery, TeamMembersMailingListQueryQueryVariables>(TeamMembersMailingListQueryDocument, baseOptions);
+export function useTeamMembersMailingListQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TeamMembersMailingListQueryData, TeamMembersMailingListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TeamMembersMailingListQueryData, TeamMembersMailingListQueryVariables>(TeamMembersMailingListQueryDocument, options);
         }
-export type TeamMembersMailingListQueryQueryHookResult = ReturnType<typeof useTeamMembersMailingListQueryQuery>;
+export type TeamMembersMailingListQueryHookResult = ReturnType<typeof useTeamMembersMailingListQuery>;
 export type TeamMembersMailingListQueryLazyQueryHookResult = ReturnType<typeof useTeamMembersMailingListQueryLazyQuery>;
-export type TeamMembersMailingListQueryQueryResult = Apollo.QueryResult<TeamMembersMailingListQueryQuery, TeamMembersMailingListQueryQueryVariables>;
+export type TeamMembersMailingListQueryDataResult = Apollo.QueryResult<TeamMembersMailingListQueryData, TeamMembersMailingListQueryVariables>;
 export const UsersWithPendingBioQueryDocument = gql`
     query UsersWithPendingBioQuery {
   convention: assertConvention {
@@ -341,29 +350,31 @@ export const UsersWithPendingBioQueryDocument = gql`
     ${MailingListsResultFieldsFragmentDoc}`;
 
 /**
- * __useUsersWithPendingBioQueryQuery__
+ * __useUsersWithPendingBioQuery__
  *
- * To run a query within a React component, call `useUsersWithPendingBioQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useUsersWithPendingBioQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useUsersWithPendingBioQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUsersWithPendingBioQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useUsersWithPendingBioQueryQuery({
+ * const { data, loading, error } = useUsersWithPendingBioQuery({
  *   variables: {
  *   },
  * });
  */
-export function useUsersWithPendingBioQueryQuery(baseOptions?: Apollo.QueryHookOptions<UsersWithPendingBioQueryQuery, UsersWithPendingBioQueryQueryVariables>) {
-        return Apollo.useQuery<UsersWithPendingBioQueryQuery, UsersWithPendingBioQueryQueryVariables>(UsersWithPendingBioQueryDocument, baseOptions);
+export function useUsersWithPendingBioQuery(baseOptions?: Apollo.QueryHookOptions<UsersWithPendingBioQueryData, UsersWithPendingBioQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<UsersWithPendingBioQueryData, UsersWithPendingBioQueryVariables>(UsersWithPendingBioQueryDocument, options);
       }
-export function useUsersWithPendingBioQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UsersWithPendingBioQueryQuery, UsersWithPendingBioQueryQueryVariables>) {
-          return Apollo.useLazyQuery<UsersWithPendingBioQueryQuery, UsersWithPendingBioQueryQueryVariables>(UsersWithPendingBioQueryDocument, baseOptions);
+export function useUsersWithPendingBioQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UsersWithPendingBioQueryData, UsersWithPendingBioQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<UsersWithPendingBioQueryData, UsersWithPendingBioQueryVariables>(UsersWithPendingBioQueryDocument, options);
         }
-export type UsersWithPendingBioQueryQueryHookResult = ReturnType<typeof useUsersWithPendingBioQueryQuery>;
+export type UsersWithPendingBioQueryHookResult = ReturnType<typeof useUsersWithPendingBioQuery>;
 export type UsersWithPendingBioQueryLazyQueryHookResult = ReturnType<typeof useUsersWithPendingBioQueryLazyQuery>;
-export type UsersWithPendingBioQueryQueryResult = Apollo.QueryResult<UsersWithPendingBioQueryQuery, UsersWithPendingBioQueryQueryVariables>;
+export type UsersWithPendingBioQueryDataResult = Apollo.QueryResult<UsersWithPendingBioQueryData, UsersWithPendingBioQueryVariables>;
 export const WaitlistMailingListsQueryDocument = gql`
     query WaitlistMailingListsQuery {
   convention: assertConvention {
@@ -392,29 +403,31 @@ export const WaitlistMailingListsQueryDocument = gql`
     ${ContactEmailFieldsFragmentDoc}`;
 
 /**
- * __useWaitlistMailingListsQueryQuery__
+ * __useWaitlistMailingListsQuery__
  *
- * To run a query within a React component, call `useWaitlistMailingListsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useWaitlistMailingListsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useWaitlistMailingListsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useWaitlistMailingListsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useWaitlistMailingListsQueryQuery({
+ * const { data, loading, error } = useWaitlistMailingListsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useWaitlistMailingListsQueryQuery(baseOptions?: Apollo.QueryHookOptions<WaitlistMailingListsQueryQuery, WaitlistMailingListsQueryQueryVariables>) {
-        return Apollo.useQuery<WaitlistMailingListsQueryQuery, WaitlistMailingListsQueryQueryVariables>(WaitlistMailingListsQueryDocument, baseOptions);
+export function useWaitlistMailingListsQuery(baseOptions?: Apollo.QueryHookOptions<WaitlistMailingListsQueryData, WaitlistMailingListsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<WaitlistMailingListsQueryData, WaitlistMailingListsQueryVariables>(WaitlistMailingListsQueryDocument, options);
       }
-export function useWaitlistMailingListsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WaitlistMailingListsQueryQuery, WaitlistMailingListsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<WaitlistMailingListsQueryQuery, WaitlistMailingListsQueryQueryVariables>(WaitlistMailingListsQueryDocument, baseOptions);
+export function useWaitlistMailingListsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WaitlistMailingListsQueryData, WaitlistMailingListsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<WaitlistMailingListsQueryData, WaitlistMailingListsQueryVariables>(WaitlistMailingListsQueryDocument, options);
         }
-export type WaitlistMailingListsQueryQueryHookResult = ReturnType<typeof useWaitlistMailingListsQueryQuery>;
+export type WaitlistMailingListsQueryHookResult = ReturnType<typeof useWaitlistMailingListsQuery>;
 export type WaitlistMailingListsQueryLazyQueryHookResult = ReturnType<typeof useWaitlistMailingListsQueryLazyQuery>;
-export type WaitlistMailingListsQueryQueryResult = Apollo.QueryResult<WaitlistMailingListsQueryQuery, WaitlistMailingListsQueryQueryVariables>;
+export type WaitlistMailingListsQueryDataResult = Apollo.QueryResult<WaitlistMailingListsQueryData, WaitlistMailingListsQueryVariables>;
 export const WhosFreeFormConventionQueryDocument = gql`
     query WhosFreeFormConventionQuery {
   convention: assertConvention {
@@ -429,29 +442,31 @@ export const WhosFreeFormConventionQueryDocument = gql`
     `;
 
 /**
- * __useWhosFreeFormConventionQueryQuery__
+ * __useWhosFreeFormConventionQuery__
  *
- * To run a query within a React component, call `useWhosFreeFormConventionQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useWhosFreeFormConventionQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useWhosFreeFormConventionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useWhosFreeFormConventionQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useWhosFreeFormConventionQueryQuery({
+ * const { data, loading, error } = useWhosFreeFormConventionQuery({
  *   variables: {
  *   },
  * });
  */
-export function useWhosFreeFormConventionQueryQuery(baseOptions?: Apollo.QueryHookOptions<WhosFreeFormConventionQueryQuery, WhosFreeFormConventionQueryQueryVariables>) {
-        return Apollo.useQuery<WhosFreeFormConventionQueryQuery, WhosFreeFormConventionQueryQueryVariables>(WhosFreeFormConventionQueryDocument, baseOptions);
+export function useWhosFreeFormConventionQuery(baseOptions?: Apollo.QueryHookOptions<WhosFreeFormConventionQueryData, WhosFreeFormConventionQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<WhosFreeFormConventionQueryData, WhosFreeFormConventionQueryVariables>(WhosFreeFormConventionQueryDocument, options);
       }
-export function useWhosFreeFormConventionQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WhosFreeFormConventionQueryQuery, WhosFreeFormConventionQueryQueryVariables>) {
-          return Apollo.useLazyQuery<WhosFreeFormConventionQueryQuery, WhosFreeFormConventionQueryQueryVariables>(WhosFreeFormConventionQueryDocument, baseOptions);
+export function useWhosFreeFormConventionQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WhosFreeFormConventionQueryData, WhosFreeFormConventionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<WhosFreeFormConventionQueryData, WhosFreeFormConventionQueryVariables>(WhosFreeFormConventionQueryDocument, options);
         }
-export type WhosFreeFormConventionQueryQueryHookResult = ReturnType<typeof useWhosFreeFormConventionQueryQuery>;
+export type WhosFreeFormConventionQueryHookResult = ReturnType<typeof useWhosFreeFormConventionQuery>;
 export type WhosFreeFormConventionQueryLazyQueryHookResult = ReturnType<typeof useWhosFreeFormConventionQueryLazyQuery>;
-export type WhosFreeFormConventionQueryQueryResult = Apollo.QueryResult<WhosFreeFormConventionQueryQuery, WhosFreeFormConventionQueryQueryVariables>;
+export type WhosFreeFormConventionQueryDataResult = Apollo.QueryResult<WhosFreeFormConventionQueryData, WhosFreeFormConventionQueryVariables>;
 export const WhosFreeQueryDocument = gql`
     query WhosFreeQuery($start: Date!, $finish: Date!) {
   convention: assertConvention {
@@ -467,28 +482,30 @@ export const WhosFreeQueryDocument = gql`
     ${MailingListsResultFieldsFragmentDoc}`;
 
 /**
- * __useWhosFreeQueryQuery__
+ * __useWhosFreeQuery__
  *
- * To run a query within a React component, call `useWhosFreeQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useWhosFreeQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useWhosFreeQuery` and pass it any options that fit your needs.
+ * When your component renders, `useWhosFreeQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useWhosFreeQueryQuery({
+ * const { data, loading, error } = useWhosFreeQuery({
  *   variables: {
  *      start: // value for 'start'
  *      finish: // value for 'finish'
  *   },
  * });
  */
-export function useWhosFreeQueryQuery(baseOptions: Apollo.QueryHookOptions<WhosFreeQueryQuery, WhosFreeQueryQueryVariables>) {
-        return Apollo.useQuery<WhosFreeQueryQuery, WhosFreeQueryQueryVariables>(WhosFreeQueryDocument, baseOptions);
+export function useWhosFreeQuery(baseOptions: Apollo.QueryHookOptions<WhosFreeQueryData, WhosFreeQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<WhosFreeQueryData, WhosFreeQueryVariables>(WhosFreeQueryDocument, options);
       }
-export function useWhosFreeQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WhosFreeQueryQuery, WhosFreeQueryQueryVariables>) {
-          return Apollo.useLazyQuery<WhosFreeQueryQuery, WhosFreeQueryQueryVariables>(WhosFreeQueryDocument, baseOptions);
+export function useWhosFreeQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WhosFreeQueryData, WhosFreeQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<WhosFreeQueryData, WhosFreeQueryVariables>(WhosFreeQueryDocument, options);
         }
-export type WhosFreeQueryQueryHookResult = ReturnType<typeof useWhosFreeQueryQuery>;
+export type WhosFreeQueryHookResult = ReturnType<typeof useWhosFreeQuery>;
 export type WhosFreeQueryLazyQueryHookResult = ReturnType<typeof useWhosFreeQueryLazyQuery>;
-export type WhosFreeQueryQueryResult = Apollo.QueryResult<WhosFreeQueryQuery, WhosFreeQueryQueryVariables>;
+export type WhosFreeQueryDataResult = Apollo.QueryResult<WhosFreeQueryData, WhosFreeQueryVariables>;

--- a/app/javascript/MyProfile/MyProfileDisplay.tsx
+++ b/app/javascript/MyProfile/MyProfileDisplay.tsx
@@ -9,14 +9,14 @@ import FormItemDisplay from '../FormPresenter/ItemDisplays/FormItemDisplay';
 import usePageTitle from '../usePageTitle';
 import Gravatar from '../Gravatar';
 import PageLoadingIndicator from '../PageLoadingIndicator';
-import { useMyProfileQueryQuery } from './queries.generated';
+import { useMyProfileQuery } from './queries.generated';
 import { getSortedParsedFormItems } from '../Models/Form';
 import AdminWarning from '../UIComponents/AdminWarning';
 import { ConventionForTimespanUtils } from '../TimespanUtils';
 
 function MyProfileDisplay() {
   const { t } = useTranslation();
-  const { data, loading, error } = useMyProfileQueryQuery();
+  const { data, loading, error } = useMyProfileQuery();
 
   const formResponse = useMemo(() => {
     if (loading || error) {

--- a/app/javascript/MyProfile/MyProfileForm.tsx
+++ b/app/javascript/MyProfile/MyProfileForm.tsx
@@ -22,7 +22,7 @@ import MarkdownInput from '../BuiltInFormControls/MarkdownInput';
 import BooleanInput from '../BuiltInFormControls/BooleanInput';
 import Gravatar from '../Gravatar';
 import PageLoadingIndicator from '../PageLoadingIndicator';
-import { useMyProfileQueryQuery, MyProfileQueryQuery } from './queries.generated';
+import { useMyProfileQuery, MyProfileQueryData } from './queries.generated';
 import { CommonFormFieldsFragment } from '../Models/commonFormFragments.generated';
 import { useUpdateUserConProfileMutation } from '../UserConProfiles/mutations.generated';
 import { WithFormResponse } from '../Models/deserializeFormResponse';
@@ -38,8 +38,8 @@ function parseResponseErrors(error: ApolloError) {
 
 type MyProfileFormInnerProps = {
   initialSetup?: boolean;
-  initialUserConProfile: WithFormResponse<NonNullable<MyProfileQueryQuery['myProfile']>>;
-  convention: NonNullable<MyProfileQueryQuery['convention']>;
+  initialUserConProfile: WithFormResponse<NonNullable<MyProfileQueryData['myProfile']>>;
+  convention: NonNullable<MyProfileQueryData['convention']>;
   form: CommonFormFieldsFragment;
 };
 
@@ -250,7 +250,7 @@ export type MyProfileFormProps = {
 };
 
 function MyProfileForm({ initialSetup }: MyProfileFormProps) {
-  const { data, loading, error } = useMyProfileQueryQuery();
+  const { data, loading, error } = useMyProfileQuery();
 
   const formState = useMemo(
     () => (loading || error ? null : buildFormStateFromData(data!.myProfile!, data!.convention!)),

--- a/app/javascript/MyProfile/queries.generated.ts
+++ b/app/javascript/MyProfile/queries.generated.ts
@@ -5,10 +5,11 @@ import { CommonFormFieldsFragment, CommonFormSectionFieldsFragment, CommonFormIt
 import { gql } from '@apollo/client';
 import { CommonFormFieldsFragmentDoc, CommonFormSectionFieldsFragmentDoc, CommonFormItemFieldsFragmentDoc } from '../Models/commonFormFragments.generated';
 import * as Apollo from '@apollo/client';
-export type MyProfileQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+const defaultOptions =  {}
+export type MyProfileQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type MyProfileQueryQuery = (
+export type MyProfileQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -70,26 +71,28 @@ export const MyProfileQueryDocument = gql`
     ${CommonFormFieldsFragmentDoc}`;
 
 /**
- * __useMyProfileQueryQuery__
+ * __useMyProfileQuery__
  *
- * To run a query within a React component, call `useMyProfileQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useMyProfileQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useMyProfileQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMyProfileQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useMyProfileQueryQuery({
+ * const { data, loading, error } = useMyProfileQuery({
  *   variables: {
  *   },
  * });
  */
-export function useMyProfileQueryQuery(baseOptions?: Apollo.QueryHookOptions<MyProfileQueryQuery, MyProfileQueryQueryVariables>) {
-        return Apollo.useQuery<MyProfileQueryQuery, MyProfileQueryQueryVariables>(MyProfileQueryDocument, baseOptions);
+export function useMyProfileQuery(baseOptions?: Apollo.QueryHookOptions<MyProfileQueryData, MyProfileQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MyProfileQueryData, MyProfileQueryVariables>(MyProfileQueryDocument, options);
       }
-export function useMyProfileQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MyProfileQueryQuery, MyProfileQueryQueryVariables>) {
-          return Apollo.useLazyQuery<MyProfileQueryQuery, MyProfileQueryQueryVariables>(MyProfileQueryDocument, baseOptions);
+export function useMyProfileQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MyProfileQueryData, MyProfileQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MyProfileQueryData, MyProfileQueryVariables>(MyProfileQueryDocument, options);
         }
-export type MyProfileQueryQueryHookResult = ReturnType<typeof useMyProfileQueryQuery>;
+export type MyProfileQueryHookResult = ReturnType<typeof useMyProfileQuery>;
 export type MyProfileQueryLazyQueryHookResult = ReturnType<typeof useMyProfileQueryLazyQuery>;
-export type MyProfileQueryQueryResult = Apollo.QueryResult<MyProfileQueryQuery, MyProfileQueryQueryVariables>;
+export type MyProfileQueryDataResult = Apollo.QueryResult<MyProfileQueryData, MyProfileQueryVariables>;

--- a/app/javascript/MyTicket/MyTicketDisplay.tsx
+++ b/app/javascript/MyTicket/MyTicketDisplay.tsx
@@ -5,11 +5,11 @@ import { DateTime } from 'luxon';
 import formatMoney from '../formatMoney';
 import usePageTitle from '../usePageTitle';
 import AppRootContext from '../AppRootContext';
-import { useMyTicketDisplayQueryQuery } from './queries.generated';
+import { useMyTicketDisplayQuery } from './queries.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 import { useAppDateTimeFormat } from '../TimeUtils';
 
-export default LoadQueryWrapper(useMyTicketDisplayQueryQuery, function MyTicketDisplay({ data }) {
+export default LoadQueryWrapper(useMyTicketDisplayQuery, function MyTicketDisplay({ data }) {
   const format = useAppDateTimeFormat();
   const { timezoneName } = useContext(AppRootContext);
 

--- a/app/javascript/MyTicket/TicketPurchaseForm.tsx
+++ b/app/javascript/MyTicket/TicketPurchaseForm.tsx
@@ -11,101 +11,98 @@ import usePageTitle from '../usePageTitle';
 import { describeUserPricingStructure } from '../Store/describePricingStructure';
 import ProductOrderForm from '../Store/ProductOrderForm';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { TicketPurchaseFormQueryQuery, useTicketPurchaseFormQueryQuery } from './queries.generated';
+import { TicketPurchaseFormQueryData, useTicketPurchaseFormQuery } from './queries.generated';
 import useLoginRequired from '../Authentication/useLoginRequired';
 
-export default LoadQueryWrapper(
-  useTicketPurchaseFormQueryQuery,
-  function TicketPurchaseForm({ data }) {
-    const { t } = useTranslation();
-    const { timezoneName } = useContext(AppRootContext);
-    const availableProducts = data.convention.products;
-    const [product, setProduct] = useState<
-      TicketPurchaseFormQueryQuery['convention']['products'][0]
-    >();
-    const [focusedProduct, setFocusedProduct] = useState<
-      TicketPurchaseFormQueryQuery['convention']['products'][0]
-    >();
+export default LoadQueryWrapper(useTicketPurchaseFormQuery, function TicketPurchaseForm({ data }) {
+  const { t } = useTranslation();
+  const { timezoneName } = useContext(AppRootContext);
+  const availableProducts = data.convention.products;
+  const [product, setProduct] = useState<
+    TicketPurchaseFormQueryData['convention']['products'][0]
+  >();
+  const [focusedProduct, setFocusedProduct] = useState<
+    TicketPurchaseFormQueryData['convention']['products'][0]
+  >();
 
-    useEffect(() => {
-      if (availableProducts.length === 1) {
-        setProduct(availableProducts[0]);
-      }
-    }, [availableProducts]);
-
-    usePageTitle(`Buy a ${data.convention.ticket_name}`);
-
-    const loginRequired = useLoginRequired();
-
-    if (loginRequired) {
-      return <></>;
+  useEffect(() => {
+    if (availableProducts.length === 1) {
+      setProduct(availableProducts[0]);
     }
+  }, [availableProducts]);
 
-    if (data.myProfile && data.myProfile.ticket) {
-      return <Redirect to="/" />;
-    }
+  usePageTitle(`Buy a ${data.convention.ticket_name}`);
 
-    const renderProductSelect = () => (
-      <div
-        className="btn-group-vertical btn-group-toggle w-100"
-        role="group"
-        aria-label={`${capitalize(data.convention.ticket_name)} type`}
-      >
-        {availableProducts.map((availableProduct) => {
-          const { pricing_structure: pricingStructure, id, name: productName } = availableProduct;
-          return (
-            <label
-              className={classNames('btn text-left btn-outline-primary', {
-                active: product?.id === id,
-                focus: focusedProduct?.id === id,
-              })}
-            >
-              <input
-                type="radio"
-                name="product"
-                checked={product?.id === id}
-                onChange={() => setProduct(availableProduct)}
-                onFocus={() => setFocusedProduct(availableProduct)}
-                onBlur={() =>
-                  setFocusedProduct((prev) => (prev?.id === availableProduct.id ? undefined : prev))
-                }
-                aria-labelledby={`product-label-${id}`}
-              />
-              <div className="d-flex align-items-center" id={`product-label-${id}`}>
-                <div className="flex-grow-1">
-                  <strong>{productName}</strong> &mdash;{' '}
-                  {describeUserPricingStructure(pricingStructure, timezoneName, t)}
-                  {availableProduct.description_html && (
-                    <div
-                      className="small"
-                      // eslint-disable-next-line react/no-danger
-                      dangerouslySetInnerHTML={{ __html: availableProduct.description_html }}
-                    />
-                  )}
-                </div>
-                <Checkmark value={(product || {}).id === id} className="ml-2" />
+  const loginRequired = useLoginRequired();
+
+  if (loginRequired) {
+    return <></>;
+  }
+
+  if (data.myProfile && data.myProfile.ticket) {
+    return <Redirect to="/" />;
+  }
+
+  const renderProductSelect = () => (
+    <div
+      className="btn-group-vertical btn-group-toggle w-100"
+      role="group"
+      aria-label={`${capitalize(data.convention.ticket_name)} type`}
+    >
+      {availableProducts.map((availableProduct) => {
+        const { pricing_structure: pricingStructure, id, name: productName } = availableProduct;
+        return (
+          <label
+            className={classNames('btn text-left btn-outline-primary', {
+              active: product?.id === id,
+              focus: focusedProduct?.id === id,
+            })}
+          >
+            <input
+              type="radio"
+              name="product"
+              checked={product?.id === id}
+              onChange={() => setProduct(availableProduct)}
+              onFocus={() => setFocusedProduct(availableProduct)}
+              onBlur={() =>
+                setFocusedProduct((prev) => (prev?.id === availableProduct.id ? undefined : prev))
+              }
+              aria-labelledby={`product-label-${id}`}
+            />
+            <div className="d-flex align-items-center" id={`product-label-${id}`}>
+              <div className="flex-grow-1">
+                <strong>{productName}</strong> &mdash;{' '}
+                {describeUserPricingStructure(pricingStructure, timezoneName, t)}
+                {availableProduct.description_html && (
+                  <div
+                    className="small"
+                    // eslint-disable-next-line react/no-danger
+                    dangerouslySetInnerHTML={{ __html: availableProduct.description_html }}
+                  />
+                )}
               </div>
-            </label>
-          );
-        })}
-      </div>
-    );
+              <Checkmark value={(product || {}).id === id} className="ml-2" />
+            </div>
+          </label>
+        );
+      })}
+    </div>
+  );
 
-    return (
-      <>
-        <h1 className="mb-4">
-          Buy a {data.convention.ticket_name} for {data.convention.name}
-        </h1>
-        {availableProducts.length > 1 && (
-          <p className="lead">Please select a {data.convention.ticket_name} type:</p>
-        )}
-        {renderProductSelect()}
-        {product && (
-          <div className="mt-4">
-            <ProductOrderForm productId={product.id} />
-          </div>
-        )}
-      </>
-    );
-  },
-);
+  return (
+    <>
+      <h1 className="mb-4">
+        Buy a {data.convention.ticket_name} for {data.convention.name}
+      </h1>
+      {availableProducts.length > 1 && (
+        <p className="lead">Please select a {data.convention.ticket_name} type:</p>
+      )}
+      {renderProductSelect()}
+      {product && (
+        <div className="mt-4">
+          <ProductOrderForm productId={product.id} />
+        </div>
+      )}
+    </>
+  );
+});

--- a/app/javascript/MyTicket/queries.generated.ts
+++ b/app/javascript/MyTicket/queries.generated.ts
@@ -5,10 +5,11 @@ import { PricingStructureFieldsFragment } from '../Store/pricingStructureFields.
 import { gql } from '@apollo/client';
 import { PricingStructureFieldsFragmentDoc } from '../Store/pricingStructureFields.generated';
 import * as Apollo from '@apollo/client';
-export type TicketPurchaseFormQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+const defaultOptions =  {}
+export type TicketPurchaseFormQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type TicketPurchaseFormQueryQuery = (
+export type TicketPurchaseFormQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -38,10 +39,10 @@ export type TicketPurchaseFormQueryQuery = (
   )> }
 );
 
-export type MyTicketDisplayQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type MyTicketDisplayQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type MyTicketDisplayQueryQuery = (
+export type MyTicketDisplayQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -107,29 +108,31 @@ export const TicketPurchaseFormQueryDocument = gql`
     ${PricingStructureFieldsFragmentDoc}`;
 
 /**
- * __useTicketPurchaseFormQueryQuery__
+ * __useTicketPurchaseFormQuery__
  *
- * To run a query within a React component, call `useTicketPurchaseFormQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useTicketPurchaseFormQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useTicketPurchaseFormQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTicketPurchaseFormQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useTicketPurchaseFormQueryQuery({
+ * const { data, loading, error } = useTicketPurchaseFormQuery({
  *   variables: {
  *   },
  * });
  */
-export function useTicketPurchaseFormQueryQuery(baseOptions?: Apollo.QueryHookOptions<TicketPurchaseFormQueryQuery, TicketPurchaseFormQueryQueryVariables>) {
-        return Apollo.useQuery<TicketPurchaseFormQueryQuery, TicketPurchaseFormQueryQueryVariables>(TicketPurchaseFormQueryDocument, baseOptions);
+export function useTicketPurchaseFormQuery(baseOptions?: Apollo.QueryHookOptions<TicketPurchaseFormQueryData, TicketPurchaseFormQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TicketPurchaseFormQueryData, TicketPurchaseFormQueryVariables>(TicketPurchaseFormQueryDocument, options);
       }
-export function useTicketPurchaseFormQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TicketPurchaseFormQueryQuery, TicketPurchaseFormQueryQueryVariables>) {
-          return Apollo.useLazyQuery<TicketPurchaseFormQueryQuery, TicketPurchaseFormQueryQueryVariables>(TicketPurchaseFormQueryDocument, baseOptions);
+export function useTicketPurchaseFormQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TicketPurchaseFormQueryData, TicketPurchaseFormQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TicketPurchaseFormQueryData, TicketPurchaseFormQueryVariables>(TicketPurchaseFormQueryDocument, options);
         }
-export type TicketPurchaseFormQueryQueryHookResult = ReturnType<typeof useTicketPurchaseFormQueryQuery>;
+export type TicketPurchaseFormQueryHookResult = ReturnType<typeof useTicketPurchaseFormQuery>;
 export type TicketPurchaseFormQueryLazyQueryHookResult = ReturnType<typeof useTicketPurchaseFormQueryLazyQuery>;
-export type TicketPurchaseFormQueryQueryResult = Apollo.QueryResult<TicketPurchaseFormQueryQuery, TicketPurchaseFormQueryQueryVariables>;
+export type TicketPurchaseFormQueryDataResult = Apollo.QueryResult<TicketPurchaseFormQueryData, TicketPurchaseFormQueryVariables>;
 export const MyTicketDisplayQueryDocument = gql`
     query MyTicketDisplayQuery {
   convention: assertConvention {
@@ -170,26 +173,28 @@ export const MyTicketDisplayQueryDocument = gql`
     `;
 
 /**
- * __useMyTicketDisplayQueryQuery__
+ * __useMyTicketDisplayQuery__
  *
- * To run a query within a React component, call `useMyTicketDisplayQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useMyTicketDisplayQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useMyTicketDisplayQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMyTicketDisplayQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useMyTicketDisplayQueryQuery({
+ * const { data, loading, error } = useMyTicketDisplayQuery({
  *   variables: {
  *   },
  * });
  */
-export function useMyTicketDisplayQueryQuery(baseOptions?: Apollo.QueryHookOptions<MyTicketDisplayQueryQuery, MyTicketDisplayQueryQueryVariables>) {
-        return Apollo.useQuery<MyTicketDisplayQueryQuery, MyTicketDisplayQueryQueryVariables>(MyTicketDisplayQueryDocument, baseOptions);
+export function useMyTicketDisplayQuery(baseOptions?: Apollo.QueryHookOptions<MyTicketDisplayQueryData, MyTicketDisplayQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MyTicketDisplayQueryData, MyTicketDisplayQueryVariables>(MyTicketDisplayQueryDocument, options);
       }
-export function useMyTicketDisplayQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MyTicketDisplayQueryQuery, MyTicketDisplayQueryQueryVariables>) {
-          return Apollo.useLazyQuery<MyTicketDisplayQueryQuery, MyTicketDisplayQueryQueryVariables>(MyTicketDisplayQueryDocument, baseOptions);
+export function useMyTicketDisplayQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MyTicketDisplayQueryData, MyTicketDisplayQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MyTicketDisplayQueryData, MyTicketDisplayQueryVariables>(MyTicketDisplayQueryDocument, options);
         }
-export type MyTicketDisplayQueryQueryHookResult = ReturnType<typeof useMyTicketDisplayQueryQuery>;
+export type MyTicketDisplayQueryHookResult = ReturnType<typeof useMyTicketDisplayQuery>;
 export type MyTicketDisplayQueryLazyQueryHookResult = ReturnType<typeof useMyTicketDisplayQueryLazyQuery>;
-export type MyTicketDisplayQueryQueryResult = Apollo.QueryResult<MyTicketDisplayQueryQuery, MyTicketDisplayQueryQueryVariables>;
+export type MyTicketDisplayQueryDataResult = Apollo.QueryResult<MyTicketDisplayQueryData, MyTicketDisplayQueryVariables>;

--- a/app/javascript/NavigationBar/SiteSearch.tsx
+++ b/app/javascript/NavigationBar/SiteSearch.tsx
@@ -14,8 +14,8 @@ import { useTranslation } from 'react-i18next';
 import buildEventUrl from '../EventsApp/buildEventUrl';
 import {
   SiteSearchQueryDocument,
-  SiteSearchQueryQuery,
-  SiteSearchQueryQueryVariables,
+  SiteSearchQueryData,
+  SiteSearchQueryVariables,
 } from './siteSearchQueries.generated';
 import { useAdminNavigationItems } from './AdminNavigationSection';
 import { useEventsNavigationItems } from './EventsNavigationSection';
@@ -108,10 +108,7 @@ function SiteSearch({ visible, setVisible, visibilityChangeComplete }: SiteSearc
     () =>
       debounce(
         async (query: string) => {
-          const { data } = await apolloClient.query<
-            SiteSearchQueryQuery,
-            SiteSearchQueryQueryVariables
-          >({
+          const { data } = await apolloClient.query<SiteSearchQueryData, SiteSearchQueryVariables>({
             query: SiteSearchQueryDocument,
             variables: { query },
             fetchPolicy: 'no-cache',

--- a/app/javascript/NavigationBar/siteSearchQueries.generated.ts
+++ b/app/javascript/NavigationBar/siteSearchQueries.generated.ts
@@ -3,12 +3,13 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type SiteSearchQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type SiteSearchQueryVariables = Types.Exact<{
   query: Types.Scalars['String'];
 }>;
 
 
-export type SiteSearchQueryQuery = (
+export type SiteSearchQueryData = (
   { __typename: 'Query' }
   & { siteSearch: (
     { __typename: 'SearchResult' }
@@ -65,27 +66,29 @@ export const SiteSearchQueryDocument = gql`
     `;
 
 /**
- * __useSiteSearchQueryQuery__
+ * __useSiteSearchQuery__
  *
- * To run a query within a React component, call `useSiteSearchQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useSiteSearchQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSiteSearchQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSiteSearchQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSiteSearchQueryQuery({
+ * const { data, loading, error } = useSiteSearchQuery({
  *   variables: {
  *      query: // value for 'query'
  *   },
  * });
  */
-export function useSiteSearchQueryQuery(baseOptions: Apollo.QueryHookOptions<SiteSearchQueryQuery, SiteSearchQueryQueryVariables>) {
-        return Apollo.useQuery<SiteSearchQueryQuery, SiteSearchQueryQueryVariables>(SiteSearchQueryDocument, baseOptions);
+export function useSiteSearchQuery(baseOptions: Apollo.QueryHookOptions<SiteSearchQueryData, SiteSearchQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SiteSearchQueryData, SiteSearchQueryVariables>(SiteSearchQueryDocument, options);
       }
-export function useSiteSearchQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SiteSearchQueryQuery, SiteSearchQueryQueryVariables>) {
-          return Apollo.useLazyQuery<SiteSearchQueryQuery, SiteSearchQueryQueryVariables>(SiteSearchQueryDocument, baseOptions);
+export function useSiteSearchQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SiteSearchQueryData, SiteSearchQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SiteSearchQueryData, SiteSearchQueryVariables>(SiteSearchQueryDocument, options);
         }
-export type SiteSearchQueryQueryHookResult = ReturnType<typeof useSiteSearchQueryQuery>;
+export type SiteSearchQueryHookResult = ReturnType<typeof useSiteSearchQuery>;
 export type SiteSearchQueryLazyQueryHookResult = ReturnType<typeof useSiteSearchQueryLazyQuery>;
-export type SiteSearchQueryQueryResult = Apollo.QueryResult<SiteSearchQueryQuery, SiteSearchQueryQueryVariables>;
+export type SiteSearchQueryDataResult = Apollo.QueryResult<SiteSearchQueryData, SiteSearchQueryVariables>;

--- a/app/javascript/NotificationAdmin/NotificationConfiguration.tsx
+++ b/app/javascript/NotificationAdmin/NotificationConfiguration.tsx
@@ -4,125 +4,111 @@ import { useHistory, useParams } from 'react-router-dom';
 import NotificationsConfig from '../../../config/notifications.json';
 import ErrorDisplay from '../ErrorDisplay';
 import LiquidInput from '../BuiltInFormControls/LiquidInput';
-import { useNotificationAdminQueryQuery } from './queries.generated';
+import { useNotificationAdminQuery } from './queries.generated';
 import { useUpdateNotificationTemplateMutation } from './mutations.generated';
 import { usePropertySetters } from '../usePropertySetters';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 import FourOhFourPage from '../FourOhFourPage';
 
-export default LoadQueryWrapper(useNotificationAdminQueryQuery, function NotificationConfiguration({
-  data,
-}) {
-  const params = useParams<{ category: string; event: string }>();
-  const history = useHistory();
-  const category = useMemo(
-    () => NotificationsConfig.categories.find((c) => c.key === params.category)!,
-    [params.category],
-  );
-  const event = useMemo(() => category.events.find((e) => e.key === params.event)!, [
-    category,
-    params.event,
-  ]);
+export default LoadQueryWrapper(
+  useNotificationAdminQuery,
+  function NotificationConfiguration({ data }) {
+    const params = useParams<{ category: string; event: string }>();
+    const history = useHistory();
+    const category = useMemo(
+      () => NotificationsConfig.categories.find((c) => c.key === params.category)!,
+      [params.category],
+    );
+    const event = useMemo(() => category.events.find((e) => e.key === params.event)!, [
+      category,
+      params.event,
+    ]);
 
-  const [
-    updateNotificationTemplate,
-    { loading: updateInProgress, error: updateError },
-  ] = useUpdateNotificationTemplateMutation();
+    const [
+      updateNotificationTemplate,
+      { loading: updateInProgress, error: updateError },
+    ] = useUpdateNotificationTemplateMutation();
 
-  const eventKey = `${category.key}/${event.key}`;
+    const eventKey = `${category.key}/${event.key}`;
 
-  const initialNotificationTemplate = data.convention.notification_templates.find(
-    (t) => t.event_key === eventKey,
-  )!;
-  const [notificationTemplate, setNotificationTemplate] = useState(initialNotificationTemplate);
+    const initialNotificationTemplate = data.convention.notification_templates.find(
+      (t) => t.event_key === eventKey,
+    )!;
+    const [notificationTemplate, setNotificationTemplate] = useState(initialNotificationTemplate);
 
-  const [setSubject, setBodyHtml, setBodyText, setBodySms] = usePropertySetters(
-    setNotificationTemplate,
-    'subject',
-    'body_html',
-    'body_text',
-    'body_sms',
-  );
+    const [setSubject, setBodyHtml, setBodyText, setBodySms] = usePropertySetters(
+      setNotificationTemplate,
+      'subject',
+      'body_html',
+      'body_text',
+      'body_sms',
+    );
 
-  // if the page changes and we're still mounted
-  useEffect(() => setNotificationTemplate(initialNotificationTemplate), [
-    initialNotificationTemplate,
-  ]);
+    // if the page changes and we're still mounted
+    useEffect(() => setNotificationTemplate(initialNotificationTemplate), [
+      initialNotificationTemplate,
+    ]);
 
-  const saveClicked = async () => {
+    const saveClicked = async () => {
+      if (!notificationTemplate) {
+        return;
+      }
+
+      await updateNotificationTemplate({
+        variables: {
+          eventKey,
+          notificationTemplate: {
+            subject: notificationTemplate.subject,
+            body_html: notificationTemplate.body_html,
+            body_text: notificationTemplate.body_text,
+            body_sms: notificationTemplate.body_sms,
+          },
+        },
+      });
+
+      history.push('/admin_notifications');
+    };
+
     if (!notificationTemplate) {
-      return;
+      return <FourOhFourPage />;
     }
 
-    await updateNotificationTemplate({
-      variables: {
-        eventKey,
-        notificationTemplate: {
-          subject: notificationTemplate.subject,
-          body_html: notificationTemplate.body_html,
-          body_text: notificationTemplate.body_text,
-          body_sms: notificationTemplate.body_sms,
-        },
-      },
-    });
+    return (
+      <>
+        <header className="mb-4">
+          <h1>
+            {category.name} &mdash; {event.name}
+          </h1>
+          <h4>Destination: {event.destination_description}</h4>
+        </header>
 
-    history.push('/admin_notifications');
-  };
-
-  if (!notificationTemplate) {
-    return <FourOhFourPage />;
-  }
-
-  return (
-    <>
-      <header className="mb-4">
-        <h1>
-          {category.name} &mdash; {event.name}
-        </h1>
-        <h4>Destination: {event.destination_description}</h4>
-      </header>
-
-      <div className="form-group">
-        <legend className="col-form-label">Subject line</legend>
-        <LiquidInput
-          value={notificationTemplate.subject ?? ''}
-          onChange={setSubject}
-          notifierEventKey={eventKey}
-          renderPreview={(previewContent) => <>{previewContent}</>}
-          lines={1}
-          disabled={updateInProgress}
-        />
-      </div>
-
-      <div className="form-group">
-        <legend className="col-form-label">Notification body (HTML)</legend>
-        <LiquidInput
-          value={notificationTemplate.body_html ?? ''}
-          onChange={setBodyHtml}
-          notifierEventKey={eventKey}
-          disabled={updateInProgress}
-        />
-      </div>
-
-      <div className="form-group">
-        <legend className="col-form-label">Notification body (plain text)</legend>
-        <LiquidInput
-          value={notificationTemplate.body_text ?? ''}
-          onChange={setBodyText}
-          notifierEventKey={eventKey}
-          renderPreview={(previewContent) => (
-            <pre style={{ whiteSpace: 'pre-wrap' }}>{previewContent}</pre>
-          )}
-          disabled={updateInProgress}
-        />
-      </div>
-
-      {event.sends_sms ? (
         <div className="form-group">
-          <legend className="col-form-label">Notification body (SMS text message)</legend>
+          <legend className="col-form-label">Subject line</legend>
           <LiquidInput
-            value={notificationTemplate.body_sms ?? ''}
-            onChange={setBodySms}
+            value={notificationTemplate.subject ?? ''}
+            onChange={setSubject}
+            notifierEventKey={eventKey}
+            renderPreview={(previewContent) => <>{previewContent}</>}
+            lines={1}
+            disabled={updateInProgress}
+          />
+        </div>
+
+        <div className="form-group">
+          <legend className="col-form-label">Notification body (HTML)</legend>
+          <LiquidInput
+            value={notificationTemplate.body_html ?? ''}
+            onChange={setBodyHtml}
+            notifierEventKey={eventKey}
+            disabled={updateInProgress}
+          />
+        </div>
+
+        <div className="form-group">
+          <legend className="col-form-label">Notification body (plain text)</legend>
+          <LiquidInput
+            value={notificationTemplate.body_text ?? ''}
+            onChange={setBodyText}
             notifierEventKey={eventKey}
             renderPreview={(previewContent) => (
               <pre style={{ whiteSpace: 'pre-wrap' }}>{previewContent}</pre>
@@ -130,22 +116,37 @@ export default LoadQueryWrapper(useNotificationAdminQueryQuery, function Notific
             disabled={updateInProgress}
           />
         </div>
-      ) : (
-        <p>
-          <em>This event does not send SMS text messages.</em>
-        </p>
-      )}
 
-      <ErrorDisplay graphQLError={updateError} />
+        {event.sends_sms ? (
+          <div className="form-group">
+            <legend className="col-form-label">Notification body (SMS text message)</legend>
+            <LiquidInput
+              value={notificationTemplate.body_sms ?? ''}
+              onChange={setBodySms}
+              notifierEventKey={eventKey}
+              renderPreview={(previewContent) => (
+                <pre style={{ whiteSpace: 'pre-wrap' }}>{previewContent}</pre>
+              )}
+              disabled={updateInProgress}
+            />
+          </div>
+        ) : (
+          <p>
+            <em>This event does not send SMS text messages.</em>
+          </p>
+        )}
 
-      <button
-        type="button"
-        className="btn btn-primary"
-        onClick={saveClicked}
-        disabled={updateInProgress}
-      >
-        Save changes
-      </button>
-    </>
-  );
-});
+        <ErrorDisplay graphQLError={updateError} />
+
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={saveClicked}
+          disabled={updateInProgress}
+        >
+          Save changes
+        </button>
+      </>
+    );
+  },
+);

--- a/app/javascript/NotificationAdmin/mutations.generated.ts
+++ b/app/javascript/NotificationAdmin/mutations.generated.ts
@@ -5,13 +5,14 @@ import { NotificationTemplateFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { NotificationTemplateFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type UpdateNotificationTemplateMutationVariables = Types.Exact<{
   eventKey: Types.Scalars['String'];
   notificationTemplate: Types.NotificationTemplateInput;
 }>;
 
 
-export type UpdateNotificationTemplateMutation = (
+export type UpdateNotificationTemplateMutationData = (
   { __typename: 'Mutation' }
   & { updateNotificationTemplate?: Types.Maybe<(
     { __typename: 'UpdateNotificationTemplatePayload' }
@@ -36,7 +37,7 @@ export const UpdateNotificationTemplateDocument = gql`
   }
 }
     ${NotificationTemplateFieldsFragmentDoc}`;
-export type UpdateNotificationTemplateMutationFn = Apollo.MutationFunction<UpdateNotificationTemplateMutation, UpdateNotificationTemplateMutationVariables>;
+export type UpdateNotificationTemplateMutationFn = Apollo.MutationFunction<UpdateNotificationTemplateMutationData, UpdateNotificationTemplateMutationVariables>;
 
 /**
  * __useUpdateNotificationTemplateMutation__
@@ -56,9 +57,10 @@ export type UpdateNotificationTemplateMutationFn = Apollo.MutationFunction<Updat
  *   },
  * });
  */
-export function useUpdateNotificationTemplateMutation(baseOptions?: Apollo.MutationHookOptions<UpdateNotificationTemplateMutation, UpdateNotificationTemplateMutationVariables>) {
-        return Apollo.useMutation<UpdateNotificationTemplateMutation, UpdateNotificationTemplateMutationVariables>(UpdateNotificationTemplateDocument, baseOptions);
+export function useUpdateNotificationTemplateMutation(baseOptions?: Apollo.MutationHookOptions<UpdateNotificationTemplateMutationData, UpdateNotificationTemplateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateNotificationTemplateMutationData, UpdateNotificationTemplateMutationVariables>(UpdateNotificationTemplateDocument, options);
       }
 export type UpdateNotificationTemplateMutationHookResult = ReturnType<typeof useUpdateNotificationTemplateMutation>;
-export type UpdateNotificationTemplateMutationResult = Apollo.MutationResult<UpdateNotificationTemplateMutation>;
-export type UpdateNotificationTemplateMutationOptions = Apollo.BaseMutationOptions<UpdateNotificationTemplateMutation, UpdateNotificationTemplateMutationVariables>;
+export type UpdateNotificationTemplateMutationResult = Apollo.MutationResult<UpdateNotificationTemplateMutationData>;
+export type UpdateNotificationTemplateMutationOptions = Apollo.BaseMutationOptions<UpdateNotificationTemplateMutationData, UpdateNotificationTemplateMutationVariables>;

--- a/app/javascript/NotificationAdmin/queries.generated.ts
+++ b/app/javascript/NotificationAdmin/queries.generated.ts
@@ -3,15 +3,16 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type NotificationTemplateFieldsFragment = (
   { __typename: 'NotificationTemplate' }
   & Pick<Types.NotificationTemplate, 'id' | 'event_key' | 'subject' | 'body_html' | 'body_text' | 'body_sms'>
 );
 
-export type NotificationAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type NotificationAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type NotificationAdminQueryQuery = (
+export type NotificationAdminQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -47,26 +48,28 @@ export const NotificationAdminQueryDocument = gql`
     ${NotificationTemplateFieldsFragmentDoc}`;
 
 /**
- * __useNotificationAdminQueryQuery__
+ * __useNotificationAdminQuery__
  *
- * To run a query within a React component, call `useNotificationAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useNotificationAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useNotificationAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNotificationAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useNotificationAdminQueryQuery({
+ * const { data, loading, error } = useNotificationAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useNotificationAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<NotificationAdminQueryQuery, NotificationAdminQueryQueryVariables>) {
-        return Apollo.useQuery<NotificationAdminQueryQuery, NotificationAdminQueryQueryVariables>(NotificationAdminQueryDocument, baseOptions);
+export function useNotificationAdminQuery(baseOptions?: Apollo.QueryHookOptions<NotificationAdminQueryData, NotificationAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<NotificationAdminQueryData, NotificationAdminQueryVariables>(NotificationAdminQueryDocument, options);
       }
-export function useNotificationAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NotificationAdminQueryQuery, NotificationAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<NotificationAdminQueryQuery, NotificationAdminQueryQueryVariables>(NotificationAdminQueryDocument, baseOptions);
+export function useNotificationAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NotificationAdminQueryData, NotificationAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<NotificationAdminQueryData, NotificationAdminQueryVariables>(NotificationAdminQueryDocument, options);
         }
-export type NotificationAdminQueryQueryHookResult = ReturnType<typeof useNotificationAdminQueryQuery>;
+export type NotificationAdminQueryHookResult = ReturnType<typeof useNotificationAdminQuery>;
 export type NotificationAdminQueryLazyQueryHookResult = ReturnType<typeof useNotificationAdminQueryLazyQuery>;
-export type NotificationAdminQueryQueryResult = Apollo.QueryResult<NotificationAdminQueryQuery, NotificationAdminQueryQueryVariables>;
+export type NotificationAdminQueryDataResult = Apollo.QueryResult<NotificationAdminQueryData, NotificationAdminQueryVariables>;

--- a/app/javascript/OAuth/AuthorizationPrompt.tsx
+++ b/app/javascript/OAuth/AuthorizationPrompt.tsx
@@ -7,7 +7,7 @@ import ErrorDisplay from '../ErrorDisplay';
 import AuthenticationModalContext from '../Authentication/AuthenticationModalContext';
 import usePageTitle from '../usePageTitle';
 import PageLoadingIndicator from '../PageLoadingIndicator';
-import { useOAuthAuthorizationPromptQueryQuery } from './queries.generated';
+import { useOAuthAuthorizationPromptQuery } from './queries.generated';
 
 type AuthorizationParams = {
   client_id?: string;
@@ -37,7 +37,7 @@ function AuthorizationPrompt() {
       ),
     [location.search],
   );
-  const { data, loading, error } = useOAuthAuthorizationPromptQueryQuery({
+  const { data, loading, error } = useOAuthAuthorizationPromptQuery({
     variables: { queryParams: preAuthParamsJSON },
   });
   const preAuth = useMemo(() => {

--- a/app/javascript/OAuth/AuthorizedApplications.tsx
+++ b/app/javascript/OAuth/AuthorizedApplications.tsx
@@ -5,12 +5,12 @@ import { RevokeAuthorizedApplication } from './mutations';
 import { useDeleteMutation } from '../MutationUtils';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 import {
-  OAuthAuthorizedApplicationsQueryQuery,
-  useOAuthAuthorizedApplicationsQueryQuery,
+  OAuthAuthorizedApplicationsQueryData,
+  useOAuthAuthorizedApplicationsQuery,
 } from './queries.generated';
 
 export default LoadQueryWrapper(
-  useOAuthAuthorizedApplicationsQueryQuery,
+  useOAuthAuthorizedApplicationsQuery,
   function AuthorizedApplications({ data }) {
     const revokeAuthorizedApplication = useDeleteMutation(RevokeAuthorizedApplication, {
       query: OAuthAuthorizedApplicationsQuery,
@@ -21,7 +21,7 @@ export default LoadQueryWrapper(
     const confirm = useGraphQLConfirm();
 
     const revokeClicked = (
-      authorizedApplication: OAuthAuthorizedApplicationsQueryQuery['myAuthorizedApplications'][0],
+      authorizedApplication: OAuthAuthorizedApplicationsQueryData['myAuthorizedApplications'][0],
     ) => {
       confirm({
         prompt: `Are you sure you want to revoke the authorization for ${authorizedApplication.name}?`,

--- a/app/javascript/OAuth/mutations.generated.ts
+++ b/app/javascript/OAuth/mutations.generated.ts
@@ -3,12 +3,13 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type RevokeAuthorizedApplicationMutationVariables = Types.Exact<{
   uid: Types.Scalars['ID'];
 }>;
 
 
-export type RevokeAuthorizedApplicationMutation = (
+export type RevokeAuthorizedApplicationMutationData = (
   { __typename: 'Mutation' }
   & { revokeAuthorizedApplication?: Types.Maybe<(
     { __typename: 'RevokeAuthorizedApplicationPayload' }
@@ -24,7 +25,7 @@ export const RevokeAuthorizedApplicationDocument = gql`
   }
 }
     `;
-export type RevokeAuthorizedApplicationMutationFn = Apollo.MutationFunction<RevokeAuthorizedApplicationMutation, RevokeAuthorizedApplicationMutationVariables>;
+export type RevokeAuthorizedApplicationMutationFn = Apollo.MutationFunction<RevokeAuthorizedApplicationMutationData, RevokeAuthorizedApplicationMutationVariables>;
 
 /**
  * __useRevokeAuthorizedApplicationMutation__
@@ -43,9 +44,10 @@ export type RevokeAuthorizedApplicationMutationFn = Apollo.MutationFunction<Revo
  *   },
  * });
  */
-export function useRevokeAuthorizedApplicationMutation(baseOptions?: Apollo.MutationHookOptions<RevokeAuthorizedApplicationMutation, RevokeAuthorizedApplicationMutationVariables>) {
-        return Apollo.useMutation<RevokeAuthorizedApplicationMutation, RevokeAuthorizedApplicationMutationVariables>(RevokeAuthorizedApplicationDocument, baseOptions);
+export function useRevokeAuthorizedApplicationMutation(baseOptions?: Apollo.MutationHookOptions<RevokeAuthorizedApplicationMutationData, RevokeAuthorizedApplicationMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RevokeAuthorizedApplicationMutationData, RevokeAuthorizedApplicationMutationVariables>(RevokeAuthorizedApplicationDocument, options);
       }
 export type RevokeAuthorizedApplicationMutationHookResult = ReturnType<typeof useRevokeAuthorizedApplicationMutation>;
-export type RevokeAuthorizedApplicationMutationResult = Apollo.MutationResult<RevokeAuthorizedApplicationMutation>;
-export type RevokeAuthorizedApplicationMutationOptions = Apollo.BaseMutationOptions<RevokeAuthorizedApplicationMutation, RevokeAuthorizedApplicationMutationVariables>;
+export type RevokeAuthorizedApplicationMutationResult = Apollo.MutationResult<RevokeAuthorizedApplicationMutationData>;
+export type RevokeAuthorizedApplicationMutationOptions = Apollo.BaseMutationOptions<RevokeAuthorizedApplicationMutationData, RevokeAuthorizedApplicationMutationVariables>;

--- a/app/javascript/OAuth/queries.generated.ts
+++ b/app/javascript/OAuth/queries.generated.ts
@@ -3,12 +3,13 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type OAuthAuthorizationPromptQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type OAuthAuthorizationPromptQueryVariables = Types.Exact<{
   queryParams: Types.Scalars['Json'];
 }>;
 
 
-export type OAuthAuthorizationPromptQueryQuery = (
+export type OAuthAuthorizationPromptQueryData = (
   { __typename: 'Query' }
   & Pick<Types.Query, 'oauthPreAuth'>
   & { currentUser?: Types.Maybe<(
@@ -17,10 +18,10 @@ export type OAuthAuthorizationPromptQueryQuery = (
   )> }
 );
 
-export type OAuthAuthorizedApplicationsQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type OAuthAuthorizedApplicationsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type OAuthAuthorizedApplicationsQueryQuery = (
+export type OAuthAuthorizedApplicationsQueryData = (
   { __typename: 'Query' }
   & { myAuthorizedApplications: Array<(
     { __typename: 'AuthorizedApplication' }
@@ -39,30 +40,32 @@ export const OAuthAuthorizationPromptQueryDocument = gql`
     `;
 
 /**
- * __useOAuthAuthorizationPromptQueryQuery__
+ * __useOAuthAuthorizationPromptQuery__
  *
- * To run a query within a React component, call `useOAuthAuthorizationPromptQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useOAuthAuthorizationPromptQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useOAuthAuthorizationPromptQuery` and pass it any options that fit your needs.
+ * When your component renders, `useOAuthAuthorizationPromptQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useOAuthAuthorizationPromptQueryQuery({
+ * const { data, loading, error } = useOAuthAuthorizationPromptQuery({
  *   variables: {
  *      queryParams: // value for 'queryParams'
  *   },
  * });
  */
-export function useOAuthAuthorizationPromptQueryQuery(baseOptions: Apollo.QueryHookOptions<OAuthAuthorizationPromptQueryQuery, OAuthAuthorizationPromptQueryQueryVariables>) {
-        return Apollo.useQuery<OAuthAuthorizationPromptQueryQuery, OAuthAuthorizationPromptQueryQueryVariables>(OAuthAuthorizationPromptQueryDocument, baseOptions);
+export function useOAuthAuthorizationPromptQuery(baseOptions: Apollo.QueryHookOptions<OAuthAuthorizationPromptQueryData, OAuthAuthorizationPromptQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<OAuthAuthorizationPromptQueryData, OAuthAuthorizationPromptQueryVariables>(OAuthAuthorizationPromptQueryDocument, options);
       }
-export function useOAuthAuthorizationPromptQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OAuthAuthorizationPromptQueryQuery, OAuthAuthorizationPromptQueryQueryVariables>) {
-          return Apollo.useLazyQuery<OAuthAuthorizationPromptQueryQuery, OAuthAuthorizationPromptQueryQueryVariables>(OAuthAuthorizationPromptQueryDocument, baseOptions);
+export function useOAuthAuthorizationPromptQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OAuthAuthorizationPromptQueryData, OAuthAuthorizationPromptQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<OAuthAuthorizationPromptQueryData, OAuthAuthorizationPromptQueryVariables>(OAuthAuthorizationPromptQueryDocument, options);
         }
-export type OAuthAuthorizationPromptQueryQueryHookResult = ReturnType<typeof useOAuthAuthorizationPromptQueryQuery>;
+export type OAuthAuthorizationPromptQueryHookResult = ReturnType<typeof useOAuthAuthorizationPromptQuery>;
 export type OAuthAuthorizationPromptQueryLazyQueryHookResult = ReturnType<typeof useOAuthAuthorizationPromptQueryLazyQuery>;
-export type OAuthAuthorizationPromptQueryQueryResult = Apollo.QueryResult<OAuthAuthorizationPromptQueryQuery, OAuthAuthorizationPromptQueryQueryVariables>;
+export type OAuthAuthorizationPromptQueryDataResult = Apollo.QueryResult<OAuthAuthorizationPromptQueryData, OAuthAuthorizationPromptQueryVariables>;
 export const OAuthAuthorizedApplicationsQueryDocument = gql`
     query OAuthAuthorizedApplicationsQuery {
   myAuthorizedApplications {
@@ -74,26 +77,28 @@ export const OAuthAuthorizedApplicationsQueryDocument = gql`
     `;
 
 /**
- * __useOAuthAuthorizedApplicationsQueryQuery__
+ * __useOAuthAuthorizedApplicationsQuery__
  *
- * To run a query within a React component, call `useOAuthAuthorizedApplicationsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useOAuthAuthorizedApplicationsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useOAuthAuthorizedApplicationsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useOAuthAuthorizedApplicationsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useOAuthAuthorizedApplicationsQueryQuery({
+ * const { data, loading, error } = useOAuthAuthorizedApplicationsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useOAuthAuthorizedApplicationsQueryQuery(baseOptions?: Apollo.QueryHookOptions<OAuthAuthorizedApplicationsQueryQuery, OAuthAuthorizedApplicationsQueryQueryVariables>) {
-        return Apollo.useQuery<OAuthAuthorizedApplicationsQueryQuery, OAuthAuthorizedApplicationsQueryQueryVariables>(OAuthAuthorizedApplicationsQueryDocument, baseOptions);
+export function useOAuthAuthorizedApplicationsQuery(baseOptions?: Apollo.QueryHookOptions<OAuthAuthorizedApplicationsQueryData, OAuthAuthorizedApplicationsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<OAuthAuthorizedApplicationsQueryData, OAuthAuthorizedApplicationsQueryVariables>(OAuthAuthorizedApplicationsQueryDocument, options);
       }
-export function useOAuthAuthorizedApplicationsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OAuthAuthorizedApplicationsQueryQuery, OAuthAuthorizedApplicationsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<OAuthAuthorizedApplicationsQueryQuery, OAuthAuthorizedApplicationsQueryQueryVariables>(OAuthAuthorizedApplicationsQueryDocument, baseOptions);
+export function useOAuthAuthorizedApplicationsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OAuthAuthorizedApplicationsQueryData, OAuthAuthorizedApplicationsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<OAuthAuthorizedApplicationsQueryData, OAuthAuthorizedApplicationsQueryVariables>(OAuthAuthorizedApplicationsQueryDocument, options);
         }
-export type OAuthAuthorizedApplicationsQueryQueryHookResult = ReturnType<typeof useOAuthAuthorizedApplicationsQueryQuery>;
+export type OAuthAuthorizedApplicationsQueryHookResult = ReturnType<typeof useOAuthAuthorizedApplicationsQuery>;
 export type OAuthAuthorizedApplicationsQueryLazyQueryHookResult = ReturnType<typeof useOAuthAuthorizedApplicationsQueryLazyQuery>;
-export type OAuthAuthorizedApplicationsQueryQueryResult = Apollo.QueryResult<OAuthAuthorizedApplicationsQueryQuery, OAuthAuthorizedApplicationsQueryQueryVariables>;
+export type OAuthAuthorizedApplicationsQueryDataResult = Apollo.QueryResult<OAuthAuthorizedApplicationsQueryData, OAuthAuthorizedApplicationsQueryVariables>;

--- a/app/javascript/OrganizationAdmin/EditOrganizationRole.tsx
+++ b/app/javascript/OrganizationAdmin/EditOrganizationRole.tsx
@@ -5,11 +5,11 @@ import ErrorDisplay from '../ErrorDisplay';
 import useOrganizationRoleForm, { OrganizationRoleFormState } from './useOrganizationRoleForm';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useOrganizationAdminOrganizationsQueryQuery } from './queries.generated';
+import { useOrganizationAdminOrganizationsQuery } from './queries.generated';
 import { useUpdateOrganizationRoleMutation } from './mutations.generated';
 
 export default LoadQueryWrapper(
-  useOrganizationAdminOrganizationsQueryQuery,
+  useOrganizationAdminOrganizationsQuery,
   function EditOrganizationRoleForm({ data }) {
     const history = useHistory();
     const params = useParams<{ organizationId: string; organizationRoleId: string }>();

--- a/app/javascript/OrganizationAdmin/NewOrganizationRole.tsx
+++ b/app/javascript/OrganizationAdmin/NewOrganizationRole.tsx
@@ -6,13 +6,13 @@ import useOrganizationRoleForm, { OrganizationRoleFormState } from './useOrganiz
 import usePageTitle from '../usePageTitle';
 import { LoadSingleValueFromCollectionWrapper } from '../GraphqlLoadingWrappers';
 import {
-  OrganizationAdminOrganizationsQueryQuery,
-  useOrganizationAdminOrganizationsQueryQuery,
+  OrganizationAdminOrganizationsQueryData,
+  useOrganizationAdminOrganizationsQuery,
 } from './queries.generated';
 import { useCreateOrganizationRoleMutation } from './mutations.generated';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useOrganizationAdminOrganizationsQueryQuery,
+  useOrganizationAdminOrganizationsQuery,
   (data, id) => data.organizations.find((org) => org.id.toString() === id),
   function NewOrganizationRole({ value: organization }) {
     const history = useHistory();
@@ -49,7 +49,7 @@ export default LoadSingleValueFromCollectionWrapper(
           })),
         },
         update: (proxy, result) => {
-          const storeData = proxy.readQuery<OrganizationAdminOrganizationsQueryQuery>({
+          const storeData = proxy.readQuery<OrganizationAdminOrganizationsQueryData>({
             query: OrganizationAdminOrganizationsQuery,
           });
           const newRole = result.data?.createOrganizationRole?.organization_role;

--- a/app/javascript/OrganizationAdmin/OrganizationDisplay.tsx
+++ b/app/javascript/OrganizationAdmin/OrganizationDisplay.tsx
@@ -9,8 +9,8 @@ import usePageTitle from '../usePageTitle';
 import { DropdownMenu } from '../UIComponents/DropdownMenu';
 import { LoadSingleValueFromCollectionWrapper } from '../GraphqlLoadingWrappers';
 import {
-  OrganizationAdminOrganizationsQueryQuery,
-  useOrganizationAdminOrganizationsQueryQuery,
+  OrganizationAdminOrganizationsQueryData,
+  useOrganizationAdminOrganizationsQuery,
 } from './queries.generated';
 import { useDeleteOrganizationRoleMutation } from './mutations.generated';
 
@@ -23,7 +23,7 @@ function getOrganizationRolePermissionName(permissionName: string) {
 }
 
 export default LoadSingleValueFromCollectionWrapper(
-  useOrganizationAdminOrganizationsQueryQuery,
+  useOrganizationAdminOrganizationsQuery,
   (data, id) => data.organizations.find((org) => org.id.toString() === id),
   function OrganizationDisplay({ value: organization }) {
     const confirm = useConfirm();
@@ -39,7 +39,7 @@ export default LoadSingleValueFromCollectionWrapper(
       mutate({
         variables: { id },
         update: (proxy) => {
-          const storeData = proxy.readQuery<OrganizationAdminOrganizationsQueryQuery>({
+          const storeData = proxy.readQuery<OrganizationAdminOrganizationsQueryData>({
             query: OrganizationAdminOrganizationsQuery,
           });
           if (!storeData) {

--- a/app/javascript/OrganizationAdmin/OrganizationIndex.tsx
+++ b/app/javascript/OrganizationAdmin/OrganizationIndex.tsx
@@ -5,12 +5,12 @@ import { sortByLocaleString } from '../ValueUtils';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 import {
-  OrganizationAdminOrganizationsQueryQuery,
-  useOrganizationAdminOrganizationsQueryQuery,
+  OrganizationAdminOrganizationsQueryData,
+  useOrganizationAdminOrganizationsQuery,
 } from './queries.generated';
 
 function renderOrganizationConventions(
-  organization: OrganizationAdminOrganizationsQueryQuery['organizations'][0],
+  organization: OrganizationAdminOrganizationsQueryData['organizations'][0],
 ) {
   const sortedConventions = sortBy(organization.conventions, [
     (convention) => convention.starts_at,
@@ -26,7 +26,7 @@ function renderOrganizationConventions(
 }
 
 export default LoadQueryWrapper(
-  useOrganizationAdminOrganizationsQueryQuery,
+  useOrganizationAdminOrganizationsQuery,
   function OrganizationIndex({ data }) {
     usePageTitle('Organizations');
 

--- a/app/javascript/OrganizationAdmin/index.tsx
+++ b/app/javascript/OrganizationAdmin/index.tsx
@@ -9,12 +9,12 @@ import BreadcrumbItem from '../Breadcrumbs/BreadcrumbItem';
 import LoadingIndicator from '../LoadingIndicator';
 import RouteActivatedBreadcrumbItem from '../Breadcrumbs/RouteActivatedBreadcrumbItem';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
-import { useOrganizationAdminOrganizationsQueryQuery } from './queries.generated';
+import { useOrganizationAdminOrganizationsQuery } from './queries.generated';
 
 function OrganizationWithIdBreadcrumbs() {
   const match = useRouteMatch();
   const { id } = useParams<{ id: string }>();
-  const { data, loading, error } = useOrganizationAdminOrganizationsQueryQuery();
+  const { data, loading, error } = useOrganizationAdminOrganizationsQuery();
 
   if (loading) {
     return (

--- a/app/javascript/OrganizationAdmin/mutations.generated.ts
+++ b/app/javascript/OrganizationAdmin/mutations.generated.ts
@@ -5,6 +5,7 @@ import { OrganizationRoleFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { OrganizationRoleFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateOrganizationRoleMutationVariables = Types.Exact<{
   organizationId: Types.Scalars['Int'];
   name: Types.Scalars['String'];
@@ -13,7 +14,7 @@ export type CreateOrganizationRoleMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateOrganizationRoleMutation = (
+export type CreateOrganizationRoleMutationData = (
   { __typename: 'Mutation' }
   & { createOrganizationRole?: Types.Maybe<(
     { __typename: 'CreateOrganizationRolePayload' }
@@ -35,7 +36,7 @@ export type UpdateOrganizationRoleMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateOrganizationRoleMutation = (
+export type UpdateOrganizationRoleMutationData = (
   { __typename: 'Mutation' }
   & { updateOrganizationRole?: Types.Maybe<(
     { __typename: 'UpdateOrganizationRolePayload' }
@@ -52,7 +53,7 @@ export type DeleteOrganizationRoleMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteOrganizationRoleMutation = (
+export type DeleteOrganizationRoleMutationData = (
   { __typename: 'Mutation' }
   & { deleteOrganizationRole?: Types.Maybe<(
     { __typename: 'DeleteOrganizationRolePayload' }
@@ -73,7 +74,7 @@ export const CreateOrganizationRoleDocument = gql`
   }
 }
     ${OrganizationRoleFieldsFragmentDoc}`;
-export type CreateOrganizationRoleMutationFn = Apollo.MutationFunction<CreateOrganizationRoleMutation, CreateOrganizationRoleMutationVariables>;
+export type CreateOrganizationRoleMutationFn = Apollo.MutationFunction<CreateOrganizationRoleMutationData, CreateOrganizationRoleMutationVariables>;
 
 /**
  * __useCreateOrganizationRoleMutation__
@@ -95,12 +96,13 @@ export type CreateOrganizationRoleMutationFn = Apollo.MutationFunction<CreateOrg
  *   },
  * });
  */
-export function useCreateOrganizationRoleMutation(baseOptions?: Apollo.MutationHookOptions<CreateOrganizationRoleMutation, CreateOrganizationRoleMutationVariables>) {
-        return Apollo.useMutation<CreateOrganizationRoleMutation, CreateOrganizationRoleMutationVariables>(CreateOrganizationRoleDocument, baseOptions);
+export function useCreateOrganizationRoleMutation(baseOptions?: Apollo.MutationHookOptions<CreateOrganizationRoleMutationData, CreateOrganizationRoleMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateOrganizationRoleMutationData, CreateOrganizationRoleMutationVariables>(CreateOrganizationRoleDocument, options);
       }
 export type CreateOrganizationRoleMutationHookResult = ReturnType<typeof useCreateOrganizationRoleMutation>;
-export type CreateOrganizationRoleMutationResult = Apollo.MutationResult<CreateOrganizationRoleMutation>;
-export type CreateOrganizationRoleMutationOptions = Apollo.BaseMutationOptions<CreateOrganizationRoleMutation, CreateOrganizationRoleMutationVariables>;
+export type CreateOrganizationRoleMutationResult = Apollo.MutationResult<CreateOrganizationRoleMutationData>;
+export type CreateOrganizationRoleMutationOptions = Apollo.BaseMutationOptions<CreateOrganizationRoleMutationData, CreateOrganizationRoleMutationVariables>;
 export const UpdateOrganizationRoleDocument = gql`
     mutation UpdateOrganizationRole($id: Int!, $name: String, $addUserIds: [Int!], $removeUserIds: [Int!], $addPermissions: [PermissionInput!], $removePermissionIds: [Int!]) {
   updateOrganizationRole(
@@ -113,7 +115,7 @@ export const UpdateOrganizationRoleDocument = gql`
   }
 }
     ${OrganizationRoleFieldsFragmentDoc}`;
-export type UpdateOrganizationRoleMutationFn = Apollo.MutationFunction<UpdateOrganizationRoleMutation, UpdateOrganizationRoleMutationVariables>;
+export type UpdateOrganizationRoleMutationFn = Apollo.MutationFunction<UpdateOrganizationRoleMutationData, UpdateOrganizationRoleMutationVariables>;
 
 /**
  * __useUpdateOrganizationRoleMutation__
@@ -137,12 +139,13 @@ export type UpdateOrganizationRoleMutationFn = Apollo.MutationFunction<UpdateOrg
  *   },
  * });
  */
-export function useUpdateOrganizationRoleMutation(baseOptions?: Apollo.MutationHookOptions<UpdateOrganizationRoleMutation, UpdateOrganizationRoleMutationVariables>) {
-        return Apollo.useMutation<UpdateOrganizationRoleMutation, UpdateOrganizationRoleMutationVariables>(UpdateOrganizationRoleDocument, baseOptions);
+export function useUpdateOrganizationRoleMutation(baseOptions?: Apollo.MutationHookOptions<UpdateOrganizationRoleMutationData, UpdateOrganizationRoleMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateOrganizationRoleMutationData, UpdateOrganizationRoleMutationVariables>(UpdateOrganizationRoleDocument, options);
       }
 export type UpdateOrganizationRoleMutationHookResult = ReturnType<typeof useUpdateOrganizationRoleMutation>;
-export type UpdateOrganizationRoleMutationResult = Apollo.MutationResult<UpdateOrganizationRoleMutation>;
-export type UpdateOrganizationRoleMutationOptions = Apollo.BaseMutationOptions<UpdateOrganizationRoleMutation, UpdateOrganizationRoleMutationVariables>;
+export type UpdateOrganizationRoleMutationResult = Apollo.MutationResult<UpdateOrganizationRoleMutationData>;
+export type UpdateOrganizationRoleMutationOptions = Apollo.BaseMutationOptions<UpdateOrganizationRoleMutationData, UpdateOrganizationRoleMutationVariables>;
 export const DeleteOrganizationRoleDocument = gql`
     mutation DeleteOrganizationRole($id: Int!) {
   deleteOrganizationRole(input: {id: $id}) {
@@ -150,7 +153,7 @@ export const DeleteOrganizationRoleDocument = gql`
   }
 }
     `;
-export type DeleteOrganizationRoleMutationFn = Apollo.MutationFunction<DeleteOrganizationRoleMutation, DeleteOrganizationRoleMutationVariables>;
+export type DeleteOrganizationRoleMutationFn = Apollo.MutationFunction<DeleteOrganizationRoleMutationData, DeleteOrganizationRoleMutationVariables>;
 
 /**
  * __useDeleteOrganizationRoleMutation__
@@ -169,9 +172,10 @@ export type DeleteOrganizationRoleMutationFn = Apollo.MutationFunction<DeleteOrg
  *   },
  * });
  */
-export function useDeleteOrganizationRoleMutation(baseOptions?: Apollo.MutationHookOptions<DeleteOrganizationRoleMutation, DeleteOrganizationRoleMutationVariables>) {
-        return Apollo.useMutation<DeleteOrganizationRoleMutation, DeleteOrganizationRoleMutationVariables>(DeleteOrganizationRoleDocument, baseOptions);
+export function useDeleteOrganizationRoleMutation(baseOptions?: Apollo.MutationHookOptions<DeleteOrganizationRoleMutationData, DeleteOrganizationRoleMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteOrganizationRoleMutationData, DeleteOrganizationRoleMutationVariables>(DeleteOrganizationRoleDocument, options);
       }
 export type DeleteOrganizationRoleMutationHookResult = ReturnType<typeof useDeleteOrganizationRoleMutation>;
-export type DeleteOrganizationRoleMutationResult = Apollo.MutationResult<DeleteOrganizationRoleMutation>;
-export type DeleteOrganizationRoleMutationOptions = Apollo.BaseMutationOptions<DeleteOrganizationRoleMutation, DeleteOrganizationRoleMutationVariables>;
+export type DeleteOrganizationRoleMutationResult = Apollo.MutationResult<DeleteOrganizationRoleMutationData>;
+export type DeleteOrganizationRoleMutationOptions = Apollo.BaseMutationOptions<DeleteOrganizationRoleMutationData, DeleteOrganizationRoleMutationVariables>;

--- a/app/javascript/OrganizationAdmin/queries.generated.ts
+++ b/app/javascript/OrganizationAdmin/queries.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type OrganizationRoleFieldsFragment = (
   { __typename: 'OrganizationRole' }
   & Pick<Types.OrganizationRole, 'id' | 'name'>
@@ -15,10 +16,10 @@ export type OrganizationRoleFieldsFragment = (
   )> }
 );
 
-export type OrganizationAdminOrganizationsQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type OrganizationAdminOrganizationsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type OrganizationAdminOrganizationsQueryQuery = (
+export type OrganizationAdminOrganizationsQueryData = (
   { __typename: 'Query' }
   & { organizations: Array<(
     { __typename: 'Organization' }
@@ -69,26 +70,28 @@ export const OrganizationAdminOrganizationsQueryDocument = gql`
     ${OrganizationRoleFieldsFragmentDoc}`;
 
 /**
- * __useOrganizationAdminOrganizationsQueryQuery__
+ * __useOrganizationAdminOrganizationsQuery__
  *
- * To run a query within a React component, call `useOrganizationAdminOrganizationsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useOrganizationAdminOrganizationsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useOrganizationAdminOrganizationsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useOrganizationAdminOrganizationsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useOrganizationAdminOrganizationsQueryQuery({
+ * const { data, loading, error } = useOrganizationAdminOrganizationsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useOrganizationAdminOrganizationsQueryQuery(baseOptions?: Apollo.QueryHookOptions<OrganizationAdminOrganizationsQueryQuery, OrganizationAdminOrganizationsQueryQueryVariables>) {
-        return Apollo.useQuery<OrganizationAdminOrganizationsQueryQuery, OrganizationAdminOrganizationsQueryQueryVariables>(OrganizationAdminOrganizationsQueryDocument, baseOptions);
+export function useOrganizationAdminOrganizationsQuery(baseOptions?: Apollo.QueryHookOptions<OrganizationAdminOrganizationsQueryData, OrganizationAdminOrganizationsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<OrganizationAdminOrganizationsQueryData, OrganizationAdminOrganizationsQueryVariables>(OrganizationAdminOrganizationsQueryDocument, options);
       }
-export function useOrganizationAdminOrganizationsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OrganizationAdminOrganizationsQueryQuery, OrganizationAdminOrganizationsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<OrganizationAdminOrganizationsQueryQuery, OrganizationAdminOrganizationsQueryQueryVariables>(OrganizationAdminOrganizationsQueryDocument, baseOptions);
+export function useOrganizationAdminOrganizationsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OrganizationAdminOrganizationsQueryData, OrganizationAdminOrganizationsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<OrganizationAdminOrganizationsQueryData, OrganizationAdminOrganizationsQueryVariables>(OrganizationAdminOrganizationsQueryDocument, options);
         }
-export type OrganizationAdminOrganizationsQueryQueryHookResult = ReturnType<typeof useOrganizationAdminOrganizationsQueryQuery>;
+export type OrganizationAdminOrganizationsQueryHookResult = ReturnType<typeof useOrganizationAdminOrganizationsQuery>;
 export type OrganizationAdminOrganizationsQueryLazyQueryHookResult = ReturnType<typeof useOrganizationAdminOrganizationsQueryLazyQuery>;
-export type OrganizationAdminOrganizationsQueryQueryResult = Apollo.QueryResult<OrganizationAdminOrganizationsQueryQuery, OrganizationAdminOrganizationsQueryQueryVariables>;
+export type OrganizationAdminOrganizationsQueryDataResult = Apollo.QueryResult<OrganizationAdminOrganizationsQueryData, OrganizationAdminOrganizationsQueryVariables>;

--- a/app/javascript/OrganizationAdmin/useOrganizationRoleForm.tsx
+++ b/app/javascript/OrganizationAdmin/useOrganizationRoleForm.tsx
@@ -6,7 +6,7 @@ import ChangeSet, { useChangeSet, useChangeSetWithSelect } from '../ChangeSet';
 import UserSelect from '../BuiltInFormControls/UserSelect';
 import PermissionNames from '../../../config/permission_names.json';
 import PermissionsTableInput from '../Permissions/PermissionsTableInput';
-import { OrganizationAdminOrganizationsQueryQuery } from './queries.generated';
+import { OrganizationAdminOrganizationsQueryData } from './queries.generated';
 import { PermissionWithId } from '../Permissions/usePermissionsChangeSet';
 
 const OrganizationRolePermissionNames = flatMap(
@@ -16,7 +16,7 @@ const OrganizationRolePermissionNames = flatMap(
   (permissionNameGroup) => permissionNameGroup.permissions,
 );
 
-type OrganizationRoleType = OrganizationAdminOrganizationsQueryQuery['organizations'][0]['organization_roles'][0];
+type OrganizationRoleType = OrganizationAdminOrganizationsQueryData['organizations'][0]['organization_roles'][0];
 export type OrganizationRoleFormState = {
   name: string;
   usersChangeSet: ChangeSet<OrganizationRoleType['users'][0]>;

--- a/app/javascript/Reports/AttendanceByPaymentAmount.tsx
+++ b/app/javascript/Reports/AttendanceByPaymentAmount.tsx
@@ -7,11 +7,11 @@ import formatMoney from '../formatMoney';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 import {
-  AttendanceByPaymentAmountQueryQuery,
-  useAttendanceByPaymentAmountQueryQuery,
+  AttendanceByPaymentAmountQueryData,
+  useAttendanceByPaymentAmountQuery,
 } from './queries.generated';
 
-type RowType = AttendanceByPaymentAmountQueryQuery['convention']['reports']['ticket_count_by_type_and_payment_amount'][0];
+type RowType = AttendanceByPaymentAmountQueryData['convention']['reports']['ticket_count_by_type_and_payment_amount'][0];
 
 function describeRow(ticketType: RowType['ticket_type'], paymentAmount: RowType['payment_amount']) {
   if (paymentAmount.fractional > 0) {
@@ -49,7 +49,7 @@ function descriptionCell(
 }
 
 export default LoadQueryWrapper(
-  useAttendanceByPaymentAmountQueryQuery,
+  useAttendanceByPaymentAmountQuery,
   function AttendanceByPaymentAmount({ data }) {
     usePageTitle('Attendance by payment amount');
 

--- a/app/javascript/Reports/EventProvidedTickets.tsx
+++ b/app/javascript/Reports/EventProvidedTickets.tsx
@@ -9,12 +9,9 @@ import pluralizeWithCount from '../pluralizeWithCount';
 import { useTabs, TabList, TabBody } from '../UIComponents/Tabs';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import {
-  EventProvidedTicketsQueryQuery,
-  useEventProvidedTicketsQueryQuery,
-} from './queries.generated';
+import { EventProvidedTicketsQueryData, useEventProvidedTicketsQuery } from './queries.generated';
 
-function EventProvidedTicketsByEvent({ data }: { data: EventProvidedTicketsQueryQuery }) {
+function EventProvidedTicketsByEvent({ data }: { data: EventProvidedTicketsQueryData }) {
   const sortedRows = titleSort(
     data.convention.reports.event_provided_tickets,
     (row) => row.provided_by_event.title ?? '',
@@ -41,7 +38,7 @@ function EventProvidedTicketsByEvent({ data }: { data: EventProvidedTicketsQuery
   );
 }
 
-function EventProvidedTicketsByUser({ data }: { data: EventProvidedTicketsQueryQuery }) {
+function EventProvidedTicketsByUser({ data }: { data: EventProvidedTicketsQueryData }) {
   const sortedRows = useMemo(() => {
     const unsortedRows = flatMap(
       data.convention.reports.event_provided_tickets,
@@ -73,40 +70,41 @@ function EventProvidedTicketsByUser({ data }: { data: EventProvidedTicketsQueryQ
   );
 }
 
-export default LoadQueryWrapper(useEventProvidedTicketsQueryQuery, function EventProvidedTickets({
-  data,
-}) {
-  const tabProps = useTabs([
-    {
-      id: 'by-event',
-      name: 'By event',
-      renderContent: () => <EventProvidedTicketsByEvent data={data} />,
-    },
-    {
-      id: 'by-user',
-      name: 'By user',
-      renderContent: () => <EventProvidedTicketsByUser data={data} />,
-    },
-  ]);
+export default LoadQueryWrapper(
+  useEventProvidedTicketsQuery,
+  function EventProvidedTickets({ data }) {
+    const tabProps = useTabs([
+      {
+        id: 'by-event',
+        name: 'By event',
+        renderContent: () => <EventProvidedTicketsByEvent data={data} />,
+      },
+      {
+        id: 'by-user',
+        name: 'By user',
+        renderContent: () => <EventProvidedTicketsByUser data={data} />,
+      },
+    ]);
 
-  usePageTitle(`Event-provided ${pluralize(data.convention.ticket_name)}`);
+    usePageTitle(`Event-provided ${pluralize(data.convention.ticket_name)}`);
 
-  return (
-    <>
-      <h1>
-        {'Event-provided '}
-        {pluralize(data.convention.ticket_name)}
-        {' report'}
-      </h1>
-      <h3 className="mb-4">
-        {'Total: '}
-        {pluralizeWithCount(
-          `event-provided ${data.convention.ticket_name}`,
-          sum(data.convention.reports.event_provided_tickets.map((row) => row.tickets.length)),
-        )}
-      </h3>
-      <TabList {...tabProps} />
-      <TabBody {...tabProps} />
-    </>
-  );
-});
+    return (
+      <>
+        <h1>
+          {'Event-provided '}
+          {pluralize(data.convention.ticket_name)}
+          {' report'}
+        </h1>
+        <h3 className="mb-4">
+          {'Total: '}
+          {pluralizeWithCount(
+            `event-provided ${data.convention.ticket_name}`,
+            sum(data.convention.reports.event_provided_tickets.map((row) => row.tickets.length)),
+          )}
+        </h3>
+        <TabList {...tabProps} />
+        <TabBody {...tabProps} />
+      </>
+    );
+  },
+);

--- a/app/javascript/Reports/EventsByChoice.tsx
+++ b/app/javascript/Reports/EventsByChoice.tsx
@@ -11,7 +11,7 @@ import { capitalize } from 'inflected';
 import { titleSort } from '../ValueUtils';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useEventsByChoiceQueryQuery } from './queries.generated';
+import { useEventsByChoiceQuery } from './queries.generated';
 
 type ProcessedChoiceCount = {
   confirmed?: number;
@@ -36,7 +36,7 @@ function renderChoiceCounts(choiceData: ProcessedChoiceCount) {
   );
 }
 
-export default LoadQueryWrapper(useEventsByChoiceQueryQuery, function EventsByChoice({ data }) {
+export default LoadQueryWrapper(useEventsByChoiceQuery, function EventsByChoice({ data }) {
   const choiceColumns = useMemo(() => {
     const choices = flatMap(data.convention.reports.events_by_choice, (eventByChoice) =>
       eventByChoice.choice_counts.map((choiceCount) => choiceCount.choice),

--- a/app/javascript/Reports/SignupSpy.tsx
+++ b/app/javascript/Reports/SignupSpy.tsx
@@ -1,10 +1,10 @@
 import SignupSpyTable from './SignupSpyTable';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useSignupCountsByStateQueryQuery } from './queries.generated';
+import { useSignupCountsByStateQuery } from './queries.generated';
 import { SignupState } from '../graphqlTypes.generated';
 
-export default LoadQueryWrapper(useSignupCountsByStateQueryQuery, function SignupSpy({ data }) {
+export default LoadQueryWrapper(useSignupCountsByStateQuery, function SignupSpy({ data }) {
   const getSignupCount = (state: SignupState) => {
     return (
       data.convention.signup_counts_by_state.find((record) => record.state === state) || {

--- a/app/javascript/Reports/SignupSpyTable.tsx
+++ b/app/javascript/Reports/SignupSpyTable.tsx
@@ -14,11 +14,11 @@ import TableHeader from '../Tables/TableHeader';
 import SignupChangesTableExportButton from '../Tables/SignupChangesTableExportButton';
 import ReactTableWithTheWorks from '../Tables/ReactTableWithTheWorks';
 import {
-  SignupSpySignupChangesQueryQuery,
-  useSignupSpySignupChangesQueryQuery,
+  SignupSpySignupChangesQueryData,
+  useSignupSpySignupChangesQuery,
 } from './queries.generated';
 
-type SignupChangeType = SignupSpySignupChangesQueryQuery['convention']['signup_changes_paginated']['entries'][0];
+type SignupChangeType = SignupSpySignupChangesQueryData['convention']['signup_changes_paginated']['entries'][0];
 
 const FILTER_CODECS = buildFieldFilterCodecs({
   action: FilterCodecs.stringArray,
@@ -100,7 +100,7 @@ function SignupSpyTable() {
     getData: ({ data }) => data.convention.signup_changes_paginated.entries,
     getPages: ({ data }) => data.convention.signup_changes_paginated.total_pages,
     getPossibleColumns: () => columns,
-    useQuery: useSignupSpySignupChangesQueryQuery,
+    useQuery: useSignupSpySignupChangesQuery,
     storageKeyPrefix: 'signupSpy',
   });
 

--- a/app/javascript/Reports/index.tsx
+++ b/app/javascript/Reports/index.tsx
@@ -8,9 +8,9 @@ import EventsByChoice from './EventsByChoice';
 import usePageTitle from '../usePageTitle';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useReportsMenuQueryQuery } from './queries.generated';
+import { useReportsMenuQuery } from './queries.generated';
 
-const ReportsMenu = LoadQueryWrapper(useReportsMenuQueryQuery, function ReportsMenu({ data }) {
+const ReportsMenu = LoadQueryWrapper(useReportsMenuQuery, function ReportsMenu({ data }) {
   usePageTitle('Reports');
 
   return (

--- a/app/javascript/Reports/queries.generated.ts
+++ b/app/javascript/Reports/queries.generated.ts
@@ -5,10 +5,11 @@ import { PricingStructureFieldsFragment } from '../Store/pricingStructureFields.
 import { gql } from '@apollo/client';
 import { PricingStructureFieldsFragmentDoc } from '../Store/pricingStructureFields.generated';
 import * as Apollo from '@apollo/client';
-export type ReportsMenuQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+const defaultOptions =  {}
+export type ReportsMenuQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type ReportsMenuQueryQuery = (
+export type ReportsMenuQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -16,10 +17,10 @@ export type ReportsMenuQueryQuery = (
   ) }
 );
 
-export type AttendanceByPaymentAmountQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type AttendanceByPaymentAmountQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type AttendanceByPaymentAmountQueryQuery = (
+export type AttendanceByPaymentAmountQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -52,10 +53,10 @@ export type AttendanceByPaymentAmountQueryQuery = (
   ) }
 );
 
-export type EventProvidedTicketsQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type EventProvidedTicketsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type EventProvidedTicketsQueryQuery = (
+export type EventProvidedTicketsQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -83,10 +84,10 @@ export type EventProvidedTicketsQueryQuery = (
   ) }
 );
 
-export type EventsByChoiceQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type EventsByChoiceQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type EventsByChoiceQueryQuery = (
+export type EventsByChoiceQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -107,10 +108,10 @@ export type EventsByChoiceQueryQuery = (
   ) }
 );
 
-export type SignupCountsByStateQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type SignupCountsByStateQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type SignupCountsByStateQueryQuery = (
+export type SignupCountsByStateQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -122,7 +123,7 @@ export type SignupCountsByStateQueryQuery = (
   ) }
 );
 
-export type SignupSpySignupChangesQueryQueryVariables = Types.Exact<{
+export type SignupSpySignupChangesQueryVariables = Types.Exact<{
   filters?: Types.Maybe<Types.SignupChangeFiltersInput>;
   page?: Types.Maybe<Types.Scalars['Int']>;
   perPage?: Types.Maybe<Types.Scalars['Int']>;
@@ -130,7 +131,7 @@ export type SignupSpySignupChangesQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type SignupSpySignupChangesQueryQuery = (
+export type SignupSpySignupChangesQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -192,29 +193,31 @@ export const ReportsMenuQueryDocument = gql`
     `;
 
 /**
- * __useReportsMenuQueryQuery__
+ * __useReportsMenuQuery__
  *
- * To run a query within a React component, call `useReportsMenuQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useReportsMenuQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useReportsMenuQuery` and pass it any options that fit your needs.
+ * When your component renders, `useReportsMenuQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useReportsMenuQueryQuery({
+ * const { data, loading, error } = useReportsMenuQuery({
  *   variables: {
  *   },
  * });
  */
-export function useReportsMenuQueryQuery(baseOptions?: Apollo.QueryHookOptions<ReportsMenuQueryQuery, ReportsMenuQueryQueryVariables>) {
-        return Apollo.useQuery<ReportsMenuQueryQuery, ReportsMenuQueryQueryVariables>(ReportsMenuQueryDocument, baseOptions);
+export function useReportsMenuQuery(baseOptions?: Apollo.QueryHookOptions<ReportsMenuQueryData, ReportsMenuQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ReportsMenuQueryData, ReportsMenuQueryVariables>(ReportsMenuQueryDocument, options);
       }
-export function useReportsMenuQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ReportsMenuQueryQuery, ReportsMenuQueryQueryVariables>) {
-          return Apollo.useLazyQuery<ReportsMenuQueryQuery, ReportsMenuQueryQueryVariables>(ReportsMenuQueryDocument, baseOptions);
+export function useReportsMenuQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ReportsMenuQueryData, ReportsMenuQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ReportsMenuQueryData, ReportsMenuQueryVariables>(ReportsMenuQueryDocument, options);
         }
-export type ReportsMenuQueryQueryHookResult = ReturnType<typeof useReportsMenuQueryQuery>;
+export type ReportsMenuQueryHookResult = ReturnType<typeof useReportsMenuQuery>;
 export type ReportsMenuQueryLazyQueryHookResult = ReturnType<typeof useReportsMenuQueryLazyQuery>;
-export type ReportsMenuQueryQueryResult = Apollo.QueryResult<ReportsMenuQueryQuery, ReportsMenuQueryQueryVariables>;
+export type ReportsMenuQueryDataResult = Apollo.QueryResult<ReportsMenuQueryData, ReportsMenuQueryVariables>;
 export const AttendanceByPaymentAmountQueryDocument = gql`
     query AttendanceByPaymentAmountQuery {
   convention: assertConvention {
@@ -249,29 +252,31 @@ export const AttendanceByPaymentAmountQueryDocument = gql`
     ${PricingStructureFieldsFragmentDoc}`;
 
 /**
- * __useAttendanceByPaymentAmountQueryQuery__
+ * __useAttendanceByPaymentAmountQuery__
  *
- * To run a query within a React component, call `useAttendanceByPaymentAmountQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useAttendanceByPaymentAmountQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAttendanceByPaymentAmountQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAttendanceByPaymentAmountQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useAttendanceByPaymentAmountQueryQuery({
+ * const { data, loading, error } = useAttendanceByPaymentAmountQuery({
  *   variables: {
  *   },
  * });
  */
-export function useAttendanceByPaymentAmountQueryQuery(baseOptions?: Apollo.QueryHookOptions<AttendanceByPaymentAmountQueryQuery, AttendanceByPaymentAmountQueryQueryVariables>) {
-        return Apollo.useQuery<AttendanceByPaymentAmountQueryQuery, AttendanceByPaymentAmountQueryQueryVariables>(AttendanceByPaymentAmountQueryDocument, baseOptions);
+export function useAttendanceByPaymentAmountQuery(baseOptions?: Apollo.QueryHookOptions<AttendanceByPaymentAmountQueryData, AttendanceByPaymentAmountQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AttendanceByPaymentAmountQueryData, AttendanceByPaymentAmountQueryVariables>(AttendanceByPaymentAmountQueryDocument, options);
       }
-export function useAttendanceByPaymentAmountQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AttendanceByPaymentAmountQueryQuery, AttendanceByPaymentAmountQueryQueryVariables>) {
-          return Apollo.useLazyQuery<AttendanceByPaymentAmountQueryQuery, AttendanceByPaymentAmountQueryQueryVariables>(AttendanceByPaymentAmountQueryDocument, baseOptions);
+export function useAttendanceByPaymentAmountQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AttendanceByPaymentAmountQueryData, AttendanceByPaymentAmountQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AttendanceByPaymentAmountQueryData, AttendanceByPaymentAmountQueryVariables>(AttendanceByPaymentAmountQueryDocument, options);
         }
-export type AttendanceByPaymentAmountQueryQueryHookResult = ReturnType<typeof useAttendanceByPaymentAmountQueryQuery>;
+export type AttendanceByPaymentAmountQueryHookResult = ReturnType<typeof useAttendanceByPaymentAmountQuery>;
 export type AttendanceByPaymentAmountQueryLazyQueryHookResult = ReturnType<typeof useAttendanceByPaymentAmountQueryLazyQuery>;
-export type AttendanceByPaymentAmountQueryQueryResult = Apollo.QueryResult<AttendanceByPaymentAmountQueryQuery, AttendanceByPaymentAmountQueryQueryVariables>;
+export type AttendanceByPaymentAmountQueryDataResult = Apollo.QueryResult<AttendanceByPaymentAmountQueryData, AttendanceByPaymentAmountQueryVariables>;
 export const EventProvidedTicketsQueryDocument = gql`
     query EventProvidedTicketsQuery {
   convention: assertConvention {
@@ -301,29 +306,31 @@ export const EventProvidedTicketsQueryDocument = gql`
     `;
 
 /**
- * __useEventProvidedTicketsQueryQuery__
+ * __useEventProvidedTicketsQuery__
  *
- * To run a query within a React component, call `useEventProvidedTicketsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventProvidedTicketsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventProvidedTicketsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventProvidedTicketsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventProvidedTicketsQueryQuery({
+ * const { data, loading, error } = useEventProvidedTicketsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useEventProvidedTicketsQueryQuery(baseOptions?: Apollo.QueryHookOptions<EventProvidedTicketsQueryQuery, EventProvidedTicketsQueryQueryVariables>) {
-        return Apollo.useQuery<EventProvidedTicketsQueryQuery, EventProvidedTicketsQueryQueryVariables>(EventProvidedTicketsQueryDocument, baseOptions);
+export function useEventProvidedTicketsQuery(baseOptions?: Apollo.QueryHookOptions<EventProvidedTicketsQueryData, EventProvidedTicketsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventProvidedTicketsQueryData, EventProvidedTicketsQueryVariables>(EventProvidedTicketsQueryDocument, options);
       }
-export function useEventProvidedTicketsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProvidedTicketsQueryQuery, EventProvidedTicketsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventProvidedTicketsQueryQuery, EventProvidedTicketsQueryQueryVariables>(EventProvidedTicketsQueryDocument, baseOptions);
+export function useEventProvidedTicketsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventProvidedTicketsQueryData, EventProvidedTicketsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventProvidedTicketsQueryData, EventProvidedTicketsQueryVariables>(EventProvidedTicketsQueryDocument, options);
         }
-export type EventProvidedTicketsQueryQueryHookResult = ReturnType<typeof useEventProvidedTicketsQueryQuery>;
+export type EventProvidedTicketsQueryHookResult = ReturnType<typeof useEventProvidedTicketsQuery>;
 export type EventProvidedTicketsQueryLazyQueryHookResult = ReturnType<typeof useEventProvidedTicketsQueryLazyQuery>;
-export type EventProvidedTicketsQueryQueryResult = Apollo.QueryResult<EventProvidedTicketsQueryQuery, EventProvidedTicketsQueryQueryVariables>;
+export type EventProvidedTicketsQueryDataResult = Apollo.QueryResult<EventProvidedTicketsQueryData, EventProvidedTicketsQueryVariables>;
 export const EventsByChoiceQueryDocument = gql`
     query EventsByChoiceQuery {
   convention: assertConvention {
@@ -346,29 +353,31 @@ export const EventsByChoiceQueryDocument = gql`
     `;
 
 /**
- * __useEventsByChoiceQueryQuery__
+ * __useEventsByChoiceQuery__
  *
- * To run a query within a React component, call `useEventsByChoiceQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventsByChoiceQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useEventsByChoiceQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventsByChoiceQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventsByChoiceQueryQuery({
+ * const { data, loading, error } = useEventsByChoiceQuery({
  *   variables: {
  *   },
  * });
  */
-export function useEventsByChoiceQueryQuery(baseOptions?: Apollo.QueryHookOptions<EventsByChoiceQueryQuery, EventsByChoiceQueryQueryVariables>) {
-        return Apollo.useQuery<EventsByChoiceQueryQuery, EventsByChoiceQueryQueryVariables>(EventsByChoiceQueryDocument, baseOptions);
+export function useEventsByChoiceQuery(baseOptions?: Apollo.QueryHookOptions<EventsByChoiceQueryData, EventsByChoiceQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EventsByChoiceQueryData, EventsByChoiceQueryVariables>(EventsByChoiceQueryDocument, options);
       }
-export function useEventsByChoiceQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventsByChoiceQueryQuery, EventsByChoiceQueryQueryVariables>) {
-          return Apollo.useLazyQuery<EventsByChoiceQueryQuery, EventsByChoiceQueryQueryVariables>(EventsByChoiceQueryDocument, baseOptions);
+export function useEventsByChoiceQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EventsByChoiceQueryData, EventsByChoiceQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EventsByChoiceQueryData, EventsByChoiceQueryVariables>(EventsByChoiceQueryDocument, options);
         }
-export type EventsByChoiceQueryQueryHookResult = ReturnType<typeof useEventsByChoiceQueryQuery>;
+export type EventsByChoiceQueryHookResult = ReturnType<typeof useEventsByChoiceQuery>;
 export type EventsByChoiceQueryLazyQueryHookResult = ReturnType<typeof useEventsByChoiceQueryLazyQuery>;
-export type EventsByChoiceQueryQueryResult = Apollo.QueryResult<EventsByChoiceQueryQuery, EventsByChoiceQueryQueryVariables>;
+export type EventsByChoiceQueryDataResult = Apollo.QueryResult<EventsByChoiceQueryData, EventsByChoiceQueryVariables>;
 export const SignupCountsByStateQueryDocument = gql`
     query SignupCountsByStateQuery {
   convention: assertConvention {
@@ -382,29 +391,31 @@ export const SignupCountsByStateQueryDocument = gql`
     `;
 
 /**
- * __useSignupCountsByStateQueryQuery__
+ * __useSignupCountsByStateQuery__
  *
- * To run a query within a React component, call `useSignupCountsByStateQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useSignupCountsByStateQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSignupCountsByStateQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSignupCountsByStateQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSignupCountsByStateQueryQuery({
+ * const { data, loading, error } = useSignupCountsByStateQuery({
  *   variables: {
  *   },
  * });
  */
-export function useSignupCountsByStateQueryQuery(baseOptions?: Apollo.QueryHookOptions<SignupCountsByStateQueryQuery, SignupCountsByStateQueryQueryVariables>) {
-        return Apollo.useQuery<SignupCountsByStateQueryQuery, SignupCountsByStateQueryQueryVariables>(SignupCountsByStateQueryDocument, baseOptions);
+export function useSignupCountsByStateQuery(baseOptions?: Apollo.QueryHookOptions<SignupCountsByStateQueryData, SignupCountsByStateQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SignupCountsByStateQueryData, SignupCountsByStateQueryVariables>(SignupCountsByStateQueryDocument, options);
       }
-export function useSignupCountsByStateQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SignupCountsByStateQueryQuery, SignupCountsByStateQueryQueryVariables>) {
-          return Apollo.useLazyQuery<SignupCountsByStateQueryQuery, SignupCountsByStateQueryQueryVariables>(SignupCountsByStateQueryDocument, baseOptions);
+export function useSignupCountsByStateQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SignupCountsByStateQueryData, SignupCountsByStateQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SignupCountsByStateQueryData, SignupCountsByStateQueryVariables>(SignupCountsByStateQueryDocument, options);
         }
-export type SignupCountsByStateQueryQueryHookResult = ReturnType<typeof useSignupCountsByStateQueryQuery>;
+export type SignupCountsByStateQueryHookResult = ReturnType<typeof useSignupCountsByStateQuery>;
 export type SignupCountsByStateQueryLazyQueryHookResult = ReturnType<typeof useSignupCountsByStateQueryLazyQuery>;
-export type SignupCountsByStateQueryQueryResult = Apollo.QueryResult<SignupCountsByStateQueryQuery, SignupCountsByStateQueryQueryVariables>;
+export type SignupCountsByStateQueryDataResult = Apollo.QueryResult<SignupCountsByStateQueryData, SignupCountsByStateQueryVariables>;
 export const SignupSpySignupChangesQueryDocument = gql`
     query SignupSpySignupChangesQuery($filters: SignupChangeFiltersInput, $page: Int, $perPage: Int, $sort: [SortInput!]) {
   convention: assertConvention {
@@ -474,16 +485,16 @@ export const SignupSpySignupChangesQueryDocument = gql`
     `;
 
 /**
- * __useSignupSpySignupChangesQueryQuery__
+ * __useSignupSpySignupChangesQuery__
  *
- * To run a query within a React component, call `useSignupSpySignupChangesQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useSignupSpySignupChangesQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSignupSpySignupChangesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSignupSpySignupChangesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSignupSpySignupChangesQueryQuery({
+ * const { data, loading, error } = useSignupSpySignupChangesQuery({
  *   variables: {
  *      filters: // value for 'filters'
  *      page: // value for 'page'
@@ -492,12 +503,14 @@ export const SignupSpySignupChangesQueryDocument = gql`
  *   },
  * });
  */
-export function useSignupSpySignupChangesQueryQuery(baseOptions?: Apollo.QueryHookOptions<SignupSpySignupChangesQueryQuery, SignupSpySignupChangesQueryQueryVariables>) {
-        return Apollo.useQuery<SignupSpySignupChangesQueryQuery, SignupSpySignupChangesQueryQueryVariables>(SignupSpySignupChangesQueryDocument, baseOptions);
+export function useSignupSpySignupChangesQuery(baseOptions?: Apollo.QueryHookOptions<SignupSpySignupChangesQueryData, SignupSpySignupChangesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SignupSpySignupChangesQueryData, SignupSpySignupChangesQueryVariables>(SignupSpySignupChangesQueryDocument, options);
       }
-export function useSignupSpySignupChangesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SignupSpySignupChangesQueryQuery, SignupSpySignupChangesQueryQueryVariables>) {
-          return Apollo.useLazyQuery<SignupSpySignupChangesQueryQuery, SignupSpySignupChangesQueryQueryVariables>(SignupSpySignupChangesQueryDocument, baseOptions);
+export function useSignupSpySignupChangesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SignupSpySignupChangesQueryData, SignupSpySignupChangesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SignupSpySignupChangesQueryData, SignupSpySignupChangesQueryVariables>(SignupSpySignupChangesQueryDocument, options);
         }
-export type SignupSpySignupChangesQueryQueryHookResult = ReturnType<typeof useSignupSpySignupChangesQueryQuery>;
+export type SignupSpySignupChangesQueryHookResult = ReturnType<typeof useSignupSpySignupChangesQuery>;
 export type SignupSpySignupChangesQueryLazyQueryHookResult = ReturnType<typeof useSignupSpySignupChangesQueryLazyQuery>;
-export type SignupSpySignupChangesQueryQueryResult = Apollo.QueryResult<SignupSpySignupChangesQueryQuery, SignupSpySignupChangesQueryQueryVariables>;
+export type SignupSpySignupChangesQueryDataResult = Apollo.QueryResult<SignupSpySignupChangesQueryData, SignupSpySignupChangesQueryVariables>;

--- a/app/javascript/RoomsAdmin/index.tsx
+++ b/app/javascript/RoomsAdmin/index.tsx
@@ -15,27 +15,27 @@ import { useCreateMutation, useDeleteMutation } from '../MutationUtils';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 import {
-  RoomsAdminQueryQuery,
-  RoomsAdminQueryQueryVariables,
-  useRoomsAdminQueryQuery,
+  RoomsAdminQueryData,
+  RoomsAdminQueryVariables,
+  useRoomsAdminQuery,
 } from './queries.generated';
 import {
-  CreateRoomMutation,
+  CreateRoomMutationData,
   CreateRoomMutationVariables,
-  DeleteRoomMutation,
+  DeleteRoomMutationData,
   DeleteRoomMutationVariables,
   useUpdateRoomMutation,
 } from './mutations.generated';
 
-export default LoadQueryWrapper(useRoomsAdminQueryQuery, function RoomsAdmin({ data }) {
+export default LoadQueryWrapper(useRoomsAdminQuery, function RoomsAdmin({ data }) {
   const authorizationWarning = useAuthorizationRequired('can_manage_rooms');
   const [updateMutate] = useUpdateRoomMutation();
   const [createRoom, createError] = useAsyncFunction(
     useCreateMutation<
-      RoomsAdminQueryQuery,
-      RoomsAdminQueryQueryVariables,
+      RoomsAdminQueryData,
+      RoomsAdminQueryVariables,
       CreateRoomMutationVariables,
-      CreateRoomMutation
+      CreateRoomMutationData
     >(CreateRoom, {
       query: RoomsAdminQuery,
       arrayPath: ['convention', 'rooms'],
@@ -44,7 +44,7 @@ export default LoadQueryWrapper(useRoomsAdminQueryQuery, function RoomsAdmin({ d
   );
   const [updateRoom, updateError] = useAsyncFunction(updateMutate);
   const [deleteRoom, deleteError] = useAsyncFunction(
-    useDeleteMutation<DeleteRoomMutation, DeleteRoomMutationVariables>(DeleteRoom, {
+    useDeleteMutation<DeleteRoomMutationData, DeleteRoomMutationVariables>(DeleteRoom, {
       query: RoomsAdminQuery,
       arrayPath: ['convention', 'rooms'],
       idVariablePath: ['input', 'id'],

--- a/app/javascript/RoomsAdmin/mutations.generated.ts
+++ b/app/javascript/RoomsAdmin/mutations.generated.ts
@@ -3,12 +3,13 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateRoomMutationVariables = Types.Exact<{
   input: Types.CreateRoomInput;
 }>;
 
 
-export type CreateRoomMutation = (
+export type CreateRoomMutationData = (
   { __typename: 'Mutation' }
   & { createRoom?: Types.Maybe<(
     { __typename: 'CreateRoomPayload' }
@@ -28,7 +29,7 @@ export type UpdateRoomMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateRoomMutation = (
+export type UpdateRoomMutationData = (
   { __typename: 'Mutation' }
   & { updateRoom?: Types.Maybe<(
     { __typename: 'UpdateRoomPayload' }
@@ -48,7 +49,7 @@ export type DeleteRoomMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteRoomMutation = (
+export type DeleteRoomMutationData = (
   { __typename: 'Mutation' }
   & { deleteRoom?: Types.Maybe<(
     { __typename: 'DeleteRoomPayload' }
@@ -73,7 +74,7 @@ export const CreateRoomDocument = gql`
   }
 }
     `;
-export type CreateRoomMutationFn = Apollo.MutationFunction<CreateRoomMutation, CreateRoomMutationVariables>;
+export type CreateRoomMutationFn = Apollo.MutationFunction<CreateRoomMutationData, CreateRoomMutationVariables>;
 
 /**
  * __useCreateRoomMutation__
@@ -92,12 +93,13 @@ export type CreateRoomMutationFn = Apollo.MutationFunction<CreateRoomMutation, C
  *   },
  * });
  */
-export function useCreateRoomMutation(baseOptions?: Apollo.MutationHookOptions<CreateRoomMutation, CreateRoomMutationVariables>) {
-        return Apollo.useMutation<CreateRoomMutation, CreateRoomMutationVariables>(CreateRoomDocument, baseOptions);
+export function useCreateRoomMutation(baseOptions?: Apollo.MutationHookOptions<CreateRoomMutationData, CreateRoomMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateRoomMutationData, CreateRoomMutationVariables>(CreateRoomDocument, options);
       }
 export type CreateRoomMutationHookResult = ReturnType<typeof useCreateRoomMutation>;
-export type CreateRoomMutationResult = Apollo.MutationResult<CreateRoomMutation>;
-export type CreateRoomMutationOptions = Apollo.BaseMutationOptions<CreateRoomMutation, CreateRoomMutationVariables>;
+export type CreateRoomMutationResult = Apollo.MutationResult<CreateRoomMutationData>;
+export type CreateRoomMutationOptions = Apollo.BaseMutationOptions<CreateRoomMutationData, CreateRoomMutationVariables>;
 export const UpdateRoomDocument = gql`
     mutation UpdateRoom($input: UpdateRoomInput!) {
   updateRoom(input: $input) {
@@ -111,7 +113,7 @@ export const UpdateRoomDocument = gql`
   }
 }
     `;
-export type UpdateRoomMutationFn = Apollo.MutationFunction<UpdateRoomMutation, UpdateRoomMutationVariables>;
+export type UpdateRoomMutationFn = Apollo.MutationFunction<UpdateRoomMutationData, UpdateRoomMutationVariables>;
 
 /**
  * __useUpdateRoomMutation__
@@ -130,12 +132,13 @@ export type UpdateRoomMutationFn = Apollo.MutationFunction<UpdateRoomMutation, U
  *   },
  * });
  */
-export function useUpdateRoomMutation(baseOptions?: Apollo.MutationHookOptions<UpdateRoomMutation, UpdateRoomMutationVariables>) {
-        return Apollo.useMutation<UpdateRoomMutation, UpdateRoomMutationVariables>(UpdateRoomDocument, baseOptions);
+export function useUpdateRoomMutation(baseOptions?: Apollo.MutationHookOptions<UpdateRoomMutationData, UpdateRoomMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateRoomMutationData, UpdateRoomMutationVariables>(UpdateRoomDocument, options);
       }
 export type UpdateRoomMutationHookResult = ReturnType<typeof useUpdateRoomMutation>;
-export type UpdateRoomMutationResult = Apollo.MutationResult<UpdateRoomMutation>;
-export type UpdateRoomMutationOptions = Apollo.BaseMutationOptions<UpdateRoomMutation, UpdateRoomMutationVariables>;
+export type UpdateRoomMutationResult = Apollo.MutationResult<UpdateRoomMutationData>;
+export type UpdateRoomMutationOptions = Apollo.BaseMutationOptions<UpdateRoomMutationData, UpdateRoomMutationVariables>;
 export const DeleteRoomDocument = gql`
     mutation DeleteRoom($input: DeleteRoomInput!) {
   deleteRoom(input: $input) {
@@ -145,7 +148,7 @@ export const DeleteRoomDocument = gql`
   }
 }
     `;
-export type DeleteRoomMutationFn = Apollo.MutationFunction<DeleteRoomMutation, DeleteRoomMutationVariables>;
+export type DeleteRoomMutationFn = Apollo.MutationFunction<DeleteRoomMutationData, DeleteRoomMutationVariables>;
 
 /**
  * __useDeleteRoomMutation__
@@ -164,9 +167,10 @@ export type DeleteRoomMutationFn = Apollo.MutationFunction<DeleteRoomMutation, D
  *   },
  * });
  */
-export function useDeleteRoomMutation(baseOptions?: Apollo.MutationHookOptions<DeleteRoomMutation, DeleteRoomMutationVariables>) {
-        return Apollo.useMutation<DeleteRoomMutation, DeleteRoomMutationVariables>(DeleteRoomDocument, baseOptions);
+export function useDeleteRoomMutation(baseOptions?: Apollo.MutationHookOptions<DeleteRoomMutationData, DeleteRoomMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteRoomMutationData, DeleteRoomMutationVariables>(DeleteRoomDocument, options);
       }
 export type DeleteRoomMutationHookResult = ReturnType<typeof useDeleteRoomMutation>;
-export type DeleteRoomMutationResult = Apollo.MutationResult<DeleteRoomMutation>;
-export type DeleteRoomMutationOptions = Apollo.BaseMutationOptions<DeleteRoomMutation, DeleteRoomMutationVariables>;
+export type DeleteRoomMutationResult = Apollo.MutationResult<DeleteRoomMutationData>;
+export type DeleteRoomMutationOptions = Apollo.BaseMutationOptions<DeleteRoomMutationData, DeleteRoomMutationVariables>;

--- a/app/javascript/RoomsAdmin/queries.generated.ts
+++ b/app/javascript/RoomsAdmin/queries.generated.ts
@@ -3,10 +3,11 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type RoomsAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+const defaultOptions =  {}
+export type RoomsAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type RoomsAdminQueryQuery = (
+export type RoomsAdminQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -39,26 +40,28 @@ export const RoomsAdminQueryDocument = gql`
     `;
 
 /**
- * __useRoomsAdminQueryQuery__
+ * __useRoomsAdminQuery__
  *
- * To run a query within a React component, call `useRoomsAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useRoomsAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useRoomsAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRoomsAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useRoomsAdminQueryQuery({
+ * const { data, loading, error } = useRoomsAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useRoomsAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<RoomsAdminQueryQuery, RoomsAdminQueryQueryVariables>) {
-        return Apollo.useQuery<RoomsAdminQueryQuery, RoomsAdminQueryQueryVariables>(RoomsAdminQueryDocument, baseOptions);
+export function useRoomsAdminQuery(baseOptions?: Apollo.QueryHookOptions<RoomsAdminQueryData, RoomsAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RoomsAdminQueryData, RoomsAdminQueryVariables>(RoomsAdminQueryDocument, options);
       }
-export function useRoomsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RoomsAdminQueryQuery, RoomsAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<RoomsAdminQueryQuery, RoomsAdminQueryQueryVariables>(RoomsAdminQueryDocument, baseOptions);
+export function useRoomsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RoomsAdminQueryData, RoomsAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RoomsAdminQueryData, RoomsAdminQueryVariables>(RoomsAdminQueryDocument, options);
         }
-export type RoomsAdminQueryQueryHookResult = ReturnType<typeof useRoomsAdminQueryQuery>;
+export type RoomsAdminQueryHookResult = ReturnType<typeof useRoomsAdminQuery>;
 export type RoomsAdminQueryLazyQueryHookResult = ReturnType<typeof useRoomsAdminQueryLazyQuery>;
-export type RoomsAdminQueryQueryResult = Apollo.QueryResult<RoomsAdminQueryQuery, RoomsAdminQueryQueryVariables>;
+export type RoomsAdminQueryDataResult = Apollo.QueryResult<RoomsAdminQueryData, RoomsAdminQueryVariables>;

--- a/app/javascript/RootSiteAdmin/EditRootSite.tsx
+++ b/app/javascript/RootSiteAdmin/EditRootSite.tsx
@@ -8,7 +8,7 @@ import SelectWithLabel from '../BuiltInFormControls/SelectWithLabel';
 import useAsyncFunction from '../useAsyncFunction';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useRootSiteAdminQueryQuery } from './queries.generated';
+import { useRootSiteAdminQuery } from './queries.generated';
 import { useUpdateRootSiteMutation } from './mutations.generated';
 
 function useDirtyState<T>(initialState: T, setDirty: () => void) {
@@ -22,7 +22,7 @@ function useDirtyState<T>(initialState: T, setDirty: () => void) {
   ] as const;
 }
 
-export default LoadQueryWrapper(useRootSiteAdminQueryQuery, function EditRootSite({ data }) {
+export default LoadQueryWrapper(useRootSiteAdminQuery, function EditRootSite({ data }) {
   const [updateMutate] = useUpdateRootSiteMutation();
   const [update, updateError, updateInProgress] = useAsyncFunction(updateMutate);
 

--- a/app/javascript/RootSiteAdmin/mutations.generated.ts
+++ b/app/javascript/RootSiteAdmin/mutations.generated.ts
@@ -5,6 +5,7 @@ import { RootSiteFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { RootSiteFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type UpdateRootSiteMutationVariables = Types.Exact<{
   siteName?: Types.Maybe<Types.Scalars['String']>;
   defaultLayoutId?: Types.Maybe<Types.Scalars['Int']>;
@@ -12,7 +13,7 @@ export type UpdateRootSiteMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateRootSiteMutation = (
+export type UpdateRootSiteMutationData = (
   { __typename: 'Mutation' }
   & { updateRootSite?: Types.Maybe<(
     { __typename: 'UpdateRootSitePayload' }
@@ -37,7 +38,7 @@ export const UpdateRootSiteDocument = gql`
   }
 }
     ${RootSiteFieldsFragmentDoc}`;
-export type UpdateRootSiteMutationFn = Apollo.MutationFunction<UpdateRootSiteMutation, UpdateRootSiteMutationVariables>;
+export type UpdateRootSiteMutationFn = Apollo.MutationFunction<UpdateRootSiteMutationData, UpdateRootSiteMutationVariables>;
 
 /**
  * __useUpdateRootSiteMutation__
@@ -58,9 +59,10 @@ export type UpdateRootSiteMutationFn = Apollo.MutationFunction<UpdateRootSiteMut
  *   },
  * });
  */
-export function useUpdateRootSiteMutation(baseOptions?: Apollo.MutationHookOptions<UpdateRootSiteMutation, UpdateRootSiteMutationVariables>) {
-        return Apollo.useMutation<UpdateRootSiteMutation, UpdateRootSiteMutationVariables>(UpdateRootSiteDocument, baseOptions);
+export function useUpdateRootSiteMutation(baseOptions?: Apollo.MutationHookOptions<UpdateRootSiteMutationData, UpdateRootSiteMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateRootSiteMutationData, UpdateRootSiteMutationVariables>(UpdateRootSiteDocument, options);
       }
 export type UpdateRootSiteMutationHookResult = ReturnType<typeof useUpdateRootSiteMutation>;
-export type UpdateRootSiteMutationResult = Apollo.MutationResult<UpdateRootSiteMutation>;
-export type UpdateRootSiteMutationOptions = Apollo.BaseMutationOptions<UpdateRootSiteMutation, UpdateRootSiteMutationVariables>;
+export type UpdateRootSiteMutationResult = Apollo.MutationResult<UpdateRootSiteMutationData>;
+export type UpdateRootSiteMutationOptions = Apollo.BaseMutationOptions<UpdateRootSiteMutationData, UpdateRootSiteMutationVariables>;

--- a/app/javascript/RootSiteAdmin/queries.generated.ts
+++ b/app/javascript/RootSiteAdmin/queries.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type PageFieldsFragment = (
   { __typename: 'Page' }
   & Pick<Types.Page, 'id' | 'name'>
@@ -27,10 +28,10 @@ export type RootSiteFieldsFragment = (
   ) }
 );
 
-export type RootSiteAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type RootSiteAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type RootSiteAdminQueryQuery = (
+export type RootSiteAdminQueryData = (
   { __typename: 'Query' }
   & { rootSite: (
     { __typename: 'RootSite' }
@@ -94,26 +95,28 @@ ${PageFieldsFragmentDoc}
 ${RootSiteAdminLayoutFieldsFragmentDoc}`;
 
 /**
- * __useRootSiteAdminQueryQuery__
+ * __useRootSiteAdminQuery__
  *
- * To run a query within a React component, call `useRootSiteAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useRootSiteAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useRootSiteAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRootSiteAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useRootSiteAdminQueryQuery({
+ * const { data, loading, error } = useRootSiteAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useRootSiteAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<RootSiteAdminQueryQuery, RootSiteAdminQueryQueryVariables>) {
-        return Apollo.useQuery<RootSiteAdminQueryQuery, RootSiteAdminQueryQueryVariables>(RootSiteAdminQueryDocument, baseOptions);
+export function useRootSiteAdminQuery(baseOptions?: Apollo.QueryHookOptions<RootSiteAdminQueryData, RootSiteAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RootSiteAdminQueryData, RootSiteAdminQueryVariables>(RootSiteAdminQueryDocument, options);
       }
-export function useRootSiteAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RootSiteAdminQueryQuery, RootSiteAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<RootSiteAdminQueryQuery, RootSiteAdminQueryQueryVariables>(RootSiteAdminQueryDocument, baseOptions);
+export function useRootSiteAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RootSiteAdminQueryData, RootSiteAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RootSiteAdminQueryData, RootSiteAdminQueryVariables>(RootSiteAdminQueryDocument, options);
         }
-export type RootSiteAdminQueryQueryHookResult = ReturnType<typeof useRootSiteAdminQueryQuery>;
+export type RootSiteAdminQueryHookResult = ReturnType<typeof useRootSiteAdminQuery>;
 export type RootSiteAdminQueryLazyQueryHookResult = ReturnType<typeof useRootSiteAdminQueryLazyQuery>;
-export type RootSiteAdminQueryQueryResult = Apollo.QueryResult<RootSiteAdminQueryQuery, RootSiteAdminQueryQueryVariables>;
+export type RootSiteAdminQueryDataResult = Apollo.QueryResult<RootSiteAdminQueryData, RootSiteAdminQueryVariables>;

--- a/app/javascript/RootSiteConventionsAdmin/NewConventionModal.tsx
+++ b/app/javascript/RootSiteConventionsAdmin/NewConventionModal.tsx
@@ -18,9 +18,9 @@ import MultipleChoiceInput from '../BuiltInFormControls/MultipleChoiceInput';
 import EnumTypes from '../enumTypes.json';
 import ConventionLanguageInput from '../ConventionAdmin/ConventionLanguageInput';
 import {
-  NewConventionModalQueryQuery,
-  RootSiteConventionsAdminTableQueryQuery,
-  useNewConventionModalQueryQuery,
+  NewConventionModalQueryData,
+  RootSiteConventionsAdminTableQueryData,
+  useNewConventionModalQuery,
 } from './queries.generated';
 import { usePropertySetters } from '../usePropertySetters';
 import { Convention, Organization, TimezoneMode } from '../graphqlTypes.generated';
@@ -58,11 +58,11 @@ const CMS_CONTENT_SET_OPTIONS = [
 export type NewConventionModalProps = {
   visible: boolean;
   close: () => void;
-  cloneConvention?: RootSiteConventionsAdminTableQueryQuery['conventions_paginated']['entries'][0];
+  cloneConvention?: RootSiteConventionsAdminTableQueryData['conventions_paginated']['entries'][0];
 };
 
-export default LoadQueryWrapper<NewConventionModalQueryQuery, NewConventionModalProps>(
-  useNewConventionModalQueryQuery,
+export default LoadQueryWrapper<NewConventionModalQueryData, NewConventionModalProps>(
+  useNewConventionModalQuery,
   function NewConventionModal({ visible, close, cloneConvention, data }) {
     const history = useHistory();
     const [createConvention] = useCreateConventionMutation();

--- a/app/javascript/RootSiteConventionsAdmin/RootSiteConventionsAdminTable.tsx
+++ b/app/javascript/RootSiteConventionsAdmin/RootSiteConventionsAdminTable.tsx
@@ -14,12 +14,12 @@ import usePageTitle from '../usePageTitle';
 import useModal from '../ModalDialogs/useModal';
 import NewConventionModal from './NewConventionModal';
 import {
-  RootSiteConventionsAdminTableQueryQuery,
-  useRootSiteConventionsAdminTableQueryQuery,
+  RootSiteConventionsAdminTableQueryData,
+  useRootSiteConventionsAdminTableQuery,
 } from './queries.generated';
 import { getDateTimeFormat } from '../TimeUtils';
 
-type ConventionType = RootSiteConventionsAdminTableQueryQuery['conventions_paginated']['entries'][0];
+type ConventionType = RootSiteConventionsAdminTableQueryData['conventions_paginated']['entries'][0];
 
 const { encodeFilterValue, decodeFilterValue } = buildFieldFilterCodecs({});
 
@@ -112,7 +112,7 @@ function RootSiteConventionsAdminTable() {
     getPages: ({ data }) => data.conventions_paginated.total_pages,
     getPossibleColumns,
     storageKeyPrefix: 'conventions',
-    useQuery: useRootSiteConventionsAdminTableQueryQuery,
+    useQuery: useRootSiteConventionsAdminTableQuery,
   });
   usePageTitle('Conventions');
 

--- a/app/javascript/RootSiteConventionsAdmin/conventionQueryHooks.ts
+++ b/app/javascript/RootSiteConventionsAdmin/conventionQueryHooks.ts
@@ -1,9 +1,9 @@
 import { useParams } from 'react-router-dom';
 
-import { useConventionDisplayQueryQuery } from './queries.generated';
+import { useConventionDisplayQuery } from './queries.generated';
 
 // eslint-disable-next-line import/prefer-default-export
 export function useConventionQueryFromIdParam() {
   const { id } = useParams<{ id: string }>();
-  return useConventionDisplayQueryQuery({ variables: { id: Number.parseInt(id, 10) } });
+  return useConventionDisplayQuery({ variables: { id: Number.parseInt(id, 10) } });
 }

--- a/app/javascript/RootSiteConventionsAdmin/mutations.generated.ts
+++ b/app/javascript/RootSiteConventionsAdmin/mutations.generated.ts
@@ -5,6 +5,7 @@ import { ConventionDisplayFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { ConventionDisplayFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateConventionMutationVariables = Types.Exact<{
   convention: Types.ConventionInput;
   cloneConventionId?: Types.Maybe<Types.Scalars['Int']>;
@@ -13,7 +14,7 @@ export type CreateConventionMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateConventionMutation = (
+export type CreateConventionMutationData = (
   { __typename: 'Mutation' }
   & { createConvention?: Types.Maybe<(
     { __typename: 'CreateConventionPayload' }
@@ -31,7 +32,7 @@ export type SetConventionCanceledMutationVariables = Types.Exact<{
 }>;
 
 
-export type SetConventionCanceledMutation = (
+export type SetConventionCanceledMutationData = (
   { __typename: 'Mutation' }
   & { setConventionCanceled?: Types.Maybe<(
     { __typename: 'SetConventionCanceledPayload' }
@@ -56,7 +57,7 @@ export const CreateConventionDocument = gql`
   }
 }
     ${ConventionDisplayFieldsFragmentDoc}`;
-export type CreateConventionMutationFn = Apollo.MutationFunction<CreateConventionMutation, CreateConventionMutationVariables>;
+export type CreateConventionMutationFn = Apollo.MutationFunction<CreateConventionMutationData, CreateConventionMutationVariables>;
 
 /**
  * __useCreateConventionMutation__
@@ -78,12 +79,13 @@ export type CreateConventionMutationFn = Apollo.MutationFunction<CreateConventio
  *   },
  * });
  */
-export function useCreateConventionMutation(baseOptions?: Apollo.MutationHookOptions<CreateConventionMutation, CreateConventionMutationVariables>) {
-        return Apollo.useMutation<CreateConventionMutation, CreateConventionMutationVariables>(CreateConventionDocument, baseOptions);
+export function useCreateConventionMutation(baseOptions?: Apollo.MutationHookOptions<CreateConventionMutationData, CreateConventionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateConventionMutationData, CreateConventionMutationVariables>(CreateConventionDocument, options);
       }
 export type CreateConventionMutationHookResult = ReturnType<typeof useCreateConventionMutation>;
-export type CreateConventionMutationResult = Apollo.MutationResult<CreateConventionMutation>;
-export type CreateConventionMutationOptions = Apollo.BaseMutationOptions<CreateConventionMutation, CreateConventionMutationVariables>;
+export type CreateConventionMutationResult = Apollo.MutationResult<CreateConventionMutationData>;
+export type CreateConventionMutationOptions = Apollo.BaseMutationOptions<CreateConventionMutationData, CreateConventionMutationVariables>;
 export const SetConventionCanceledDocument = gql`
     mutation SetConventionCanceled($id: Int!, $canceled: Boolean!) {
   setConventionCanceled(input: {id: $id, canceled: $canceled}) {
@@ -94,7 +96,7 @@ export const SetConventionCanceledDocument = gql`
   }
 }
     ${ConventionDisplayFieldsFragmentDoc}`;
-export type SetConventionCanceledMutationFn = Apollo.MutationFunction<SetConventionCanceledMutation, SetConventionCanceledMutationVariables>;
+export type SetConventionCanceledMutationFn = Apollo.MutationFunction<SetConventionCanceledMutationData, SetConventionCanceledMutationVariables>;
 
 /**
  * __useSetConventionCanceledMutation__
@@ -114,9 +116,10 @@ export type SetConventionCanceledMutationFn = Apollo.MutationFunction<SetConvent
  *   },
  * });
  */
-export function useSetConventionCanceledMutation(baseOptions?: Apollo.MutationHookOptions<SetConventionCanceledMutation, SetConventionCanceledMutationVariables>) {
-        return Apollo.useMutation<SetConventionCanceledMutation, SetConventionCanceledMutationVariables>(SetConventionCanceledDocument, baseOptions);
+export function useSetConventionCanceledMutation(baseOptions?: Apollo.MutationHookOptions<SetConventionCanceledMutationData, SetConventionCanceledMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SetConventionCanceledMutationData, SetConventionCanceledMutationVariables>(SetConventionCanceledDocument, options);
       }
 export type SetConventionCanceledMutationHookResult = ReturnType<typeof useSetConventionCanceledMutation>;
-export type SetConventionCanceledMutationResult = Apollo.MutationResult<SetConventionCanceledMutation>;
-export type SetConventionCanceledMutationOptions = Apollo.BaseMutationOptions<SetConventionCanceledMutation, SetConventionCanceledMutationVariables>;
+export type SetConventionCanceledMutationResult = Apollo.MutationResult<SetConventionCanceledMutationData>;
+export type SetConventionCanceledMutationOptions = Apollo.BaseMutationOptions<SetConventionCanceledMutationData, SetConventionCanceledMutationVariables>;

--- a/app/javascript/RootSiteConventionsAdmin/queries.generated.ts
+++ b/app/javascript/RootSiteConventionsAdmin/queries.generated.ts
@@ -3,14 +3,15 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type RootSiteConventionsAdminTableQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type RootSiteConventionsAdminTableQueryVariables = Types.Exact<{
   page?: Types.Maybe<Types.Scalars['Int']>;
   filters?: Types.Maybe<Types.ConventionFiltersInput>;
   sort?: Types.Maybe<Array<Types.SortInput> | Types.SortInput>;
 }>;
 
 
-export type RootSiteConventionsAdminTableQueryQuery = (
+export type RootSiteConventionsAdminTableQueryData = (
   { __typename: 'Query' }
   & { conventions_paginated: (
     { __typename: 'ConventionsPagination' }
@@ -41,12 +42,12 @@ export type ConventionDisplayFieldsFragment = (
   )> }
 );
 
-export type ConventionDisplayQueryQueryVariables = Types.Exact<{
+export type ConventionDisplayQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type ConventionDisplayQueryQuery = (
+export type ConventionDisplayQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -55,10 +56,10 @@ export type ConventionDisplayQueryQuery = (
   ) }
 );
 
-export type NewConventionModalQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type NewConventionModalQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type NewConventionModalQueryQuery = (
+export type NewConventionModalQueryData = (
   { __typename: 'Query' }
   & { organizations: Array<(
     { __typename: 'Organization' }
@@ -118,16 +119,16 @@ export const RootSiteConventionsAdminTableQueryDocument = gql`
     `;
 
 /**
- * __useRootSiteConventionsAdminTableQueryQuery__
+ * __useRootSiteConventionsAdminTableQuery__
  *
- * To run a query within a React component, call `useRootSiteConventionsAdminTableQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useRootSiteConventionsAdminTableQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useRootSiteConventionsAdminTableQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRootSiteConventionsAdminTableQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useRootSiteConventionsAdminTableQueryQuery({
+ * const { data, loading, error } = useRootSiteConventionsAdminTableQuery({
  *   variables: {
  *      page: // value for 'page'
  *      filters: // value for 'filters'
@@ -135,15 +136,17 @@ export const RootSiteConventionsAdminTableQueryDocument = gql`
  *   },
  * });
  */
-export function useRootSiteConventionsAdminTableQueryQuery(baseOptions?: Apollo.QueryHookOptions<RootSiteConventionsAdminTableQueryQuery, RootSiteConventionsAdminTableQueryQueryVariables>) {
-        return Apollo.useQuery<RootSiteConventionsAdminTableQueryQuery, RootSiteConventionsAdminTableQueryQueryVariables>(RootSiteConventionsAdminTableQueryDocument, baseOptions);
+export function useRootSiteConventionsAdminTableQuery(baseOptions?: Apollo.QueryHookOptions<RootSiteConventionsAdminTableQueryData, RootSiteConventionsAdminTableQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RootSiteConventionsAdminTableQueryData, RootSiteConventionsAdminTableQueryVariables>(RootSiteConventionsAdminTableQueryDocument, options);
       }
-export function useRootSiteConventionsAdminTableQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RootSiteConventionsAdminTableQueryQuery, RootSiteConventionsAdminTableQueryQueryVariables>) {
-          return Apollo.useLazyQuery<RootSiteConventionsAdminTableQueryQuery, RootSiteConventionsAdminTableQueryQueryVariables>(RootSiteConventionsAdminTableQueryDocument, baseOptions);
+export function useRootSiteConventionsAdminTableQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RootSiteConventionsAdminTableQueryData, RootSiteConventionsAdminTableQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RootSiteConventionsAdminTableQueryData, RootSiteConventionsAdminTableQueryVariables>(RootSiteConventionsAdminTableQueryDocument, options);
         }
-export type RootSiteConventionsAdminTableQueryQueryHookResult = ReturnType<typeof useRootSiteConventionsAdminTableQueryQuery>;
+export type RootSiteConventionsAdminTableQueryHookResult = ReturnType<typeof useRootSiteConventionsAdminTableQuery>;
 export type RootSiteConventionsAdminTableQueryLazyQueryHookResult = ReturnType<typeof useRootSiteConventionsAdminTableQueryLazyQuery>;
-export type RootSiteConventionsAdminTableQueryQueryResult = Apollo.QueryResult<RootSiteConventionsAdminTableQueryQuery, RootSiteConventionsAdminTableQueryQueryVariables>;
+export type RootSiteConventionsAdminTableQueryDataResult = Apollo.QueryResult<RootSiteConventionsAdminTableQueryData, RootSiteConventionsAdminTableQueryVariables>;
 export const ConventionDisplayQueryDocument = gql`
     query ConventionDisplayQuery($id: Int!) {
   convention: conventionById(id: $id) {
@@ -154,30 +157,32 @@ export const ConventionDisplayQueryDocument = gql`
     ${ConventionDisplayFieldsFragmentDoc}`;
 
 /**
- * __useConventionDisplayQueryQuery__
+ * __useConventionDisplayQuery__
  *
- * To run a query within a React component, call `useConventionDisplayQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useConventionDisplayQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useConventionDisplayQuery` and pass it any options that fit your needs.
+ * When your component renders, `useConventionDisplayQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useConventionDisplayQueryQuery({
+ * const { data, loading, error } = useConventionDisplayQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useConventionDisplayQueryQuery(baseOptions: Apollo.QueryHookOptions<ConventionDisplayQueryQuery, ConventionDisplayQueryQueryVariables>) {
-        return Apollo.useQuery<ConventionDisplayQueryQuery, ConventionDisplayQueryQueryVariables>(ConventionDisplayQueryDocument, baseOptions);
+export function useConventionDisplayQuery(baseOptions: Apollo.QueryHookOptions<ConventionDisplayQueryData, ConventionDisplayQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ConventionDisplayQueryData, ConventionDisplayQueryVariables>(ConventionDisplayQueryDocument, options);
       }
-export function useConventionDisplayQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ConventionDisplayQueryQuery, ConventionDisplayQueryQueryVariables>) {
-          return Apollo.useLazyQuery<ConventionDisplayQueryQuery, ConventionDisplayQueryQueryVariables>(ConventionDisplayQueryDocument, baseOptions);
+export function useConventionDisplayQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ConventionDisplayQueryData, ConventionDisplayQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ConventionDisplayQueryData, ConventionDisplayQueryVariables>(ConventionDisplayQueryDocument, options);
         }
-export type ConventionDisplayQueryQueryHookResult = ReturnType<typeof useConventionDisplayQueryQuery>;
+export type ConventionDisplayQueryHookResult = ReturnType<typeof useConventionDisplayQuery>;
 export type ConventionDisplayQueryLazyQueryHookResult = ReturnType<typeof useConventionDisplayQueryLazyQuery>;
-export type ConventionDisplayQueryQueryResult = Apollo.QueryResult<ConventionDisplayQueryQuery, ConventionDisplayQueryQueryVariables>;
+export type ConventionDisplayQueryDataResult = Apollo.QueryResult<ConventionDisplayQueryData, ConventionDisplayQueryVariables>;
 export const NewConventionModalQueryDocument = gql`
     query NewConventionModalQuery {
   organizations {
@@ -188,26 +193,28 @@ export const NewConventionModalQueryDocument = gql`
     `;
 
 /**
- * __useNewConventionModalQueryQuery__
+ * __useNewConventionModalQuery__
  *
- * To run a query within a React component, call `useNewConventionModalQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useNewConventionModalQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useNewConventionModalQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNewConventionModalQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useNewConventionModalQueryQuery({
+ * const { data, loading, error } = useNewConventionModalQuery({
  *   variables: {
  *   },
  * });
  */
-export function useNewConventionModalQueryQuery(baseOptions?: Apollo.QueryHookOptions<NewConventionModalQueryQuery, NewConventionModalQueryQueryVariables>) {
-        return Apollo.useQuery<NewConventionModalQueryQuery, NewConventionModalQueryQueryVariables>(NewConventionModalQueryDocument, baseOptions);
+export function useNewConventionModalQuery(baseOptions?: Apollo.QueryHookOptions<NewConventionModalQueryData, NewConventionModalQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<NewConventionModalQueryData, NewConventionModalQueryVariables>(NewConventionModalQueryDocument, options);
       }
-export function useNewConventionModalQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NewConventionModalQueryQuery, NewConventionModalQueryQueryVariables>) {
-          return Apollo.useLazyQuery<NewConventionModalQueryQuery, NewConventionModalQueryQueryVariables>(NewConventionModalQueryDocument, baseOptions);
+export function useNewConventionModalQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NewConventionModalQueryData, NewConventionModalQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<NewConventionModalQueryData, NewConventionModalQueryVariables>(NewConventionModalQueryDocument, options);
         }
-export type NewConventionModalQueryQueryHookResult = ReturnType<typeof useNewConventionModalQueryQuery>;
+export type NewConventionModalQueryHookResult = ReturnType<typeof useNewConventionModalQuery>;
 export type NewConventionModalQueryLazyQueryHookResult = ReturnType<typeof useNewConventionModalQueryLazyQuery>;
-export type NewConventionModalQueryQueryResult = Apollo.QueryResult<NewConventionModalQueryQuery, NewConventionModalQueryQueryVariables>;
+export type NewConventionModalQueryDataResult = Apollo.QueryResult<NewConventionModalQueryData, NewConventionModalQueryVariables>;

--- a/app/javascript/RootSiteEmailRoutesAdmin/EditEmailRouteModal.tsx
+++ b/app/javascript/RootSiteEmailRoutesAdmin/EditEmailRouteModal.tsx
@@ -7,13 +7,13 @@ import useAsyncFunction from '../useAsyncFunction';
 import buildEmailRouteInput from './buildEmailRouteInput';
 import ErrorDisplay from '../ErrorDisplay';
 import { useConfirm } from '../ModalDialogs/Confirm';
-import { RootSiteEmailRoutesAdminTableQueryQuery } from './queries.generated';
+import { RootSiteEmailRoutesAdminTableQueryData } from './queries.generated';
 import { useDeleteEmailRouteMutation, useUpdateEmailRouteMutation } from './mutations.generated';
 
 export type EditEmailRouteModalProps = {
   visible: boolean;
   close: () => void;
-  initialEmailRoute?: RootSiteEmailRoutesAdminTableQueryQuery['email_routes_paginated']['entries'][0];
+  initialEmailRoute?: RootSiteEmailRoutesAdminTableQueryData['email_routes_paginated']['entries'][0];
 };
 
 function EditEmailRouteModal({ visible, close, initialEmailRoute }: EditEmailRouteModalProps) {

--- a/app/javascript/RootSiteEmailRoutesAdmin/index.tsx
+++ b/app/javascript/RootSiteEmailRoutesAdmin/index.tsx
@@ -10,12 +10,12 @@ import NewEmailRouteModal from './NewEmailRouteModal';
 import EditEmailRouteModal from './EditEmailRouteModal';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
 import {
-  RootSiteEmailRoutesAdminTableQueryQuery,
-  useRootSiteEmailRoutesAdminTableQueryQuery,
+  RootSiteEmailRoutesAdminTableQueryData,
+  useRootSiteEmailRoutesAdminTableQuery,
 } from './queries.generated';
 import ReactTableWithTheWorks from '../Tables/ReactTableWithTheWorks';
 
-type EmailRouteType = RootSiteEmailRoutesAdminTableQueryQuery['email_routes_paginated']['entries'][0];
+type EmailRouteType = RootSiteEmailRoutesAdminTableQueryData['email_routes_paginated']['entries'][0];
 
 const { encodeFilterValue, decodeFilterValue } = buildFieldFilterCodecs({});
 
@@ -56,7 +56,7 @@ function RootSiteEmailRoutesAdminTable() {
     getPages: ({ data }) => data.email_routes_paginated.total_pages,
     getPossibleColumns,
     storageKeyPrefix: 'email-routes',
-    useQuery: useRootSiteEmailRoutesAdminTableQueryQuery,
+    useQuery: useRootSiteEmailRoutesAdminTableQuery,
   });
   usePageTitle('Email routes');
 

--- a/app/javascript/RootSiteEmailRoutesAdmin/mutations.generated.ts
+++ b/app/javascript/RootSiteEmailRoutesAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { EmailRouteFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { EmailRouteFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateEmailRouteMutationVariables = Types.Exact<{
   emailRoute: Types.EmailRouteInput;
 }>;
 
 
-export type CreateEmailRouteMutation = (
+export type CreateEmailRouteMutationData = (
   { __typename: 'Mutation' }
   & { createEmailRoute?: Types.Maybe<(
     { __typename: 'CreateEmailRoutePayload' }
@@ -28,7 +29,7 @@ export type UpdateEmailRouteMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateEmailRouteMutation = (
+export type UpdateEmailRouteMutationData = (
   { __typename: 'Mutation' }
   & { updateEmailRoute?: Types.Maybe<(
     { __typename: 'UpdateEmailRoutePayload' }
@@ -45,7 +46,7 @@ export type DeleteEmailRouteMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteEmailRouteMutation = (
+export type DeleteEmailRouteMutationData = (
   { __typename: 'Mutation' }
   & { deleteEmailRoute?: Types.Maybe<(
     { __typename: 'DeleteEmailRoutePayload' }
@@ -64,7 +65,7 @@ export const CreateEmailRouteDocument = gql`
   }
 }
     ${EmailRouteFieldsFragmentDoc}`;
-export type CreateEmailRouteMutationFn = Apollo.MutationFunction<CreateEmailRouteMutation, CreateEmailRouteMutationVariables>;
+export type CreateEmailRouteMutationFn = Apollo.MutationFunction<CreateEmailRouteMutationData, CreateEmailRouteMutationVariables>;
 
 /**
  * __useCreateEmailRouteMutation__
@@ -83,12 +84,13 @@ export type CreateEmailRouteMutationFn = Apollo.MutationFunction<CreateEmailRout
  *   },
  * });
  */
-export function useCreateEmailRouteMutation(baseOptions?: Apollo.MutationHookOptions<CreateEmailRouteMutation, CreateEmailRouteMutationVariables>) {
-        return Apollo.useMutation<CreateEmailRouteMutation, CreateEmailRouteMutationVariables>(CreateEmailRouteDocument, baseOptions);
+export function useCreateEmailRouteMutation(baseOptions?: Apollo.MutationHookOptions<CreateEmailRouteMutationData, CreateEmailRouteMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateEmailRouteMutationData, CreateEmailRouteMutationVariables>(CreateEmailRouteDocument, options);
       }
 export type CreateEmailRouteMutationHookResult = ReturnType<typeof useCreateEmailRouteMutation>;
-export type CreateEmailRouteMutationResult = Apollo.MutationResult<CreateEmailRouteMutation>;
-export type CreateEmailRouteMutationOptions = Apollo.BaseMutationOptions<CreateEmailRouteMutation, CreateEmailRouteMutationVariables>;
+export type CreateEmailRouteMutationResult = Apollo.MutationResult<CreateEmailRouteMutationData>;
+export type CreateEmailRouteMutationOptions = Apollo.BaseMutationOptions<CreateEmailRouteMutationData, CreateEmailRouteMutationVariables>;
 export const UpdateEmailRouteDocument = gql`
     mutation UpdateEmailRoute($id: Int!, $emailRoute: EmailRouteInput!) {
   updateEmailRoute(input: {id: $id, email_route: $emailRoute}) {
@@ -99,7 +101,7 @@ export const UpdateEmailRouteDocument = gql`
   }
 }
     ${EmailRouteFieldsFragmentDoc}`;
-export type UpdateEmailRouteMutationFn = Apollo.MutationFunction<UpdateEmailRouteMutation, UpdateEmailRouteMutationVariables>;
+export type UpdateEmailRouteMutationFn = Apollo.MutationFunction<UpdateEmailRouteMutationData, UpdateEmailRouteMutationVariables>;
 
 /**
  * __useUpdateEmailRouteMutation__
@@ -119,12 +121,13 @@ export type UpdateEmailRouteMutationFn = Apollo.MutationFunction<UpdateEmailRout
  *   },
  * });
  */
-export function useUpdateEmailRouteMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEmailRouteMutation, UpdateEmailRouteMutationVariables>) {
-        return Apollo.useMutation<UpdateEmailRouteMutation, UpdateEmailRouteMutationVariables>(UpdateEmailRouteDocument, baseOptions);
+export function useUpdateEmailRouteMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEmailRouteMutationData, UpdateEmailRouteMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateEmailRouteMutationData, UpdateEmailRouteMutationVariables>(UpdateEmailRouteDocument, options);
       }
 export type UpdateEmailRouteMutationHookResult = ReturnType<typeof useUpdateEmailRouteMutation>;
-export type UpdateEmailRouteMutationResult = Apollo.MutationResult<UpdateEmailRouteMutation>;
-export type UpdateEmailRouteMutationOptions = Apollo.BaseMutationOptions<UpdateEmailRouteMutation, UpdateEmailRouteMutationVariables>;
+export type UpdateEmailRouteMutationResult = Apollo.MutationResult<UpdateEmailRouteMutationData>;
+export type UpdateEmailRouteMutationOptions = Apollo.BaseMutationOptions<UpdateEmailRouteMutationData, UpdateEmailRouteMutationVariables>;
 export const DeleteEmailRouteDocument = gql`
     mutation DeleteEmailRoute($id: Int!) {
   deleteEmailRoute(input: {id: $id}) {
@@ -132,7 +135,7 @@ export const DeleteEmailRouteDocument = gql`
   }
 }
     `;
-export type DeleteEmailRouteMutationFn = Apollo.MutationFunction<DeleteEmailRouteMutation, DeleteEmailRouteMutationVariables>;
+export type DeleteEmailRouteMutationFn = Apollo.MutationFunction<DeleteEmailRouteMutationData, DeleteEmailRouteMutationVariables>;
 
 /**
  * __useDeleteEmailRouteMutation__
@@ -151,9 +154,10 @@ export type DeleteEmailRouteMutationFn = Apollo.MutationFunction<DeleteEmailRout
  *   },
  * });
  */
-export function useDeleteEmailRouteMutation(baseOptions?: Apollo.MutationHookOptions<DeleteEmailRouteMutation, DeleteEmailRouteMutationVariables>) {
-        return Apollo.useMutation<DeleteEmailRouteMutation, DeleteEmailRouteMutationVariables>(DeleteEmailRouteDocument, baseOptions);
+export function useDeleteEmailRouteMutation(baseOptions?: Apollo.MutationHookOptions<DeleteEmailRouteMutationData, DeleteEmailRouteMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteEmailRouteMutationData, DeleteEmailRouteMutationVariables>(DeleteEmailRouteDocument, options);
       }
 export type DeleteEmailRouteMutationHookResult = ReturnType<typeof useDeleteEmailRouteMutation>;
-export type DeleteEmailRouteMutationResult = Apollo.MutationResult<DeleteEmailRouteMutation>;
-export type DeleteEmailRouteMutationOptions = Apollo.BaseMutationOptions<DeleteEmailRouteMutation, DeleteEmailRouteMutationVariables>;
+export type DeleteEmailRouteMutationResult = Apollo.MutationResult<DeleteEmailRouteMutationData>;
+export type DeleteEmailRouteMutationOptions = Apollo.BaseMutationOptions<DeleteEmailRouteMutationData, DeleteEmailRouteMutationVariables>;

--- a/app/javascript/RootSiteEmailRoutesAdmin/queries.generated.ts
+++ b/app/javascript/RootSiteEmailRoutesAdmin/queries.generated.ts
@@ -3,19 +3,20 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type EmailRouteFieldsFragment = (
   { __typename: 'EmailRoute' }
   & Pick<Types.EmailRoute, 'id' | 'receiver_address' | 'forward_addresses'>
 );
 
-export type RootSiteEmailRoutesAdminTableQueryQueryVariables = Types.Exact<{
+export type RootSiteEmailRoutesAdminTableQueryVariables = Types.Exact<{
   page?: Types.Maybe<Types.Scalars['Int']>;
   filters?: Types.Maybe<Types.EmailRouteFiltersInput>;
   sort?: Types.Maybe<Array<Types.SortInput> | Types.SortInput>;
 }>;
 
 
-export type RootSiteEmailRoutesAdminTableQueryQuery = (
+export type RootSiteEmailRoutesAdminTableQueryData = (
   { __typename: 'Query' }
   & { email_routes_paginated: (
     { __typename: 'EmailRoutesPagination' }
@@ -49,16 +50,16 @@ export const RootSiteEmailRoutesAdminTableQueryDocument = gql`
     ${EmailRouteFieldsFragmentDoc}`;
 
 /**
- * __useRootSiteEmailRoutesAdminTableQueryQuery__
+ * __useRootSiteEmailRoutesAdminTableQuery__
  *
- * To run a query within a React component, call `useRootSiteEmailRoutesAdminTableQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useRootSiteEmailRoutesAdminTableQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useRootSiteEmailRoutesAdminTableQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRootSiteEmailRoutesAdminTableQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useRootSiteEmailRoutesAdminTableQueryQuery({
+ * const { data, loading, error } = useRootSiteEmailRoutesAdminTableQuery({
  *   variables: {
  *      page: // value for 'page'
  *      filters: // value for 'filters'
@@ -66,12 +67,14 @@ export const RootSiteEmailRoutesAdminTableQueryDocument = gql`
  *   },
  * });
  */
-export function useRootSiteEmailRoutesAdminTableQueryQuery(baseOptions?: Apollo.QueryHookOptions<RootSiteEmailRoutesAdminTableQueryQuery, RootSiteEmailRoutesAdminTableQueryQueryVariables>) {
-        return Apollo.useQuery<RootSiteEmailRoutesAdminTableQueryQuery, RootSiteEmailRoutesAdminTableQueryQueryVariables>(RootSiteEmailRoutesAdminTableQueryDocument, baseOptions);
+export function useRootSiteEmailRoutesAdminTableQuery(baseOptions?: Apollo.QueryHookOptions<RootSiteEmailRoutesAdminTableQueryData, RootSiteEmailRoutesAdminTableQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RootSiteEmailRoutesAdminTableQueryData, RootSiteEmailRoutesAdminTableQueryVariables>(RootSiteEmailRoutesAdminTableQueryDocument, options);
       }
-export function useRootSiteEmailRoutesAdminTableQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RootSiteEmailRoutesAdminTableQueryQuery, RootSiteEmailRoutesAdminTableQueryQueryVariables>) {
-          return Apollo.useLazyQuery<RootSiteEmailRoutesAdminTableQueryQuery, RootSiteEmailRoutesAdminTableQueryQueryVariables>(RootSiteEmailRoutesAdminTableQueryDocument, baseOptions);
+export function useRootSiteEmailRoutesAdminTableQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RootSiteEmailRoutesAdminTableQueryData, RootSiteEmailRoutesAdminTableQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RootSiteEmailRoutesAdminTableQueryData, RootSiteEmailRoutesAdminTableQueryVariables>(RootSiteEmailRoutesAdminTableQueryDocument, options);
         }
-export type RootSiteEmailRoutesAdminTableQueryQueryHookResult = ReturnType<typeof useRootSiteEmailRoutesAdminTableQueryQuery>;
+export type RootSiteEmailRoutesAdminTableQueryHookResult = ReturnType<typeof useRootSiteEmailRoutesAdminTableQuery>;
 export type RootSiteEmailRoutesAdminTableQueryLazyQueryHookResult = ReturnType<typeof useRootSiteEmailRoutesAdminTableQueryLazyQuery>;
-export type RootSiteEmailRoutesAdminTableQueryQueryResult = Apollo.QueryResult<RootSiteEmailRoutesAdminTableQueryQuery, RootSiteEmailRoutesAdminTableQueryQueryVariables>;
+export type RootSiteEmailRoutesAdminTableQueryDataResult = Apollo.QueryResult<RootSiteEmailRoutesAdminTableQueryData, RootSiteEmailRoutesAdminTableQueryVariables>;

--- a/app/javascript/SignupModeration/CreateSignup.tsx
+++ b/app/javascript/SignupModeration/CreateSignup.tsx
@@ -6,15 +6,15 @@ import EventSelect from '../BuiltInFormControls/EventSelect';
 import FormGroupWithLabel from '../BuiltInFormControls/FormGroupWithLabel';
 import LoadingIndicator from '../LoadingIndicator';
 import UserConProfileSelect from '../BuiltInFormControls/UserConProfileSelect';
-import { CreateSignupEventsQueryQuery } from './queries.generated';
-import { DefaultUserConProfilesQueryQuery } from '../BuiltInFormControls/selectDefaultQueries.generated';
+import { CreateSignupEventsQueryData } from './queries.generated';
+import { DefaultUserConProfilesQueryData } from '../BuiltInFormControls/selectDefaultQueries.generated';
 
 type EventType = NonNullable<
-  CreateSignupEventsQueryQuery['convention']
+  CreateSignupEventsQueryData['convention']
 >['events_paginated']['entries'][0];
 
 type UserConProfileType = NonNullable<
-  DefaultUserConProfilesQueryQuery['convention']
+  DefaultUserConProfilesQueryData['convention']
 >['user_con_profiles_paginated']['entries'][0];
 
 function CreateSignup() {

--- a/app/javascript/SignupModeration/CreateSignupRunCard.tsx
+++ b/app/javascript/SignupModeration/CreateSignupRunCard.tsx
@@ -7,7 +7,7 @@ import RunCard from '../EventsApp/EventPage/RunCard';
 import { useConfirm } from '../ModalDialogs/Confirm';
 import { useAlert } from '../ModalDialogs/Alert';
 import LoadingIndicator from '../LoadingIndicator';
-import { useCreateSignupRunCardQueryQuery } from './queries.generated';
+import { useCreateSignupRunCardQuery } from './queries.generated';
 import { useCreateUserSignupMutation, useWithdrawUserSignupMutation } from './mutations.generated';
 
 export type CreateSignupRunCardProps = {
@@ -21,7 +21,7 @@ function CreateSignupRunCard({ eventId, runId, userConProfileId }: CreateSignupR
   const confirm = useConfirm();
   const alert = useAlert();
 
-  const { data, loading, error } = useCreateSignupRunCardQueryQuery({
+  const { data, loading, error } = useCreateSignupRunCardQuery({
     variables: { userConProfileId, eventId },
   });
 

--- a/app/javascript/SignupModeration/SignupModerationQueue.tsx
+++ b/app/javascript/SignupModeration/SignupModerationQueue.tsx
@@ -9,9 +9,9 @@ import { useConfirm } from '../ModalDialogs/Confirm';
 import RunCapacityGraph from '../EventsApp/EventPage/RunCapacityGraph';
 import { SignupRequestState } from '../graphqlTypes.generated';
 import {
-  SignupModerationQueueQueryQuery,
+  SignupModerationQueueQueryData,
   SignupModerationSignupRequestFieldsFragment,
-  useSignupModerationQueueQueryQuery,
+  useSignupModerationQueueQuery,
 } from './queries.generated';
 import {
   useAcceptSignupRequestMutation,
@@ -61,7 +61,7 @@ function describeRequestedBucket(signupRequest: SignupModerationSignupRequestFie
 
 type SignupModerationRunDetailsProps = {
   run: NonNullable<
-    SignupModerationQueueQueryQuery['convention']
+    SignupModerationQueueQueryData['convention']
   >['signup_requests_paginated']['entries'][0]['target_run'];
   showRequestedBucket?: boolean;
   requestedBucketKey?: string;
@@ -165,7 +165,7 @@ function SignupRequestActionsCell({
 }
 
 function getPossibleColumns(): Column<
-  SignupModerationQueueQueryQuery['convention']['signup_requests_paginated']['entries'][number]
+  SignupModerationQueueQueryData['convention']['signup_requests_paginated']['entries'][number]
 >[] {
   return [
     {
@@ -210,7 +210,7 @@ function SignupModerationQueue() {
   const [rejectSignupRequest] = useRejectSignupRequestMutation();
   const confirm = useConfirm();
   const { tableInstance, loading } = useReactTableWithTheWorks({
-    useQuery: useSignupModerationQueueQueryQuery,
+    useQuery: useSignupModerationQueueQuery,
     storageKeyPrefix: 'signupModerationQueue',
     getData: (result) => result.data.convention.signup_requests_paginated.entries,
     getPages: (result) => result.data.convention.signup_requests_paginated.total_pages,
@@ -254,7 +254,7 @@ function SignupModerationQueue() {
         }),
       rejectClicked: (
         signupRequest: NonNullable<
-          SignupModerationQueueQueryQuery['convention']
+          SignupModerationQueueQueryData['convention']
         >['signup_requests_paginated']['entries'][0],
       ) =>
         confirm({

--- a/app/javascript/SignupModeration/mutations.generated.ts
+++ b/app/javascript/SignupModeration/mutations.generated.ts
@@ -5,6 +5,7 @@ import { SignupModerationSignupRequestFieldsFragment } from './queries.generated
 import { gql } from '@apollo/client';
 import { SignupModerationSignupRequestFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateUserSignupMutationVariables = Types.Exact<{
   runId: Types.Scalars['Int'];
   userConProfileId: Types.Scalars['Int'];
@@ -13,7 +14,7 @@ export type CreateUserSignupMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateUserSignupMutation = (
+export type CreateUserSignupMutationData = (
   { __typename: 'Mutation' }
   & { createUserSignup?: Types.Maybe<(
     { __typename: 'CreateUserSignupPayload' }
@@ -27,7 +28,7 @@ export type WithdrawUserSignupMutationVariables = Types.Exact<{
 }>;
 
 
-export type WithdrawUserSignupMutation = (
+export type WithdrawUserSignupMutationData = (
   { __typename: 'Mutation' }
   & { withdrawUserSignup?: Types.Maybe<(
     { __typename: 'WithdrawUserSignupPayload' }
@@ -40,7 +41,7 @@ export type AcceptSignupRequestMutationVariables = Types.Exact<{
 }>;
 
 
-export type AcceptSignupRequestMutation = (
+export type AcceptSignupRequestMutationData = (
   { __typename: 'Mutation' }
   & { acceptSignupRequest?: Types.Maybe<(
     { __typename: 'AcceptSignupRequestPayload' }
@@ -57,7 +58,7 @@ export type RejectSignupRequestMutationVariables = Types.Exact<{
 }>;
 
 
-export type RejectSignupRequestMutation = (
+export type RejectSignupRequestMutationData = (
   { __typename: 'Mutation' }
   & { rejectSignupRequest?: Types.Maybe<(
     { __typename: 'RejectSignupRequestPayload' }
@@ -79,7 +80,7 @@ export const CreateUserSignupDocument = gql`
   }
 }
     `;
-export type CreateUserSignupMutationFn = Apollo.MutationFunction<CreateUserSignupMutation, CreateUserSignupMutationVariables>;
+export type CreateUserSignupMutationFn = Apollo.MutationFunction<CreateUserSignupMutationData, CreateUserSignupMutationVariables>;
 
 /**
  * __useCreateUserSignupMutation__
@@ -101,12 +102,13 @@ export type CreateUserSignupMutationFn = Apollo.MutationFunction<CreateUserSignu
  *   },
  * });
  */
-export function useCreateUserSignupMutation(baseOptions?: Apollo.MutationHookOptions<CreateUserSignupMutation, CreateUserSignupMutationVariables>) {
-        return Apollo.useMutation<CreateUserSignupMutation, CreateUserSignupMutationVariables>(CreateUserSignupDocument, baseOptions);
+export function useCreateUserSignupMutation(baseOptions?: Apollo.MutationHookOptions<CreateUserSignupMutationData, CreateUserSignupMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateUserSignupMutationData, CreateUserSignupMutationVariables>(CreateUserSignupDocument, options);
       }
 export type CreateUserSignupMutationHookResult = ReturnType<typeof useCreateUserSignupMutation>;
-export type CreateUserSignupMutationResult = Apollo.MutationResult<CreateUserSignupMutation>;
-export type CreateUserSignupMutationOptions = Apollo.BaseMutationOptions<CreateUserSignupMutation, CreateUserSignupMutationVariables>;
+export type CreateUserSignupMutationResult = Apollo.MutationResult<CreateUserSignupMutationData>;
+export type CreateUserSignupMutationOptions = Apollo.BaseMutationOptions<CreateUserSignupMutationData, CreateUserSignupMutationVariables>;
 export const WithdrawUserSignupDocument = gql`
     mutation WithdrawUserSignup($runId: Int!, $userConProfileId: Int!) {
   withdrawUserSignup(
@@ -116,7 +118,7 @@ export const WithdrawUserSignupDocument = gql`
   }
 }
     `;
-export type WithdrawUserSignupMutationFn = Apollo.MutationFunction<WithdrawUserSignupMutation, WithdrawUserSignupMutationVariables>;
+export type WithdrawUserSignupMutationFn = Apollo.MutationFunction<WithdrawUserSignupMutationData, WithdrawUserSignupMutationVariables>;
 
 /**
  * __useWithdrawUserSignupMutation__
@@ -136,12 +138,13 @@ export type WithdrawUserSignupMutationFn = Apollo.MutationFunction<WithdrawUserS
  *   },
  * });
  */
-export function useWithdrawUserSignupMutation(baseOptions?: Apollo.MutationHookOptions<WithdrawUserSignupMutation, WithdrawUserSignupMutationVariables>) {
-        return Apollo.useMutation<WithdrawUserSignupMutation, WithdrawUserSignupMutationVariables>(WithdrawUserSignupDocument, baseOptions);
+export function useWithdrawUserSignupMutation(baseOptions?: Apollo.MutationHookOptions<WithdrawUserSignupMutationData, WithdrawUserSignupMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<WithdrawUserSignupMutationData, WithdrawUserSignupMutationVariables>(WithdrawUserSignupDocument, options);
       }
 export type WithdrawUserSignupMutationHookResult = ReturnType<typeof useWithdrawUserSignupMutation>;
-export type WithdrawUserSignupMutationResult = Apollo.MutationResult<WithdrawUserSignupMutation>;
-export type WithdrawUserSignupMutationOptions = Apollo.BaseMutationOptions<WithdrawUserSignupMutation, WithdrawUserSignupMutationVariables>;
+export type WithdrawUserSignupMutationResult = Apollo.MutationResult<WithdrawUserSignupMutationData>;
+export type WithdrawUserSignupMutationOptions = Apollo.BaseMutationOptions<WithdrawUserSignupMutationData, WithdrawUserSignupMutationVariables>;
 export const AcceptSignupRequestDocument = gql`
     mutation AcceptSignupRequest($id: Int!) {
   acceptSignupRequest(input: {id: $id}) {
@@ -152,7 +155,7 @@ export const AcceptSignupRequestDocument = gql`
   }
 }
     ${SignupModerationSignupRequestFieldsFragmentDoc}`;
-export type AcceptSignupRequestMutationFn = Apollo.MutationFunction<AcceptSignupRequestMutation, AcceptSignupRequestMutationVariables>;
+export type AcceptSignupRequestMutationFn = Apollo.MutationFunction<AcceptSignupRequestMutationData, AcceptSignupRequestMutationVariables>;
 
 /**
  * __useAcceptSignupRequestMutation__
@@ -171,12 +174,13 @@ export type AcceptSignupRequestMutationFn = Apollo.MutationFunction<AcceptSignup
  *   },
  * });
  */
-export function useAcceptSignupRequestMutation(baseOptions?: Apollo.MutationHookOptions<AcceptSignupRequestMutation, AcceptSignupRequestMutationVariables>) {
-        return Apollo.useMutation<AcceptSignupRequestMutation, AcceptSignupRequestMutationVariables>(AcceptSignupRequestDocument, baseOptions);
+export function useAcceptSignupRequestMutation(baseOptions?: Apollo.MutationHookOptions<AcceptSignupRequestMutationData, AcceptSignupRequestMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AcceptSignupRequestMutationData, AcceptSignupRequestMutationVariables>(AcceptSignupRequestDocument, options);
       }
 export type AcceptSignupRequestMutationHookResult = ReturnType<typeof useAcceptSignupRequestMutation>;
-export type AcceptSignupRequestMutationResult = Apollo.MutationResult<AcceptSignupRequestMutation>;
-export type AcceptSignupRequestMutationOptions = Apollo.BaseMutationOptions<AcceptSignupRequestMutation, AcceptSignupRequestMutationVariables>;
+export type AcceptSignupRequestMutationResult = Apollo.MutationResult<AcceptSignupRequestMutationData>;
+export type AcceptSignupRequestMutationOptions = Apollo.BaseMutationOptions<AcceptSignupRequestMutationData, AcceptSignupRequestMutationVariables>;
 export const RejectSignupRequestDocument = gql`
     mutation RejectSignupRequest($id: Int!) {
   rejectSignupRequest(input: {id: $id}) {
@@ -187,7 +191,7 @@ export const RejectSignupRequestDocument = gql`
   }
 }
     ${SignupModerationSignupRequestFieldsFragmentDoc}`;
-export type RejectSignupRequestMutationFn = Apollo.MutationFunction<RejectSignupRequestMutation, RejectSignupRequestMutationVariables>;
+export type RejectSignupRequestMutationFn = Apollo.MutationFunction<RejectSignupRequestMutationData, RejectSignupRequestMutationVariables>;
 
 /**
  * __useRejectSignupRequestMutation__
@@ -206,9 +210,10 @@ export type RejectSignupRequestMutationFn = Apollo.MutationFunction<RejectSignup
  *   },
  * });
  */
-export function useRejectSignupRequestMutation(baseOptions?: Apollo.MutationHookOptions<RejectSignupRequestMutation, RejectSignupRequestMutationVariables>) {
-        return Apollo.useMutation<RejectSignupRequestMutation, RejectSignupRequestMutationVariables>(RejectSignupRequestDocument, baseOptions);
+export function useRejectSignupRequestMutation(baseOptions?: Apollo.MutationHookOptions<RejectSignupRequestMutationData, RejectSignupRequestMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RejectSignupRequestMutationData, RejectSignupRequestMutationVariables>(RejectSignupRequestDocument, options);
       }
 export type RejectSignupRequestMutationHookResult = ReturnType<typeof useRejectSignupRequestMutation>;
-export type RejectSignupRequestMutationResult = Apollo.MutationResult<RejectSignupRequestMutation>;
-export type RejectSignupRequestMutationOptions = Apollo.BaseMutationOptions<RejectSignupRequestMutation, RejectSignupRequestMutationVariables>;
+export type RejectSignupRequestMutationResult = Apollo.MutationResult<RejectSignupRequestMutationData>;
+export type RejectSignupRequestMutationOptions = Apollo.BaseMutationOptions<RejectSignupRequestMutationData, RejectSignupRequestMutationVariables>;

--- a/app/javascript/SignupModeration/queries.generated.ts
+++ b/app/javascript/SignupModeration/queries.generated.ts
@@ -5,6 +5,7 @@ import { RunCardRegistrationPolicyFieldsFragment, EventPageRunFieldsFragment } f
 import { gql } from '@apollo/client';
 import { RunCardRegistrationPolicyFieldsFragmentDoc, EventPageRunFieldsFragmentDoc } from '../EventsApp/EventPage/queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type SignupModerationRunFieldsFragment = (
   { __typename: 'Run' }
   & Pick<Types.Run, 'id' | 'title_suffix' | 'starts_at' | 'signup_count_by_state_and_bucket_key_and_counted'>
@@ -50,12 +51,12 @@ export type SignupModerationSignupRequestFieldsFragment = (
   )> }
 );
 
-export type CreateSignupEventsQueryQueryVariables = Types.Exact<{
+export type CreateSignupEventsQueryVariables = Types.Exact<{
   title?: Types.Maybe<Types.Scalars['String']>;
 }>;
 
 
-export type CreateSignupEventsQueryQuery = (
+export type CreateSignupEventsQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -78,13 +79,13 @@ export type CreateSignupEventsQueryQuery = (
   )> }
 );
 
-export type CreateSignupRunCardQueryQueryVariables = Types.Exact<{
+export type CreateSignupRunCardQueryVariables = Types.Exact<{
   userConProfileId: Types.Scalars['Int'];
   eventId: Types.Scalars['Int'];
 }>;
 
 
-export type CreateSignupRunCardQueryQuery = (
+export type CreateSignupRunCardQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -131,13 +132,13 @@ export type CreateSignupRunCardQueryQuery = (
   ) }
 );
 
-export type SignupModerationQueueQueryQueryVariables = Types.Exact<{
+export type SignupModerationQueueQueryVariables = Types.Exact<{
   page?: Types.Maybe<Types.Scalars['Int']>;
   perPage?: Types.Maybe<Types.Scalars['Int']>;
 }>;
 
 
-export type SignupModerationQueueQueryQuery = (
+export type SignupModerationQueueQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -238,30 +239,32 @@ export const CreateSignupEventsQueryDocument = gql`
     `;
 
 /**
- * __useCreateSignupEventsQueryQuery__
+ * __useCreateSignupEventsQuery__
  *
- * To run a query within a React component, call `useCreateSignupEventsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCreateSignupEventsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCreateSignupEventsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCreateSignupEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCreateSignupEventsQueryQuery({
+ * const { data, loading, error } = useCreateSignupEventsQuery({
  *   variables: {
  *      title: // value for 'title'
  *   },
  * });
  */
-export function useCreateSignupEventsQueryQuery(baseOptions?: Apollo.QueryHookOptions<CreateSignupEventsQueryQuery, CreateSignupEventsQueryQueryVariables>) {
-        return Apollo.useQuery<CreateSignupEventsQueryQuery, CreateSignupEventsQueryQueryVariables>(CreateSignupEventsQueryDocument, baseOptions);
+export function useCreateSignupEventsQuery(baseOptions?: Apollo.QueryHookOptions<CreateSignupEventsQueryData, CreateSignupEventsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CreateSignupEventsQueryData, CreateSignupEventsQueryVariables>(CreateSignupEventsQueryDocument, options);
       }
-export function useCreateSignupEventsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CreateSignupEventsQueryQuery, CreateSignupEventsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CreateSignupEventsQueryQuery, CreateSignupEventsQueryQueryVariables>(CreateSignupEventsQueryDocument, baseOptions);
+export function useCreateSignupEventsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CreateSignupEventsQueryData, CreateSignupEventsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CreateSignupEventsQueryData, CreateSignupEventsQueryVariables>(CreateSignupEventsQueryDocument, options);
         }
-export type CreateSignupEventsQueryQueryHookResult = ReturnType<typeof useCreateSignupEventsQueryQuery>;
+export type CreateSignupEventsQueryHookResult = ReturnType<typeof useCreateSignupEventsQuery>;
 export type CreateSignupEventsQueryLazyQueryHookResult = ReturnType<typeof useCreateSignupEventsQueryLazyQuery>;
-export type CreateSignupEventsQueryQueryResult = Apollo.QueryResult<CreateSignupEventsQueryQuery, CreateSignupEventsQueryQueryVariables>;
+export type CreateSignupEventsQueryDataResult = Apollo.QueryResult<CreateSignupEventsQueryData, CreateSignupEventsQueryVariables>;
 export const CreateSignupRunCardQueryDocument = gql`
     query CreateSignupRunCardQuery($userConProfileId: Int!, $eventId: Int!) {
   currentAbility {
@@ -321,31 +324,33 @@ export const CreateSignupRunCardQueryDocument = gql`
 ${EventPageRunFieldsFragmentDoc}`;
 
 /**
- * __useCreateSignupRunCardQueryQuery__
+ * __useCreateSignupRunCardQuery__
  *
- * To run a query within a React component, call `useCreateSignupRunCardQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCreateSignupRunCardQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCreateSignupRunCardQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCreateSignupRunCardQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCreateSignupRunCardQueryQuery({
+ * const { data, loading, error } = useCreateSignupRunCardQuery({
  *   variables: {
  *      userConProfileId: // value for 'userConProfileId'
  *      eventId: // value for 'eventId'
  *   },
  * });
  */
-export function useCreateSignupRunCardQueryQuery(baseOptions: Apollo.QueryHookOptions<CreateSignupRunCardQueryQuery, CreateSignupRunCardQueryQueryVariables>) {
-        return Apollo.useQuery<CreateSignupRunCardQueryQuery, CreateSignupRunCardQueryQueryVariables>(CreateSignupRunCardQueryDocument, baseOptions);
+export function useCreateSignupRunCardQuery(baseOptions: Apollo.QueryHookOptions<CreateSignupRunCardQueryData, CreateSignupRunCardQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CreateSignupRunCardQueryData, CreateSignupRunCardQueryVariables>(CreateSignupRunCardQueryDocument, options);
       }
-export function useCreateSignupRunCardQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CreateSignupRunCardQueryQuery, CreateSignupRunCardQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CreateSignupRunCardQueryQuery, CreateSignupRunCardQueryQueryVariables>(CreateSignupRunCardQueryDocument, baseOptions);
+export function useCreateSignupRunCardQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CreateSignupRunCardQueryData, CreateSignupRunCardQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CreateSignupRunCardQueryData, CreateSignupRunCardQueryVariables>(CreateSignupRunCardQueryDocument, options);
         }
-export type CreateSignupRunCardQueryQueryHookResult = ReturnType<typeof useCreateSignupRunCardQueryQuery>;
+export type CreateSignupRunCardQueryHookResult = ReturnType<typeof useCreateSignupRunCardQuery>;
 export type CreateSignupRunCardQueryLazyQueryHookResult = ReturnType<typeof useCreateSignupRunCardQueryLazyQuery>;
-export type CreateSignupRunCardQueryQueryResult = Apollo.QueryResult<CreateSignupRunCardQueryQuery, CreateSignupRunCardQueryQueryVariables>;
+export type CreateSignupRunCardQueryDataResult = Apollo.QueryResult<CreateSignupRunCardQueryData, CreateSignupRunCardQueryVariables>;
 export const SignupModerationQueueQueryDocument = gql`
     query SignupModerationQueueQuery($page: Int, $perPage: Int) {
   convention: assertConvention {
@@ -366,28 +371,30 @@ export const SignupModerationQueueQueryDocument = gql`
     ${SignupModerationSignupRequestFieldsFragmentDoc}`;
 
 /**
- * __useSignupModerationQueueQueryQuery__
+ * __useSignupModerationQueueQuery__
  *
- * To run a query within a React component, call `useSignupModerationQueueQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useSignupModerationQueueQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSignupModerationQueueQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSignupModerationQueueQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSignupModerationQueueQueryQuery({
+ * const { data, loading, error } = useSignupModerationQueueQuery({
  *   variables: {
  *      page: // value for 'page'
  *      perPage: // value for 'perPage'
  *   },
  * });
  */
-export function useSignupModerationQueueQueryQuery(baseOptions?: Apollo.QueryHookOptions<SignupModerationQueueQueryQuery, SignupModerationQueueQueryQueryVariables>) {
-        return Apollo.useQuery<SignupModerationQueueQueryQuery, SignupModerationQueueQueryQueryVariables>(SignupModerationQueueQueryDocument, baseOptions);
+export function useSignupModerationQueueQuery(baseOptions?: Apollo.QueryHookOptions<SignupModerationQueueQueryData, SignupModerationQueueQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SignupModerationQueueQueryData, SignupModerationQueueQueryVariables>(SignupModerationQueueQueryDocument, options);
       }
-export function useSignupModerationQueueQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SignupModerationQueueQueryQuery, SignupModerationQueueQueryQueryVariables>) {
-          return Apollo.useLazyQuery<SignupModerationQueueQueryQuery, SignupModerationQueueQueryQueryVariables>(SignupModerationQueueQueryDocument, baseOptions);
+export function useSignupModerationQueueQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SignupModerationQueueQueryData, SignupModerationQueueQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SignupModerationQueueQueryData, SignupModerationQueueQueryVariables>(SignupModerationQueueQueryDocument, options);
         }
-export type SignupModerationQueueQueryQueryHookResult = ReturnType<typeof useSignupModerationQueueQueryQuery>;
+export type SignupModerationQueueQueryHookResult = ReturnType<typeof useSignupModerationQueueQuery>;
 export type SignupModerationQueueQueryLazyQueryHookResult = ReturnType<typeof useSignupModerationQueueQueryLazyQuery>;
-export type SignupModerationQueueQueryQueryResult = Apollo.QueryResult<SignupModerationQueueQueryQuery, SignupModerationQueueQueryQueryVariables>;
+export type SignupModerationQueueQueryDataResult = Apollo.QueryResult<SignupModerationQueueQueryData, SignupModerationQueueQueryVariables>;

--- a/app/javascript/StaffPositionAdmin/EditStaffPosition.tsx
+++ b/app/javascript/StaffPositionAdmin/EditStaffPosition.tsx
@@ -8,11 +8,11 @@ import useAsyncFunction from '../useAsyncFunction';
 import usePageTitle from '../usePageTitle';
 import buildStaffPositionInput from './buildStaffPositionInput';
 import { LoadSingleValueFromCollectionWrapper } from '../GraphqlLoadingWrappers';
-import { useStaffPositionsQueryQuery } from './queries.generated';
+import { useStaffPositionsQuery } from './queries.generated';
 import { useUpdateStaffPositionMutation } from './mutations.generated';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useStaffPositionsQueryQuery,
+  useStaffPositionsQuery,
   (data, id) => data.convention.staff_positions.find((sp) => sp.id.toString(10) === id),
   function EditStaffPosition({ value: initialStaffPosition }) {
     const history = useHistory();

--- a/app/javascript/StaffPositionAdmin/EditStaffPositionPermissions.tsx
+++ b/app/javascript/StaffPositionAdmin/EditStaffPositionPermissions.tsx
@@ -15,7 +15,7 @@ import {
 import { useTabs, TabList, TabBody } from '../UIComponents/Tabs';
 import PageLoadingIndicator from '../PageLoadingIndicator';
 import { PermissionedModelTypeIndicator } from '../graphqlTypes.generated';
-import { StaffPositionsQueryQuery, useStaffPositionsQueryQuery } from './queries.generated';
+import { StaffPositionsQueryData, useStaffPositionsQuery } from './queries.generated';
 import { PermissionWithId } from '../Permissions/usePermissionsChangeSet';
 import { useUpdateStaffPositionPermissionsMutation } from './mutations.generated';
 import { notEmpty } from '../ValueUtils';
@@ -32,8 +32,8 @@ const ConventionPermissionNames = getPermissionNamesForModelType(
 );
 
 type EditStaffPositionPermissionsForm = {
-  convention: StaffPositionsQueryQuery['convention'];
-  staffPosition: StaffPositionsQueryQuery['convention']['staff_positions'][0];
+  convention: StaffPositionsQueryData['convention'];
+  staffPosition: StaffPositionsQueryData['convention']['staff_positions'][0];
 };
 
 function EditStaffPositionPermissionsForm({
@@ -159,7 +159,7 @@ function EditStaffPositionPermissionsForm({
 
 function EditStaffPositionPermissions() {
   const { id } = useParams<{ id: string }>();
-  const { data, loading, error } = useStaffPositionsQueryQuery();
+  const { data, loading, error } = useStaffPositionsQuery();
 
   const convention = useMemo(() => (loading || error || !data ? null : data.convention), [
     loading,

--- a/app/javascript/StaffPositionAdmin/NewStaffPosition.tsx
+++ b/app/javascript/StaffPositionAdmin/NewStaffPosition.tsx
@@ -9,13 +9,13 @@ import useAsyncFunction from '../useAsyncFunction';
 import usePageTitle from '../usePageTitle';
 import buildStaffPositionInput from './buildStaffPositionInput';
 import { useCreateStaffPositionMutation } from './mutations.generated';
-import { StaffPositionsQueryQuery } from './queries.generated';
+import { StaffPositionsQueryData } from './queries.generated';
 
 function NewStaffPosition() {
   const history = useHistory();
   const [createMutate] = useCreateStaffPositionMutation({
     update: (proxy, result) => {
-      const data = proxy.readQuery<StaffPositionsQueryQuery>({ query: StaffPositionsQuery });
+      const data = proxy.readQuery<StaffPositionsQueryData>({ query: StaffPositionsQuery });
       const newStaffPosition = result.data?.createStaffPosition?.staff_position;
       if (!data || !newStaffPosition) {
         return;

--- a/app/javascript/StaffPositionAdmin/StaffPositionForm.tsx
+++ b/app/javascript/StaffPositionAdmin/StaffPositionForm.tsx
@@ -9,9 +9,9 @@ import EmailAliasInput from '../BuiltInFormControls/EmailAliasInput';
 import FormGroupWithLabel from '../BuiltInFormControls/FormGroupWithLabel';
 import { StringArrayEditor } from '../BuiltInFormControls/ArrayEditor';
 import { usePropertySetters, useFunctionalStateUpdater } from '../usePropertySetters';
-import { StaffPositionsQueryQuery } from './queries.generated';
+import { StaffPositionsQueryData } from './queries.generated';
 
-export type EditingStaffPosition = StaffPositionsQueryQuery['convention']['staff_positions'][0];
+export type EditingStaffPosition = StaffPositionsQueryData['convention']['staff_positions'][0];
 
 export type StaffPositionFormProps = {
   staffPosition: EditingStaffPosition;

--- a/app/javascript/StaffPositionAdmin/StaffPositionsTable.tsx
+++ b/app/javascript/StaffPositionAdmin/StaffPositionsTable.tsx
@@ -18,12 +18,12 @@ import AppRootContext from '../AppRootContext';
 
 import DisclosureTriangle from '../BuiltInFormControls/DisclosureTriangle';
 import { DropdownMenu } from '../UIComponents/DropdownMenu';
-import { StaffPositionsQueryQuery, useStaffPositionsQueryQuery } from './queries.generated';
+import { StaffPositionsQueryData, useStaffPositionsQuery } from './queries.generated';
 import { PolymorphicPermission } from '../Permissions/PermissionUtils';
 import { useDeleteStaffPositionMutation } from './mutations.generated';
 
 type UserConProfilesListProps = {
-  userConProfiles: StaffPositionsQueryQuery['convention']['staff_positions'][0]['user_con_profiles'];
+  userConProfiles: StaffPositionsQueryData['convention']['staff_positions'][0]['user_con_profiles'];
 };
 
 function UserConProfilesList({ userConProfiles }: UserConProfilesListProps) {
@@ -86,7 +86,7 @@ function describePermissionAbilities(
 }
 
 function describePermissionModel(
-  model: StaffPositionsQueryQuery['convention']['staff_positions'][0]['permissions'][0]['model'],
+  model: StaffPositionsQueryData['convention']['staff_positions'][0]['permissions'][0]['model'],
 ) {
   switch (model.__typename) {
     case 'CmsContentGroup':
@@ -115,7 +115,7 @@ function describePermissionModel(
 }
 
 type PermissionsDescriptionProps = {
-  permissions: StaffPositionsQueryQuery['convention']['staff_positions'][0]['permissions'];
+  permissions: StaffPositionsQueryData['convention']['staff_positions'][0]['permissions'];
 };
 
 function PermissionsDescription({ permissions }: PermissionsDescriptionProps) {
@@ -136,35 +136,37 @@ function PermissionsDescription({ permissions }: PermissionsDescriptionProps) {
     return <></>;
   }
 
-  return <>
-    <button
-      className="hidden-button text-left"
-      type="button"
-      onClick={() => setExpanded((prevExpanded) => !prevExpanded)}
-    >
-      <DisclosureTriangle expanded={expanded} />{' '}
-      {joinReact(
-        descriptions.map(({ key, model }) => <Fragment key={key}>{model}</Fragment>),
-        ', ',
+  return (
+    <>
+      <button
+        className="hidden-button text-left"
+        type="button"
+        onClick={() => setExpanded((prevExpanded) => !prevExpanded)}
+      >
+        <DisclosureTriangle expanded={expanded} />{' '}
+        {joinReact(
+          descriptions.map(({ key, model }) => <Fragment key={key}>{model}</Fragment>),
+          ', ',
+        )}
+      </button>
+      {expanded && (
+        <ul className="list-unstyled">
+          {descriptions.map(({ key, model, abilities }) => (
+            <li key={key}>
+              {model}
+              {': '}
+              {abilities}
+            </li>
+          ))}
+        </ul>
       )}
-    </button>
-    {expanded && (
-      <ul className="list-unstyled">
-        {descriptions.map(({ key, model, abilities }) => (
-          <li key={key}>
-            {model}
-            {': '}
-            {abilities}
-          </li>
-        ))}
-      </ul>
-    )}
-  </>;
+    </>
+  );
 }
 
 function StaffPositionsTable() {
   const { conventionDomain } = useContext(AppRootContext);
-  const { data, loading, error } = useStaffPositionsQueryQuery();
+  const { data, loading, error } = useStaffPositionsQuery();
   const confirm = useConfirm();
 
   const [deleteMutate] = useDeleteStaffPositionMutation();
@@ -173,7 +175,7 @@ function StaffPositionsTable() {
       deleteMutate({
         variables: { input: { id } },
         update: (proxy) => {
-          const storeData = proxy.readQuery<StaffPositionsQueryQuery>({
+          const storeData = proxy.readQuery<StaffPositionsQueryData>({
             query: StaffPositionsQuery,
           });
           if (storeData == null) {
@@ -208,7 +210,7 @@ function StaffPositionsTable() {
   }
 
   const renderRow = (
-    staffPosition: StaffPositionsQueryQuery['convention']['staff_positions'][0],
+    staffPosition: StaffPositionsQueryData['convention']['staff_positions'][0],
   ) => (
     <tr key={staffPosition.id}>
       <td>{staffPosition.name}</td>

--- a/app/javascript/StaffPositionAdmin/mutations.generated.ts
+++ b/app/javascript/StaffPositionAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { StaffPositionFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { StaffPositionFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateStaffPositionMutationVariables = Types.Exact<{
   input: Types.CreateStaffPositionInput;
 }>;
 
 
-export type CreateStaffPositionMutation = (
+export type CreateStaffPositionMutationData = (
   { __typename: 'Mutation' }
   & { createStaffPosition?: Types.Maybe<(
     { __typename: 'CreateStaffPositionPayload' }
@@ -27,7 +28,7 @@ export type UpdateStaffPositionMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateStaffPositionMutation = (
+export type UpdateStaffPositionMutationData = (
   { __typename: 'Mutation' }
   & { updateStaffPosition?: Types.Maybe<(
     { __typename: 'UpdateStaffPositionPayload' }
@@ -46,7 +47,7 @@ export type UpdateStaffPositionPermissionsMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateStaffPositionPermissionsMutation = (
+export type UpdateStaffPositionPermissionsMutationData = (
   { __typename: 'Mutation' }
   & { updateStaffPositionPermissions?: Types.Maybe<(
     { __typename: 'UpdateStaffPositionPermissionsPayload' }
@@ -63,7 +64,7 @@ export type DeleteStaffPositionMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteStaffPositionMutation = (
+export type DeleteStaffPositionMutationData = (
   { __typename: 'Mutation' }
   & { deleteStaffPosition?: Types.Maybe<(
     { __typename: 'DeleteStaffPositionPayload' }
@@ -85,7 +86,7 @@ export const CreateStaffPositionDocument = gql`
   }
 }
     ${StaffPositionFieldsFragmentDoc}`;
-export type CreateStaffPositionMutationFn = Apollo.MutationFunction<CreateStaffPositionMutation, CreateStaffPositionMutationVariables>;
+export type CreateStaffPositionMutationFn = Apollo.MutationFunction<CreateStaffPositionMutationData, CreateStaffPositionMutationVariables>;
 
 /**
  * __useCreateStaffPositionMutation__
@@ -104,12 +105,13 @@ export type CreateStaffPositionMutationFn = Apollo.MutationFunction<CreateStaffP
  *   },
  * });
  */
-export function useCreateStaffPositionMutation(baseOptions?: Apollo.MutationHookOptions<CreateStaffPositionMutation, CreateStaffPositionMutationVariables>) {
-        return Apollo.useMutation<CreateStaffPositionMutation, CreateStaffPositionMutationVariables>(CreateStaffPositionDocument, baseOptions);
+export function useCreateStaffPositionMutation(baseOptions?: Apollo.MutationHookOptions<CreateStaffPositionMutationData, CreateStaffPositionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateStaffPositionMutationData, CreateStaffPositionMutationVariables>(CreateStaffPositionDocument, options);
       }
 export type CreateStaffPositionMutationHookResult = ReturnType<typeof useCreateStaffPositionMutation>;
-export type CreateStaffPositionMutationResult = Apollo.MutationResult<CreateStaffPositionMutation>;
-export type CreateStaffPositionMutationOptions = Apollo.BaseMutationOptions<CreateStaffPositionMutation, CreateStaffPositionMutationVariables>;
+export type CreateStaffPositionMutationResult = Apollo.MutationResult<CreateStaffPositionMutationData>;
+export type CreateStaffPositionMutationOptions = Apollo.BaseMutationOptions<CreateStaffPositionMutationData, CreateStaffPositionMutationVariables>;
 export const UpdateStaffPositionDocument = gql`
     mutation UpdateStaffPosition($input: UpdateStaffPositionInput!) {
   updateStaffPosition(input: $input) {
@@ -120,7 +122,7 @@ export const UpdateStaffPositionDocument = gql`
   }
 }
     ${StaffPositionFieldsFragmentDoc}`;
-export type UpdateStaffPositionMutationFn = Apollo.MutationFunction<UpdateStaffPositionMutation, UpdateStaffPositionMutationVariables>;
+export type UpdateStaffPositionMutationFn = Apollo.MutationFunction<UpdateStaffPositionMutationData, UpdateStaffPositionMutationVariables>;
 
 /**
  * __useUpdateStaffPositionMutation__
@@ -139,12 +141,13 @@ export type UpdateStaffPositionMutationFn = Apollo.MutationFunction<UpdateStaffP
  *   },
  * });
  */
-export function useUpdateStaffPositionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateStaffPositionMutation, UpdateStaffPositionMutationVariables>) {
-        return Apollo.useMutation<UpdateStaffPositionMutation, UpdateStaffPositionMutationVariables>(UpdateStaffPositionDocument, baseOptions);
+export function useUpdateStaffPositionMutation(baseOptions?: Apollo.MutationHookOptions<UpdateStaffPositionMutationData, UpdateStaffPositionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateStaffPositionMutationData, UpdateStaffPositionMutationVariables>(UpdateStaffPositionDocument, options);
       }
 export type UpdateStaffPositionMutationHookResult = ReturnType<typeof useUpdateStaffPositionMutation>;
-export type UpdateStaffPositionMutationResult = Apollo.MutationResult<UpdateStaffPositionMutation>;
-export type UpdateStaffPositionMutationOptions = Apollo.BaseMutationOptions<UpdateStaffPositionMutation, UpdateStaffPositionMutationVariables>;
+export type UpdateStaffPositionMutationResult = Apollo.MutationResult<UpdateStaffPositionMutationData>;
+export type UpdateStaffPositionMutationOptions = Apollo.BaseMutationOptions<UpdateStaffPositionMutationData, UpdateStaffPositionMutationVariables>;
 export const UpdateStaffPositionPermissionsDocument = gql`
     mutation UpdateStaffPositionPermissions($staffPositionId: Int!, $grantPermissions: [PermissionInput!]!, $revokePermissions: [PermissionInput!]!) {
   updateStaffPositionPermissions(
@@ -157,7 +160,7 @@ export const UpdateStaffPositionPermissionsDocument = gql`
   }
 }
     ${StaffPositionFieldsFragmentDoc}`;
-export type UpdateStaffPositionPermissionsMutationFn = Apollo.MutationFunction<UpdateStaffPositionPermissionsMutation, UpdateStaffPositionPermissionsMutationVariables>;
+export type UpdateStaffPositionPermissionsMutationFn = Apollo.MutationFunction<UpdateStaffPositionPermissionsMutationData, UpdateStaffPositionPermissionsMutationVariables>;
 
 /**
  * __useUpdateStaffPositionPermissionsMutation__
@@ -178,12 +181,13 @@ export type UpdateStaffPositionPermissionsMutationFn = Apollo.MutationFunction<U
  *   },
  * });
  */
-export function useUpdateStaffPositionPermissionsMutation(baseOptions?: Apollo.MutationHookOptions<UpdateStaffPositionPermissionsMutation, UpdateStaffPositionPermissionsMutationVariables>) {
-        return Apollo.useMutation<UpdateStaffPositionPermissionsMutation, UpdateStaffPositionPermissionsMutationVariables>(UpdateStaffPositionPermissionsDocument, baseOptions);
+export function useUpdateStaffPositionPermissionsMutation(baseOptions?: Apollo.MutationHookOptions<UpdateStaffPositionPermissionsMutationData, UpdateStaffPositionPermissionsMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateStaffPositionPermissionsMutationData, UpdateStaffPositionPermissionsMutationVariables>(UpdateStaffPositionPermissionsDocument, options);
       }
 export type UpdateStaffPositionPermissionsMutationHookResult = ReturnType<typeof useUpdateStaffPositionPermissionsMutation>;
-export type UpdateStaffPositionPermissionsMutationResult = Apollo.MutationResult<UpdateStaffPositionPermissionsMutation>;
-export type UpdateStaffPositionPermissionsMutationOptions = Apollo.BaseMutationOptions<UpdateStaffPositionPermissionsMutation, UpdateStaffPositionPermissionsMutationVariables>;
+export type UpdateStaffPositionPermissionsMutationResult = Apollo.MutationResult<UpdateStaffPositionPermissionsMutationData>;
+export type UpdateStaffPositionPermissionsMutationOptions = Apollo.BaseMutationOptions<UpdateStaffPositionPermissionsMutationData, UpdateStaffPositionPermissionsMutationVariables>;
 export const DeleteStaffPositionDocument = gql`
     mutation DeleteStaffPosition($input: DeleteStaffPositionInput!) {
   deleteStaffPosition(input: $input) {
@@ -193,7 +197,7 @@ export const DeleteStaffPositionDocument = gql`
   }
 }
     `;
-export type DeleteStaffPositionMutationFn = Apollo.MutationFunction<DeleteStaffPositionMutation, DeleteStaffPositionMutationVariables>;
+export type DeleteStaffPositionMutationFn = Apollo.MutationFunction<DeleteStaffPositionMutationData, DeleteStaffPositionMutationVariables>;
 
 /**
  * __useDeleteStaffPositionMutation__
@@ -212,9 +216,10 @@ export type DeleteStaffPositionMutationFn = Apollo.MutationFunction<DeleteStaffP
  *   },
  * });
  */
-export function useDeleteStaffPositionMutation(baseOptions?: Apollo.MutationHookOptions<DeleteStaffPositionMutation, DeleteStaffPositionMutationVariables>) {
-        return Apollo.useMutation<DeleteStaffPositionMutation, DeleteStaffPositionMutationVariables>(DeleteStaffPositionDocument, baseOptions);
+export function useDeleteStaffPositionMutation(baseOptions?: Apollo.MutationHookOptions<DeleteStaffPositionMutationData, DeleteStaffPositionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteStaffPositionMutationData, DeleteStaffPositionMutationVariables>(DeleteStaffPositionDocument, options);
       }
 export type DeleteStaffPositionMutationHookResult = ReturnType<typeof useDeleteStaffPositionMutation>;
-export type DeleteStaffPositionMutationResult = Apollo.MutationResult<DeleteStaffPositionMutation>;
-export type DeleteStaffPositionMutationOptions = Apollo.BaseMutationOptions<DeleteStaffPositionMutation, DeleteStaffPositionMutationVariables>;
+export type DeleteStaffPositionMutationResult = Apollo.MutationResult<DeleteStaffPositionMutationData>;
+export type DeleteStaffPositionMutationOptions = Apollo.BaseMutationOptions<DeleteStaffPositionMutationData, DeleteStaffPositionMutationVariables>;

--- a/app/javascript/StaffPositionAdmin/queries.generated.ts
+++ b/app/javascript/StaffPositionAdmin/queries.generated.ts
@@ -5,6 +5,7 @@ import { PermissionedModelFields_CmsContentGroup_Fragment, PermissionedModelFiel
 import { gql } from '@apollo/client';
 import { PermissionedModelFieldsFragmentDoc, PermissionedRoleFieldsFragmentDoc } from '../Permissions/fragments.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type StaffPositionFieldsFragment = (
   { __typename: 'StaffPosition' }
   & Pick<Types.StaffPosition, 'id' | 'name' | 'email' | 'visible' | 'email_aliases' | 'cc_addresses'>
@@ -27,10 +28,10 @@ export type StaffPositionFieldsFragment = (
   )> }
 );
 
-export type StaffPositionsQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type StaffPositionsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type StaffPositionsQueryQuery = (
+export type StaffPositionsQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -95,26 +96,28 @@ export const StaffPositionsQueryDocument = gql`
     ${StaffPositionFieldsFragmentDoc}`;
 
 /**
- * __useStaffPositionsQueryQuery__
+ * __useStaffPositionsQuery__
  *
- * To run a query within a React component, call `useStaffPositionsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useStaffPositionsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useStaffPositionsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useStaffPositionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useStaffPositionsQueryQuery({
+ * const { data, loading, error } = useStaffPositionsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useStaffPositionsQueryQuery(baseOptions?: Apollo.QueryHookOptions<StaffPositionsQueryQuery, StaffPositionsQueryQueryVariables>) {
-        return Apollo.useQuery<StaffPositionsQueryQuery, StaffPositionsQueryQueryVariables>(StaffPositionsQueryDocument, baseOptions);
+export function useStaffPositionsQuery(baseOptions?: Apollo.QueryHookOptions<StaffPositionsQueryData, StaffPositionsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<StaffPositionsQueryData, StaffPositionsQueryVariables>(StaffPositionsQueryDocument, options);
       }
-export function useStaffPositionsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<StaffPositionsQueryQuery, StaffPositionsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<StaffPositionsQueryQuery, StaffPositionsQueryQueryVariables>(StaffPositionsQueryDocument, baseOptions);
+export function useStaffPositionsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<StaffPositionsQueryData, StaffPositionsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<StaffPositionsQueryData, StaffPositionsQueryVariables>(StaffPositionsQueryDocument, options);
         }
-export type StaffPositionsQueryQueryHookResult = ReturnType<typeof useStaffPositionsQueryQuery>;
+export type StaffPositionsQueryHookResult = ReturnType<typeof useStaffPositionsQuery>;
 export type StaffPositionsQueryLazyQueryHookResult = ReturnType<typeof useStaffPositionsQueryLazyQuery>;
-export type StaffPositionsQueryQueryResult = Apollo.QueryResult<StaffPositionsQueryQuery, StaffPositionsQueryQueryVariables>;
+export type StaffPositionsQueryDataResult = Apollo.QueryResult<StaffPositionsQueryData, StaffPositionsQueryVariables>;

--- a/app/javascript/Store/Cart.tsx
+++ b/app/javascript/Store/Cart.tsx
@@ -12,7 +12,7 @@ import { useConfirm } from '../ModalDialogs/Confirm';
 import usePageTitle from '../usePageTitle';
 import CartContents from './CartContents';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { CartQueryQuery, useCartQueryQuery } from './queries.generated';
+import { CartQueryData, useCartQuery } from './queries.generated';
 import {
   useCreateCouponApplicationMutation,
   useDeleteCouponApplicationMutation,
@@ -21,9 +21,9 @@ import {
 } from './mutations.generated';
 import useLoginRequired from '../Authentication/useLoginRequired';
 
-type OrderEntryType = NonNullable<CartQueryQuery['currentPendingOrder']>['order_entries'][0];
+type OrderEntryType = NonNullable<CartQueryData['currentPendingOrder']>['order_entries'][0];
 
-export default LoadQueryWrapper(useCartQueryQuery, function Cart({ data }) {
+export default LoadQueryWrapper(useCartQuery, function Cart({ data }) {
   const history = useHistory();
   const [updateMutate] = useUpdateOrderEntryMutation();
   const [deleteMutate] = useDeleteOrderEntryMutation();
@@ -47,7 +47,7 @@ export default LoadQueryWrapper(useCartQueryQuery, function Cart({ data }) {
       deleteMutate({
         variables: { input: { id } },
         update: (proxy) => {
-          const storeData = proxy.readQuery<CartQueryQuery>({ query: CartQuery });
+          const storeData = proxy.readQuery<CartQueryData>({ query: CartQuery });
           if (!storeData || !storeData.currentPendingOrder) {
             return;
           }

--- a/app/javascript/Store/CartContents.tsx
+++ b/app/javascript/Store/CartContents.tsx
@@ -7,10 +7,10 @@ import describeCoupon from './describeCoupon';
 import { useConfirm } from '../ModalDialogs/Confirm';
 import ApplyCouponControl from './ApplyCouponControl';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { CartQueryQuery, useCartQueryQuery } from './queries.generated';
+import { CartQueryData, useCartQuery } from './queries.generated';
 import { parseIntOrNull } from '../ValueUtils';
 
-type OrderType = NonNullable<CartQueryQuery['currentPendingOrder']>;
+type OrderType = NonNullable<CartQueryData['currentPendingOrder']>;
 type OrderEntryType = OrderType['order_entries'][0];
 
 export type CartContentsProps = {
@@ -21,8 +21,8 @@ export type CartContentsProps = {
   checkOutButton?: React.ReactNode;
 };
 
-export default LoadQueryWrapper<CartQueryQuery, CartContentsProps>(
-  useCartQueryQuery,
+export default LoadQueryWrapper<CartQueryData, CartContentsProps>(
+  useCartQuery,
   function CartContents({
     data,
     removeFromCart,

--- a/app/javascript/Store/CouponAdmin/CouponAdminTable.tsx
+++ b/app/javascript/Store/CouponAdmin/CouponAdminTable.tsx
@@ -9,10 +9,10 @@ import useModal from '../../ModalDialogs/useModal';
 import NewCouponModal from './NewCouponModal';
 import EditCouponModal from './EditCouponModal';
 import ReactTableExportButtonWithColumnTransform from '../../Tables/ReactTableExportButtonWithColumnTransform';
-import { AdminCouponsQueryQuery, useAdminCouponsQueryQuery } from './queries.generated';
+import { AdminCouponsQueryData, useAdminCouponsQuery } from './queries.generated';
 import ReactTableWithTheWorks from '../../Tables/ReactTableWithTheWorks';
 
-type CouponType = AdminCouponsQueryQuery['convention']['coupons_paginated']['entries'][0];
+type CouponType = AdminCouponsQueryData['convention']['coupons_paginated']['entries'][0];
 
 const transformColumnIdForExport = (columnId: string) => {
   if (columnId === 'effect') {
@@ -69,7 +69,7 @@ function CouponAdminTable() {
     getData: ({ data }) => data!.convention.coupons_paginated.entries,
     getPages: ({ data }) => data!.convention.coupons_paginated.total_pages,
     getPossibleColumns,
-    useQuery: useAdminCouponsQueryQuery,
+    useQuery: useAdminCouponsQuery,
     storageKeyPrefix: 'coupons',
   });
 

--- a/app/javascript/Store/CouponAdmin/mutations.generated.ts
+++ b/app/javascript/Store/CouponAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { AdminCouponFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { AdminCouponFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateCouponMutationVariables = Types.Exact<{
   coupon: Types.CouponInput;
 }>;
 
 
-export type CreateCouponMutation = (
+export type CreateCouponMutationData = (
   { __typename: 'Mutation' }
   & { createCoupon?: Types.Maybe<(
     { __typename: 'CreateCouponPayload' }
@@ -28,7 +29,7 @@ export type UpdateCouponMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateCouponMutation = (
+export type UpdateCouponMutationData = (
   { __typename: 'Mutation' }
   & { updateCoupon?: Types.Maybe<(
     { __typename: 'UpdateCouponPayload' }
@@ -45,7 +46,7 @@ export type DeleteCouponMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteCouponMutation = (
+export type DeleteCouponMutationData = (
   { __typename: 'Mutation' }
   & { deleteCoupon?: Types.Maybe<(
     { __typename: 'DeleteCouponPayload' }
@@ -64,7 +65,7 @@ export const CreateCouponDocument = gql`
   }
 }
     ${AdminCouponFieldsFragmentDoc}`;
-export type CreateCouponMutationFn = Apollo.MutationFunction<CreateCouponMutation, CreateCouponMutationVariables>;
+export type CreateCouponMutationFn = Apollo.MutationFunction<CreateCouponMutationData, CreateCouponMutationVariables>;
 
 /**
  * __useCreateCouponMutation__
@@ -83,12 +84,13 @@ export type CreateCouponMutationFn = Apollo.MutationFunction<CreateCouponMutatio
  *   },
  * });
  */
-export function useCreateCouponMutation(baseOptions?: Apollo.MutationHookOptions<CreateCouponMutation, CreateCouponMutationVariables>) {
-        return Apollo.useMutation<CreateCouponMutation, CreateCouponMutationVariables>(CreateCouponDocument, baseOptions);
+export function useCreateCouponMutation(baseOptions?: Apollo.MutationHookOptions<CreateCouponMutationData, CreateCouponMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateCouponMutationData, CreateCouponMutationVariables>(CreateCouponDocument, options);
       }
 export type CreateCouponMutationHookResult = ReturnType<typeof useCreateCouponMutation>;
-export type CreateCouponMutationResult = Apollo.MutationResult<CreateCouponMutation>;
-export type CreateCouponMutationOptions = Apollo.BaseMutationOptions<CreateCouponMutation, CreateCouponMutationVariables>;
+export type CreateCouponMutationResult = Apollo.MutationResult<CreateCouponMutationData>;
+export type CreateCouponMutationOptions = Apollo.BaseMutationOptions<CreateCouponMutationData, CreateCouponMutationVariables>;
 export const UpdateCouponDocument = gql`
     mutation UpdateCoupon($id: Int!, $coupon: CouponInput!) {
   updateCoupon(input: {id: $id, coupon: $coupon}) {
@@ -99,7 +101,7 @@ export const UpdateCouponDocument = gql`
   }
 }
     ${AdminCouponFieldsFragmentDoc}`;
-export type UpdateCouponMutationFn = Apollo.MutationFunction<UpdateCouponMutation, UpdateCouponMutationVariables>;
+export type UpdateCouponMutationFn = Apollo.MutationFunction<UpdateCouponMutationData, UpdateCouponMutationVariables>;
 
 /**
  * __useUpdateCouponMutation__
@@ -119,12 +121,13 @@ export type UpdateCouponMutationFn = Apollo.MutationFunction<UpdateCouponMutatio
  *   },
  * });
  */
-export function useUpdateCouponMutation(baseOptions?: Apollo.MutationHookOptions<UpdateCouponMutation, UpdateCouponMutationVariables>) {
-        return Apollo.useMutation<UpdateCouponMutation, UpdateCouponMutationVariables>(UpdateCouponDocument, baseOptions);
+export function useUpdateCouponMutation(baseOptions?: Apollo.MutationHookOptions<UpdateCouponMutationData, UpdateCouponMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateCouponMutationData, UpdateCouponMutationVariables>(UpdateCouponDocument, options);
       }
 export type UpdateCouponMutationHookResult = ReturnType<typeof useUpdateCouponMutation>;
-export type UpdateCouponMutationResult = Apollo.MutationResult<UpdateCouponMutation>;
-export type UpdateCouponMutationOptions = Apollo.BaseMutationOptions<UpdateCouponMutation, UpdateCouponMutationVariables>;
+export type UpdateCouponMutationResult = Apollo.MutationResult<UpdateCouponMutationData>;
+export type UpdateCouponMutationOptions = Apollo.BaseMutationOptions<UpdateCouponMutationData, UpdateCouponMutationVariables>;
 export const DeleteCouponDocument = gql`
     mutation DeleteCoupon($id: Int!) {
   deleteCoupon(input: {id: $id}) {
@@ -132,7 +135,7 @@ export const DeleteCouponDocument = gql`
   }
 }
     `;
-export type DeleteCouponMutationFn = Apollo.MutationFunction<DeleteCouponMutation, DeleteCouponMutationVariables>;
+export type DeleteCouponMutationFn = Apollo.MutationFunction<DeleteCouponMutationData, DeleteCouponMutationVariables>;
 
 /**
  * __useDeleteCouponMutation__
@@ -151,9 +154,10 @@ export type DeleteCouponMutationFn = Apollo.MutationFunction<DeleteCouponMutatio
  *   },
  * });
  */
-export function useDeleteCouponMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCouponMutation, DeleteCouponMutationVariables>) {
-        return Apollo.useMutation<DeleteCouponMutation, DeleteCouponMutationVariables>(DeleteCouponDocument, baseOptions);
+export function useDeleteCouponMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCouponMutationData, DeleteCouponMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteCouponMutationData, DeleteCouponMutationVariables>(DeleteCouponDocument, options);
       }
 export type DeleteCouponMutationHookResult = ReturnType<typeof useDeleteCouponMutation>;
-export type DeleteCouponMutationResult = Apollo.MutationResult<DeleteCouponMutation>;
-export type DeleteCouponMutationOptions = Apollo.BaseMutationOptions<DeleteCouponMutation, DeleteCouponMutationVariables>;
+export type DeleteCouponMutationResult = Apollo.MutationResult<DeleteCouponMutationData>;
+export type DeleteCouponMutationOptions = Apollo.BaseMutationOptions<DeleteCouponMutationData, DeleteCouponMutationVariables>;

--- a/app/javascript/Store/CouponAdmin/queries.generated.ts
+++ b/app/javascript/Store/CouponAdmin/queries.generated.ts
@@ -5,13 +5,14 @@ import { CouponFieldsFragment } from '../couponFields.generated';
 import { gql } from '@apollo/client';
 import { CouponFieldsFragmentDoc } from '../couponFields.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type AdminCouponFieldsFragment = (
   { __typename: 'Coupon' }
   & Pick<Types.Coupon, 'id' | 'usage_limit' | 'expires_at'>
   & CouponFieldsFragment
 );
 
-export type AdminCouponsQueryQueryVariables = Types.Exact<{
+export type AdminCouponsQueryVariables = Types.Exact<{
   filters?: Types.Maybe<Types.CouponFiltersInput>;
   sort?: Types.Maybe<Array<Types.SortInput> | Types.SortInput>;
   page?: Types.Maybe<Types.Scalars['Int']>;
@@ -19,7 +20,7 @@ export type AdminCouponsQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type AdminCouponsQueryQuery = (
+export type AdminCouponsQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -66,16 +67,16 @@ export const AdminCouponsQueryDocument = gql`
     ${AdminCouponFieldsFragmentDoc}`;
 
 /**
- * __useAdminCouponsQueryQuery__
+ * __useAdminCouponsQuery__
  *
- * To run a query within a React component, call `useAdminCouponsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useAdminCouponsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAdminCouponsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAdminCouponsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useAdminCouponsQueryQuery({
+ * const { data, loading, error } = useAdminCouponsQuery({
  *   variables: {
  *      filters: // value for 'filters'
  *      sort: // value for 'sort'
@@ -84,12 +85,14 @@ export const AdminCouponsQueryDocument = gql`
  *   },
  * });
  */
-export function useAdminCouponsQueryQuery(baseOptions?: Apollo.QueryHookOptions<AdminCouponsQueryQuery, AdminCouponsQueryQueryVariables>) {
-        return Apollo.useQuery<AdminCouponsQueryQuery, AdminCouponsQueryQueryVariables>(AdminCouponsQueryDocument, baseOptions);
+export function useAdminCouponsQuery(baseOptions?: Apollo.QueryHookOptions<AdminCouponsQueryData, AdminCouponsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AdminCouponsQueryData, AdminCouponsQueryVariables>(AdminCouponsQueryDocument, options);
       }
-export function useAdminCouponsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminCouponsQueryQuery, AdminCouponsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<AdminCouponsQueryQuery, AdminCouponsQueryQueryVariables>(AdminCouponsQueryDocument, baseOptions);
+export function useAdminCouponsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminCouponsQueryData, AdminCouponsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AdminCouponsQueryData, AdminCouponsQueryVariables>(AdminCouponsQueryDocument, options);
         }
-export type AdminCouponsQueryQueryHookResult = ReturnType<typeof useAdminCouponsQueryQuery>;
+export type AdminCouponsQueryHookResult = ReturnType<typeof useAdminCouponsQuery>;
 export type AdminCouponsQueryLazyQueryHookResult = ReturnType<typeof useAdminCouponsQueryLazyQuery>;
-export type AdminCouponsQueryQueryResult = Apollo.QueryResult<AdminCouponsQueryQuery, AdminCouponsQueryQueryVariables>;
+export type AdminCouponsQueryDataResult = Apollo.QueryResult<AdminCouponsQueryData, AdminCouponsQueryVariables>;

--- a/app/javascript/Store/OrderAdmin.tsx
+++ b/app/javascript/Store/OrderAdmin.tsx
@@ -14,11 +14,11 @@ import useModal from '../ModalDialogs/useModal';
 import EditOrderModal from './EditOrderModal';
 import NewOrderModal from './NewOrderModal';
 import AppRootContext from '../AppRootContext';
-import { AdminOrdersQueryQuery, useAdminOrdersQueryQuery } from './queries.generated';
+import { AdminOrdersQueryData, useAdminOrdersQuery } from './queries.generated';
 import ReactTableWithTheWorks from '../Tables/ReactTableWithTheWorks';
 import { useAppDateTimeFormat } from '../TimeUtils';
 
-type OrderType = AdminOrdersQueryQuery['convention']['orders_paginated']['entries'][0];
+type OrderType = AdminOrdersQueryData['convention']['orders_paginated']['entries'][0];
 
 const fieldFilterCodecs = buildFieldFilterCodecs({
   status: FilterCodecs.stringArray,
@@ -110,7 +110,7 @@ function OrderAdmin() {
     getPages: ({ data }) => data!.convention.orders_paginated.total_pages,
     getPossibleColumns,
     storageKeyPrefix: 'orderAdmin',
-    useQuery: useAdminOrdersQueryQuery,
+    useQuery: useAdminOrdersQuery,
     decodeFilterValue: fieldFilterCodecs.decodeFilterValue,
     encodeFilterValue: fieldFilterCodecs.encodeFilterValue,
   });

--- a/app/javascript/Store/OrderHistory.tsx
+++ b/app/javascript/Store/OrderHistory.tsx
@@ -8,11 +8,11 @@ import useModal, { ModalData } from '../ModalDialogs/useModal';
 import usePageTitle from '../usePageTitle';
 import AppRootContext from '../AppRootContext';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { OrderHistoryQueryQuery, useOrderHistoryQueryQuery } from './queries.generated';
+import { OrderHistoryQueryData, useOrderHistoryQuery } from './queries.generated';
 import useLoginRequired from '../Authentication/useLoginRequired';
 import { useAppDateTimeFormat } from '../TimeUtils';
 
-type OrderType = NonNullable<OrderHistoryQueryQuery['myProfile']>['orders'][0];
+type OrderType = NonNullable<OrderHistoryQueryData['myProfile']>['orders'][0];
 type PaymentModalState = {
   order: OrderType;
 };
@@ -62,7 +62,7 @@ function OrderHistoryCouponApplication({ couponApplication }: OrderHistoryCoupon
 
 type OrderHistoryOrderStatusProps = {
   order: OrderType;
-  convention: OrderHistoryQueryQuery['convention'];
+  convention: OrderHistoryQueryData['convention'];
   paymentModal: ModalData<PaymentModalState>;
 };
 
@@ -131,7 +131,7 @@ function OrderHistoryOrderStatus({
 
 type OrderHistoryOrderProps = {
   order: OrderType;
-  convention: OrderHistoryQueryQuery['convention'];
+  convention: OrderHistoryQueryData['convention'];
   paymentModal: ModalData<PaymentModalState>;
 };
 
@@ -180,7 +180,7 @@ function OrderHistoryOrder({ order, convention, paymentModal }: OrderHistoryOrde
   );
 }
 
-export default LoadQueryWrapper(useOrderHistoryQueryQuery, function OrderHistory({ data }) {
+export default LoadQueryWrapper(useOrderHistoryQuery, function OrderHistory({ data }) {
   const paymentModal = useModal<PaymentModalState>();
 
   usePageTitle('My order history');

--- a/app/javascript/Store/OrderPaymentModal.tsx
+++ b/app/javascript/Store/OrderPaymentModal.tsx
@@ -13,7 +13,7 @@ import useAsyncFunction from '../useAsyncFunction';
 import useSubmitOrder from './useSubmitOrder';
 import formatMoney from '../formatMoney';
 import { Money, PaymentMode } from '../graphqlTypes.generated';
-import { CurrentPendingOrderPaymentIntentClientSecretQueryQuery } from './queries.generated';
+import { CurrentPendingOrderPaymentIntentClientSecretQueryData } from './queries.generated';
 import { CurrentPendingOrderPaymentIntentClientSecret } from './queries';
 import PageLoadingIndicator from '../PageLoadingIndicator';
 
@@ -61,9 +61,11 @@ function OrderPaymentModalContents({
       let clientSecret: string = '';
 
       try {
-        const { data } = await apolloClient.query<
-          CurrentPendingOrderPaymentIntentClientSecretQueryQuery
-        >({ query: CurrentPendingOrderPaymentIntentClientSecret });
+        const {
+          data,
+        } = await apolloClient.query<CurrentPendingOrderPaymentIntentClientSecretQueryData>({
+          query: CurrentPendingOrderPaymentIntentClientSecret,
+        });
 
         clientSecret = data.currentPendingOrderPaymentIntentClientSecret;
       } catch (error) {

--- a/app/javascript/Store/OrderSummary.tsx
+++ b/app/javascript/Store/OrderSummary.tsx
@@ -4,11 +4,11 @@ import { humanize } from 'inflected';
 import usePageTitle from '../usePageTitle';
 import { OrderQuantityByStatus, OrderStatus } from '../graphqlTypes.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { OrderSummaryQueryQuery, useOrderSummaryQueryQuery } from './queries.generated';
+import { OrderSummaryQueryData, useOrderSummaryQuery } from './queries.generated';
 
 const ORDER_STATUSES = [OrderStatus.Paid, OrderStatus.Unpaid, OrderStatus.Cancelled];
 
-type ProductType = OrderSummaryQueryQuery['convention']['products'][0];
+type ProductType = OrderSummaryQueryData['convention']['products'][0];
 
 function statusClass(status: OrderStatus) {
   switch (status) {
@@ -23,7 +23,7 @@ function statusClass(status: OrderStatus) {
   }
 }
 
-export default LoadQueryWrapper(useOrderSummaryQueryQuery, function OrderSummary({ data }) {
+export default LoadQueryWrapper(useOrderSummaryQuery, function OrderSummary({ data }) {
   usePageTitle('Order summary');
 
   const renderQuantityCell = (quantitiesByStatus: OrderQuantityByStatus[], status: OrderStatus) => {

--- a/app/javascript/Store/ProductAdmin/AdminProductCard.tsx
+++ b/app/javascript/Store/ProductAdmin/AdminProductCard.tsx
@@ -7,11 +7,11 @@ import ErrorDisplay from '../../ErrorDisplay';
 import { useConfirm } from '../../ModalDialogs/Confirm';
 import { describeAdminPricingStructure } from '../describePricingStructure';
 import { useDeleteProductMutation } from '../mutations.generated';
-import { AdminProductsQueryQuery } from '../queries.generated';
+import { AdminProductsQueryData } from '../queries.generated';
 import { EditingProductWithRealId } from './EditingProductTypes';
 
 export type AdminProductCardProps = {
-  currentAbility: AdminProductsQueryQuery['currentAbility'];
+  currentAbility: AdminProductsQueryData['currentAbility'];
   startEditing: () => void;
   product: EditingProductWithRealId;
 };
@@ -27,7 +27,7 @@ function AdminProductCard({ currentAbility, startEditing, product }: AdminProduc
         deleteProduct({
           variables: { id: product.id },
           update: (cache) => {
-            const data = cache.readQuery<AdminProductsQueryQuery>({ query: AdminProductsQuery });
+            const data = cache.readQuery<AdminProductsQueryData>({ query: AdminProductsQuery });
             if (!data) {
               return;
             }

--- a/app/javascript/Store/ProductAdmin/EditAdminProductCard.tsx
+++ b/app/javascript/Store/ProductAdmin/EditAdminProductCard.tsx
@@ -14,7 +14,7 @@ import buildProductInput from '../buildProductInput';
 import BooleanInput from '../../BuiltInFormControls/BooleanInput';
 import BootstrapFormSelect from '../../BuiltInFormControls/BootstrapFormSelect';
 import AppRootContext from '../../AppRootContext';
-import { AdminProductsQueryQuery } from '../queries.generated';
+import { AdminProductsQueryData } from '../queries.generated';
 import { useCreateProductMutation, useUpdateProductMutation } from '../mutations.generated';
 import { usePropertySetters } from '../../usePropertySetters';
 import { EditingProduct } from './EditingProductTypes';
@@ -24,7 +24,7 @@ import { PricingStrategy } from '../../graphqlTypes.generated';
 export type EditAdminProductCardProps = {
   initialProduct: EditingProduct;
   close: () => void;
-  ticketTypes: AdminProductsQueryQuery['convention']['ticket_types'];
+  ticketTypes: AdminProductsQueryData['convention']['ticket_types'];
 };
 
 function EditAdminProductCard({ initialProduct, close, ticketTypes }: EditAdminProductCardProps) {
@@ -88,12 +88,12 @@ function EditAdminProductCard({ initialProduct, close, ticketTypes }: EditAdminP
       await createProduct({
         variables: { product: productInput },
         update: (cache, result) => {
-          const data = cache.readQuery<AdminProductsQueryQuery>({ query: AdminProductsQuery });
+          const data = cache.readQuery<AdminProductsQueryData>({ query: AdminProductsQuery });
           const newProduct = result.data?.createProduct?.product;
           if (!data || !newProduct) {
             return;
           }
-          cache.writeQuery<AdminProductsQueryQuery>({
+          cache.writeQuery<AdminProductsQueryData>({
             query: AdminProductsQuery,
             data: {
               ...data,

--- a/app/javascript/Store/ProductAdmin/EditingProductTypes.ts
+++ b/app/javascript/Store/ProductAdmin/EditingProductTypes.ts
@@ -1,7 +1,7 @@
 import { RealIdObject, WithRealOrGeneratedId } from '../../GeneratedIdUtils';
-import { AdminProductsQueryQuery } from '../queries.generated';
+import { AdminProductsQueryData } from '../queries.generated';
 
-type QueryProduct = AdminProductsQueryQuery['convention']['products'][0];
+type QueryProduct = AdminProductsQueryData['convention']['products'][0];
 
 export type EditingVariant = WithRealOrGeneratedId<QueryProduct['product_variants'][0], number>;
 
@@ -19,7 +19,7 @@ export type EditingProductWithRealId = EditingProductBase & RealIdObject<QueryPr
 export type EditingPricingStructure = NonNullable<EditingProduct['pricing_structure']>;
 
 export function duplicateProductForEditing(
-  product: AdminProductsQueryQuery['convention']['products'][0],
+  product: AdminProductsQueryData['convention']['products'][0],
 ): EditingProductWithRealId {
   return {
     ...product,

--- a/app/javascript/Store/ProductAdmin/index.tsx
+++ b/app/javascript/Store/ProductAdmin/index.tsx
@@ -11,7 +11,7 @@ import EditPricingStructureModal, {
 import EditAdminProductCard from './EditAdminProductCard';
 import scrollToLocationHash from '../../scrollToLocationHash';
 import { LoadQueryWrapper } from '../../GraphqlLoadingWrappers';
-import { useAdminProductsQueryQuery } from '../queries.generated';
+import { useAdminProductsQuery } from '../queries.generated';
 import { duplicateProductForEditing, EditingProduct } from './EditingProductTypes';
 import { getRealOrGeneratedId, realOrGeneratedIdsMatch } from '../../GeneratedIdUtils';
 import DndWrapper from '../../DndWrapper';
@@ -28,9 +28,7 @@ const blankProduct: EditingProduct = {
   available: true,
 };
 
-const ProductAdminPage = LoadQueryWrapper(useAdminProductsQueryQuery, function ProductAdmin({
-  data,
-}) {
+const ProductAdminPage = LoadQueryWrapper(useAdminProductsQuery, function ProductAdmin({ data }) {
   const [newProducts, setNewProducts] = useState<EditingProduct[]>([]);
   const [editingProductIds, setEditingProductIds] = useState<number[]>([]);
   const pricingStructureModal = useModal<PricingStructureModalState>();

--- a/app/javascript/Store/ProductOrderForm.tsx
+++ b/app/javascript/Store/ProductOrderForm.tsx
@@ -10,7 +10,7 @@ import { parseIntOrNull } from '../ValueUtils';
 import sortProductVariants from './sortProductVariants';
 import useAsyncFunction from '../useAsyncFunction';
 import PageLoadingIndicator from '../PageLoadingIndicator';
-import { useOrderFormProductQueryQuery } from './queries.generated';
+import { useOrderFormProductQuery } from './queries.generated';
 import { useAddOrderEntryToCurrentPendingOrderMutation } from './mutations.generated';
 import { Money } from '../graphqlTypes.generated';
 
@@ -20,7 +20,7 @@ export type ProductOrderFormProps = {
 
 function ProductOrderForm({ productId }: ProductOrderFormProps) {
   const history = useHistory();
-  const { data, loading, error } = useOrderFormProductQueryQuery({ variables: { productId } });
+  const { data, loading, error } = useOrderFormProductQuery({ variables: { productId } });
   const [addOrderEntryToCurrentPendingOrder] = useAddOrderEntryToCurrentPendingOrderMutation({
     refetchQueries: [{ query: CartQuery }],
   });

--- a/app/javascript/Store/ProductPage.tsx
+++ b/app/javascript/Store/ProductPage.tsx
@@ -8,12 +8,12 @@ import usePageTitle from '../usePageTitle';
 import parseCmsContent from '../parseCmsContent';
 import { describeUserPricingStructure } from './describePricingStructure';
 import AppRootContext from '../AppRootContext';
-import { useOrderFormProductQueryQuery } from './queries.generated';
+import { useOrderFormProductQuery } from './queries.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 
 function useLoadProduct() {
   const { id } = useParams<{ id: string }>();
-  return useOrderFormProductQueryQuery({
+  return useOrderFormProductQuery({
     variables: { productId: Number.parseInt(id, 10) },
   });
 }

--- a/app/javascript/Store/mutations.generated.ts
+++ b/app/javascript/Store/mutations.generated.ts
@@ -1,25 +1,26 @@
 /* eslint-disable */
 import * as Types from '../graphqlTypes.generated';
 
-import { AdminOrderFieldsFragmentFragment, OrderEntryFieldsFragment, CartOrderFieldsFragment, CouponApplicationFieldsFragment } from './orderFields.generated';
+import { AdminOrderFieldsFragment, OrderEntryFieldsFragment, CartOrderFieldsFragment, CouponApplicationFieldsFragment } from './orderFields.generated';
 import { AdminProductFieldsFragment } from './adminProductFields.generated';
 import { gql } from '@apollo/client';
-import { AdminOrderFieldsFragmentFragmentDoc, OrderEntryFieldsFragmentDoc, CartOrderFieldsFragmentDoc, CouponApplicationFieldsFragmentDoc } from './orderFields.generated';
+import { AdminOrderFieldsFragmentDoc, OrderEntryFieldsFragmentDoc, CartOrderFieldsFragmentDoc, CouponApplicationFieldsFragmentDoc } from './orderFields.generated';
 import { AdminProductFieldsFragmentDoc } from './adminProductFields.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type MarkOrderPaidMutationVariables = Types.Exact<{
   orderId: Types.Scalars['Int'];
 }>;
 
 
-export type MarkOrderPaidMutation = (
+export type MarkOrderPaidMutationData = (
   { __typename: 'Mutation' }
   & { markOrderPaid?: Types.Maybe<(
     { __typename: 'MarkOrderPaidPayload' }
     & { order: (
       { __typename: 'Order' }
       & Pick<Types.Order, 'id'>
-      & AdminOrderFieldsFragmentFragment
+      & AdminOrderFieldsFragment
     ) }
   )> }
 );
@@ -30,14 +31,14 @@ export type CancelOrderMutationVariables = Types.Exact<{
 }>;
 
 
-export type CancelOrderMutation = (
+export type CancelOrderMutationData = (
   { __typename: 'Mutation' }
   & { cancelOrder?: Types.Maybe<(
     { __typename: 'CancelOrderPayload' }
     & { order: (
       { __typename: 'Order' }
       & Pick<Types.Order, 'id'>
-      & AdminOrderFieldsFragmentFragment
+      & AdminOrderFieldsFragment
     ) }
   )> }
 );
@@ -50,14 +51,14 @@ export type CreateOrderMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateOrderMutation = (
+export type CreateOrderMutationData = (
   { __typename: 'Mutation' }
   & { createOrder?: Types.Maybe<(
     { __typename: 'CreateOrderPayload' }
     & { order: (
       { __typename: 'Order' }
       & Pick<Types.Order, 'id'>
-      & AdminOrderFieldsFragmentFragment
+      & AdminOrderFieldsFragment
     ) }
   )> }
 );
@@ -68,14 +69,14 @@ export type AdminUpdateOrderMutationVariables = Types.Exact<{
 }>;
 
 
-export type AdminUpdateOrderMutation = (
+export type AdminUpdateOrderMutationData = (
   { __typename: 'Mutation' }
   & { updateOrder?: Types.Maybe<(
     { __typename: 'UpdateOrderPayload' }
     & { order: (
       { __typename: 'Order' }
       & Pick<Types.Order, 'id'>
-      & AdminOrderFieldsFragmentFragment
+      & AdminOrderFieldsFragment
     ) }
   )> }
 );
@@ -85,7 +86,7 @@ export type CreateProductMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateProductMutation = (
+export type CreateProductMutationData = (
   { __typename: 'Mutation' }
   & { createProduct?: Types.Maybe<(
     { __typename: 'CreateProductPayload' }
@@ -103,7 +104,7 @@ export type UpdateProductMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateProductMutation = (
+export type UpdateProductMutationData = (
   { __typename: 'Mutation' }
   & { updateProduct?: Types.Maybe<(
     { __typename: 'UpdateProductPayload' }
@@ -120,7 +121,7 @@ export type DeleteProductMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteProductMutation = (
+export type DeleteProductMutationData = (
   { __typename: 'Mutation' }
   & { deleteProduct?: Types.Maybe<(
     { __typename: 'DeleteProductPayload' }
@@ -137,7 +138,7 @@ export type AdminCreateOrderEntryMutationVariables = Types.Exact<{
 }>;
 
 
-export type AdminCreateOrderEntryMutation = (
+export type AdminCreateOrderEntryMutationData = (
   { __typename: 'Mutation' }
   & { createOrderEntry?: Types.Maybe<(
     { __typename: 'CreateOrderEntryPayload' }
@@ -147,7 +148,7 @@ export type AdminCreateOrderEntryMutation = (
       & { order: (
         { __typename: 'Order' }
         & Pick<Types.Order, 'id'>
-        & AdminOrderFieldsFragmentFragment
+        & AdminOrderFieldsFragment
       ) }
       & OrderEntryFieldsFragment
     ) }
@@ -159,7 +160,7 @@ export type AdminUpdateOrderEntryMutationVariables = Types.Exact<{
 }>;
 
 
-export type AdminUpdateOrderEntryMutation = (
+export type AdminUpdateOrderEntryMutationData = (
   { __typename: 'Mutation' }
   & { updateOrderEntry?: Types.Maybe<(
     { __typename: 'UpdateOrderEntryPayload' }
@@ -169,7 +170,7 @@ export type AdminUpdateOrderEntryMutation = (
       & { order: (
         { __typename: 'Order' }
         & Pick<Types.Order, 'id'>
-        & AdminOrderFieldsFragmentFragment
+        & AdminOrderFieldsFragment
       ) }
       & OrderEntryFieldsFragment
     ) }
@@ -181,7 +182,7 @@ export type UpdateOrderEntryMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateOrderEntryMutation = (
+export type UpdateOrderEntryMutationData = (
   { __typename: 'Mutation' }
   & { updateOrderEntry?: Types.Maybe<(
     { __typename: 'UpdateOrderEntryPayload' }
@@ -198,7 +199,7 @@ export type DeleteOrderEntryMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteOrderEntryMutation = (
+export type DeleteOrderEntryMutationData = (
   { __typename: 'Mutation' }
   & { deleteOrderEntry?: Types.Maybe<(
     { __typename: 'DeleteOrderEntryPayload' }
@@ -214,7 +215,7 @@ export type AdminDeleteOrderEntryMutationVariables = Types.Exact<{
 }>;
 
 
-export type AdminDeleteOrderEntryMutation = (
+export type AdminDeleteOrderEntryMutationData = (
   { __typename: 'Mutation' }
   & { deleteOrderEntry?: Types.Maybe<(
     { __typename: 'DeleteOrderEntryPayload' }
@@ -224,7 +225,7 @@ export type AdminDeleteOrderEntryMutation = (
       & { order: (
         { __typename: 'Order' }
         & Pick<Types.Order, 'id'>
-        & AdminOrderFieldsFragmentFragment
+        & AdminOrderFieldsFragment
       ) }
     ) }
   )> }
@@ -235,7 +236,7 @@ export type SubmitOrderMutationVariables = Types.Exact<{
 }>;
 
 
-export type SubmitOrderMutation = (
+export type SubmitOrderMutationData = (
   { __typename: 'Mutation' }
   & { submitOrder?: Types.Maybe<(
     { __typename: 'SubmitOrderPayload' }
@@ -253,7 +254,7 @@ export type AddOrderEntryToCurrentPendingOrderMutationVariables = Types.Exact<{
 }>;
 
 
-export type AddOrderEntryToCurrentPendingOrderMutation = (
+export type AddOrderEntryToCurrentPendingOrderMutationData = (
   { __typename: 'Mutation' }
   & { addOrderEntryToCurrentPendingOrder?: Types.Maybe<(
     { __typename: 'AddOrderEntryToCurrentPendingOrderPayload' }
@@ -270,7 +271,7 @@ export type CreateCouponApplicationMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateCouponApplicationMutation = (
+export type CreateCouponApplicationMutationData = (
   { __typename: 'Mutation' }
   & { createCouponApplication?: Types.Maybe<(
     { __typename: 'CreateCouponApplicationPayload' }
@@ -291,7 +292,7 @@ export type DeleteCouponApplicationMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteCouponApplicationMutation = (
+export type DeleteCouponApplicationMutationData = (
   { __typename: 'Mutation' }
   & { deleteCouponApplication?: Types.Maybe<(
     { __typename: 'DeleteCouponApplicationPayload' }
@@ -317,8 +318,8 @@ export const MarkOrderPaidDocument = gql`
     }
   }
 }
-    ${AdminOrderFieldsFragmentFragmentDoc}`;
-export type MarkOrderPaidMutationFn = Apollo.MutationFunction<MarkOrderPaidMutation, MarkOrderPaidMutationVariables>;
+    ${AdminOrderFieldsFragmentDoc}`;
+export type MarkOrderPaidMutationFn = Apollo.MutationFunction<MarkOrderPaidMutationData, MarkOrderPaidMutationVariables>;
 
 /**
  * __useMarkOrderPaidMutation__
@@ -337,12 +338,13 @@ export type MarkOrderPaidMutationFn = Apollo.MutationFunction<MarkOrderPaidMutat
  *   },
  * });
  */
-export function useMarkOrderPaidMutation(baseOptions?: Apollo.MutationHookOptions<MarkOrderPaidMutation, MarkOrderPaidMutationVariables>) {
-        return Apollo.useMutation<MarkOrderPaidMutation, MarkOrderPaidMutationVariables>(MarkOrderPaidDocument, baseOptions);
+export function useMarkOrderPaidMutation(baseOptions?: Apollo.MutationHookOptions<MarkOrderPaidMutationData, MarkOrderPaidMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<MarkOrderPaidMutationData, MarkOrderPaidMutationVariables>(MarkOrderPaidDocument, options);
       }
 export type MarkOrderPaidMutationHookResult = ReturnType<typeof useMarkOrderPaidMutation>;
-export type MarkOrderPaidMutationResult = Apollo.MutationResult<MarkOrderPaidMutation>;
-export type MarkOrderPaidMutationOptions = Apollo.BaseMutationOptions<MarkOrderPaidMutation, MarkOrderPaidMutationVariables>;
+export type MarkOrderPaidMutationResult = Apollo.MutationResult<MarkOrderPaidMutationData>;
+export type MarkOrderPaidMutationOptions = Apollo.BaseMutationOptions<MarkOrderPaidMutationData, MarkOrderPaidMutationVariables>;
 export const CancelOrderDocument = gql`
     mutation CancelOrder($orderId: Int!, $skipRefund: Boolean) {
   cancelOrder(input: {id: $orderId, skip_refund: $skipRefund}) {
@@ -352,8 +354,8 @@ export const CancelOrderDocument = gql`
     }
   }
 }
-    ${AdminOrderFieldsFragmentFragmentDoc}`;
-export type CancelOrderMutationFn = Apollo.MutationFunction<CancelOrderMutation, CancelOrderMutationVariables>;
+    ${AdminOrderFieldsFragmentDoc}`;
+export type CancelOrderMutationFn = Apollo.MutationFunction<CancelOrderMutationData, CancelOrderMutationVariables>;
 
 /**
  * __useCancelOrderMutation__
@@ -373,12 +375,13 @@ export type CancelOrderMutationFn = Apollo.MutationFunction<CancelOrderMutation,
  *   },
  * });
  */
-export function useCancelOrderMutation(baseOptions?: Apollo.MutationHookOptions<CancelOrderMutation, CancelOrderMutationVariables>) {
-        return Apollo.useMutation<CancelOrderMutation, CancelOrderMutationVariables>(CancelOrderDocument, baseOptions);
+export function useCancelOrderMutation(baseOptions?: Apollo.MutationHookOptions<CancelOrderMutationData, CancelOrderMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CancelOrderMutationData, CancelOrderMutationVariables>(CancelOrderDocument, options);
       }
 export type CancelOrderMutationHookResult = ReturnType<typeof useCancelOrderMutation>;
-export type CancelOrderMutationResult = Apollo.MutationResult<CancelOrderMutation>;
-export type CancelOrderMutationOptions = Apollo.BaseMutationOptions<CancelOrderMutation, CancelOrderMutationVariables>;
+export type CancelOrderMutationResult = Apollo.MutationResult<CancelOrderMutationData>;
+export type CancelOrderMutationOptions = Apollo.BaseMutationOptions<CancelOrderMutationData, CancelOrderMutationVariables>;
 export const CreateOrderDocument = gql`
     mutation CreateOrder($userConProfileId: Int!, $order: OrderInput!, $status: OrderStatus!, $orderEntries: [OrderEntryInput!]) {
   createOrder(
@@ -390,8 +393,8 @@ export const CreateOrderDocument = gql`
     }
   }
 }
-    ${AdminOrderFieldsFragmentFragmentDoc}`;
-export type CreateOrderMutationFn = Apollo.MutationFunction<CreateOrderMutation, CreateOrderMutationVariables>;
+    ${AdminOrderFieldsFragmentDoc}`;
+export type CreateOrderMutationFn = Apollo.MutationFunction<CreateOrderMutationData, CreateOrderMutationVariables>;
 
 /**
  * __useCreateOrderMutation__
@@ -413,12 +416,13 @@ export type CreateOrderMutationFn = Apollo.MutationFunction<CreateOrderMutation,
  *   },
  * });
  */
-export function useCreateOrderMutation(baseOptions?: Apollo.MutationHookOptions<CreateOrderMutation, CreateOrderMutationVariables>) {
-        return Apollo.useMutation<CreateOrderMutation, CreateOrderMutationVariables>(CreateOrderDocument, baseOptions);
+export function useCreateOrderMutation(baseOptions?: Apollo.MutationHookOptions<CreateOrderMutationData, CreateOrderMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateOrderMutationData, CreateOrderMutationVariables>(CreateOrderDocument, options);
       }
 export type CreateOrderMutationHookResult = ReturnType<typeof useCreateOrderMutation>;
-export type CreateOrderMutationResult = Apollo.MutationResult<CreateOrderMutation>;
-export type CreateOrderMutationOptions = Apollo.BaseMutationOptions<CreateOrderMutation, CreateOrderMutationVariables>;
+export type CreateOrderMutationResult = Apollo.MutationResult<CreateOrderMutationData>;
+export type CreateOrderMutationOptions = Apollo.BaseMutationOptions<CreateOrderMutationData, CreateOrderMutationVariables>;
 export const AdminUpdateOrderDocument = gql`
     mutation AdminUpdateOrder($id: Int!, $order: OrderInput!) {
   updateOrder(input: {id: $id, order: $order}) {
@@ -428,8 +432,8 @@ export const AdminUpdateOrderDocument = gql`
     }
   }
 }
-    ${AdminOrderFieldsFragmentFragmentDoc}`;
-export type AdminUpdateOrderMutationFn = Apollo.MutationFunction<AdminUpdateOrderMutation, AdminUpdateOrderMutationVariables>;
+    ${AdminOrderFieldsFragmentDoc}`;
+export type AdminUpdateOrderMutationFn = Apollo.MutationFunction<AdminUpdateOrderMutationData, AdminUpdateOrderMutationVariables>;
 
 /**
  * __useAdminUpdateOrderMutation__
@@ -449,12 +453,13 @@ export type AdminUpdateOrderMutationFn = Apollo.MutationFunction<AdminUpdateOrde
  *   },
  * });
  */
-export function useAdminUpdateOrderMutation(baseOptions?: Apollo.MutationHookOptions<AdminUpdateOrderMutation, AdminUpdateOrderMutationVariables>) {
-        return Apollo.useMutation<AdminUpdateOrderMutation, AdminUpdateOrderMutationVariables>(AdminUpdateOrderDocument, baseOptions);
+export function useAdminUpdateOrderMutation(baseOptions?: Apollo.MutationHookOptions<AdminUpdateOrderMutationData, AdminUpdateOrderMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AdminUpdateOrderMutationData, AdminUpdateOrderMutationVariables>(AdminUpdateOrderDocument, options);
       }
 export type AdminUpdateOrderMutationHookResult = ReturnType<typeof useAdminUpdateOrderMutation>;
-export type AdminUpdateOrderMutationResult = Apollo.MutationResult<AdminUpdateOrderMutation>;
-export type AdminUpdateOrderMutationOptions = Apollo.BaseMutationOptions<AdminUpdateOrderMutation, AdminUpdateOrderMutationVariables>;
+export type AdminUpdateOrderMutationResult = Apollo.MutationResult<AdminUpdateOrderMutationData>;
+export type AdminUpdateOrderMutationOptions = Apollo.BaseMutationOptions<AdminUpdateOrderMutationData, AdminUpdateOrderMutationVariables>;
 export const CreateProductDocument = gql`
     mutation CreateProduct($product: ProductInput!) {
   createProduct(input: {product: $product}) {
@@ -465,7 +470,7 @@ export const CreateProductDocument = gql`
   }
 }
     ${AdminProductFieldsFragmentDoc}`;
-export type CreateProductMutationFn = Apollo.MutationFunction<CreateProductMutation, CreateProductMutationVariables>;
+export type CreateProductMutationFn = Apollo.MutationFunction<CreateProductMutationData, CreateProductMutationVariables>;
 
 /**
  * __useCreateProductMutation__
@@ -484,12 +489,13 @@ export type CreateProductMutationFn = Apollo.MutationFunction<CreateProductMutat
  *   },
  * });
  */
-export function useCreateProductMutation(baseOptions?: Apollo.MutationHookOptions<CreateProductMutation, CreateProductMutationVariables>) {
-        return Apollo.useMutation<CreateProductMutation, CreateProductMutationVariables>(CreateProductDocument, baseOptions);
+export function useCreateProductMutation(baseOptions?: Apollo.MutationHookOptions<CreateProductMutationData, CreateProductMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateProductMutationData, CreateProductMutationVariables>(CreateProductDocument, options);
       }
 export type CreateProductMutationHookResult = ReturnType<typeof useCreateProductMutation>;
-export type CreateProductMutationResult = Apollo.MutationResult<CreateProductMutation>;
-export type CreateProductMutationOptions = Apollo.BaseMutationOptions<CreateProductMutation, CreateProductMutationVariables>;
+export type CreateProductMutationResult = Apollo.MutationResult<CreateProductMutationData>;
+export type CreateProductMutationOptions = Apollo.BaseMutationOptions<CreateProductMutationData, CreateProductMutationVariables>;
 export const UpdateProductDocument = gql`
     mutation UpdateProduct($id: Int!, $product: ProductInput!) {
   updateProduct(input: {id: $id, product: $product}) {
@@ -500,7 +506,7 @@ export const UpdateProductDocument = gql`
   }
 }
     ${AdminProductFieldsFragmentDoc}`;
-export type UpdateProductMutationFn = Apollo.MutationFunction<UpdateProductMutation, UpdateProductMutationVariables>;
+export type UpdateProductMutationFn = Apollo.MutationFunction<UpdateProductMutationData, UpdateProductMutationVariables>;
 
 /**
  * __useUpdateProductMutation__
@@ -520,12 +526,13 @@ export type UpdateProductMutationFn = Apollo.MutationFunction<UpdateProductMutat
  *   },
  * });
  */
-export function useUpdateProductMutation(baseOptions?: Apollo.MutationHookOptions<UpdateProductMutation, UpdateProductMutationVariables>) {
-        return Apollo.useMutation<UpdateProductMutation, UpdateProductMutationVariables>(UpdateProductDocument, baseOptions);
+export function useUpdateProductMutation(baseOptions?: Apollo.MutationHookOptions<UpdateProductMutationData, UpdateProductMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateProductMutationData, UpdateProductMutationVariables>(UpdateProductDocument, options);
       }
 export type UpdateProductMutationHookResult = ReturnType<typeof useUpdateProductMutation>;
-export type UpdateProductMutationResult = Apollo.MutationResult<UpdateProductMutation>;
-export type UpdateProductMutationOptions = Apollo.BaseMutationOptions<UpdateProductMutation, UpdateProductMutationVariables>;
+export type UpdateProductMutationResult = Apollo.MutationResult<UpdateProductMutationData>;
+export type UpdateProductMutationOptions = Apollo.BaseMutationOptions<UpdateProductMutationData, UpdateProductMutationVariables>;
 export const DeleteProductDocument = gql`
     mutation DeleteProduct($id: Int!) {
   deleteProduct(input: {id: $id}) {
@@ -536,7 +543,7 @@ export const DeleteProductDocument = gql`
   }
 }
     ${AdminProductFieldsFragmentDoc}`;
-export type DeleteProductMutationFn = Apollo.MutationFunction<DeleteProductMutation, DeleteProductMutationVariables>;
+export type DeleteProductMutationFn = Apollo.MutationFunction<DeleteProductMutationData, DeleteProductMutationVariables>;
 
 /**
  * __useDeleteProductMutation__
@@ -555,12 +562,13 @@ export type DeleteProductMutationFn = Apollo.MutationFunction<DeleteProductMutat
  *   },
  * });
  */
-export function useDeleteProductMutation(baseOptions?: Apollo.MutationHookOptions<DeleteProductMutation, DeleteProductMutationVariables>) {
-        return Apollo.useMutation<DeleteProductMutation, DeleteProductMutationVariables>(DeleteProductDocument, baseOptions);
+export function useDeleteProductMutation(baseOptions?: Apollo.MutationHookOptions<DeleteProductMutationData, DeleteProductMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteProductMutationData, DeleteProductMutationVariables>(DeleteProductDocument, options);
       }
 export type DeleteProductMutationHookResult = ReturnType<typeof useDeleteProductMutation>;
-export type DeleteProductMutationResult = Apollo.MutationResult<DeleteProductMutation>;
-export type DeleteProductMutationOptions = Apollo.BaseMutationOptions<DeleteProductMutation, DeleteProductMutationVariables>;
+export type DeleteProductMutationResult = Apollo.MutationResult<DeleteProductMutationData>;
+export type DeleteProductMutationOptions = Apollo.BaseMutationOptions<DeleteProductMutationData, DeleteProductMutationVariables>;
 export const AdminCreateOrderEntryDocument = gql`
     mutation AdminCreateOrderEntry($input: CreateOrderEntryInput!) {
   createOrderEntry(input: $input) {
@@ -575,8 +583,8 @@ export const AdminCreateOrderEntryDocument = gql`
   }
 }
     ${OrderEntryFieldsFragmentDoc}
-${AdminOrderFieldsFragmentFragmentDoc}`;
-export type AdminCreateOrderEntryMutationFn = Apollo.MutationFunction<AdminCreateOrderEntryMutation, AdminCreateOrderEntryMutationVariables>;
+${AdminOrderFieldsFragmentDoc}`;
+export type AdminCreateOrderEntryMutationFn = Apollo.MutationFunction<AdminCreateOrderEntryMutationData, AdminCreateOrderEntryMutationVariables>;
 
 /**
  * __useAdminCreateOrderEntryMutation__
@@ -595,12 +603,13 @@ export type AdminCreateOrderEntryMutationFn = Apollo.MutationFunction<AdminCreat
  *   },
  * });
  */
-export function useAdminCreateOrderEntryMutation(baseOptions?: Apollo.MutationHookOptions<AdminCreateOrderEntryMutation, AdminCreateOrderEntryMutationVariables>) {
-        return Apollo.useMutation<AdminCreateOrderEntryMutation, AdminCreateOrderEntryMutationVariables>(AdminCreateOrderEntryDocument, baseOptions);
+export function useAdminCreateOrderEntryMutation(baseOptions?: Apollo.MutationHookOptions<AdminCreateOrderEntryMutationData, AdminCreateOrderEntryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AdminCreateOrderEntryMutationData, AdminCreateOrderEntryMutationVariables>(AdminCreateOrderEntryDocument, options);
       }
 export type AdminCreateOrderEntryMutationHookResult = ReturnType<typeof useAdminCreateOrderEntryMutation>;
-export type AdminCreateOrderEntryMutationResult = Apollo.MutationResult<AdminCreateOrderEntryMutation>;
-export type AdminCreateOrderEntryMutationOptions = Apollo.BaseMutationOptions<AdminCreateOrderEntryMutation, AdminCreateOrderEntryMutationVariables>;
+export type AdminCreateOrderEntryMutationResult = Apollo.MutationResult<AdminCreateOrderEntryMutationData>;
+export type AdminCreateOrderEntryMutationOptions = Apollo.BaseMutationOptions<AdminCreateOrderEntryMutationData, AdminCreateOrderEntryMutationVariables>;
 export const AdminUpdateOrderEntryDocument = gql`
     mutation AdminUpdateOrderEntry($input: UpdateOrderEntryInput!) {
   updateOrderEntry(input: $input) {
@@ -615,8 +624,8 @@ export const AdminUpdateOrderEntryDocument = gql`
   }
 }
     ${OrderEntryFieldsFragmentDoc}
-${AdminOrderFieldsFragmentFragmentDoc}`;
-export type AdminUpdateOrderEntryMutationFn = Apollo.MutationFunction<AdminUpdateOrderEntryMutation, AdminUpdateOrderEntryMutationVariables>;
+${AdminOrderFieldsFragmentDoc}`;
+export type AdminUpdateOrderEntryMutationFn = Apollo.MutationFunction<AdminUpdateOrderEntryMutationData, AdminUpdateOrderEntryMutationVariables>;
 
 /**
  * __useAdminUpdateOrderEntryMutation__
@@ -635,12 +644,13 @@ export type AdminUpdateOrderEntryMutationFn = Apollo.MutationFunction<AdminUpdat
  *   },
  * });
  */
-export function useAdminUpdateOrderEntryMutation(baseOptions?: Apollo.MutationHookOptions<AdminUpdateOrderEntryMutation, AdminUpdateOrderEntryMutationVariables>) {
-        return Apollo.useMutation<AdminUpdateOrderEntryMutation, AdminUpdateOrderEntryMutationVariables>(AdminUpdateOrderEntryDocument, baseOptions);
+export function useAdminUpdateOrderEntryMutation(baseOptions?: Apollo.MutationHookOptions<AdminUpdateOrderEntryMutationData, AdminUpdateOrderEntryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AdminUpdateOrderEntryMutationData, AdminUpdateOrderEntryMutationVariables>(AdminUpdateOrderEntryDocument, options);
       }
 export type AdminUpdateOrderEntryMutationHookResult = ReturnType<typeof useAdminUpdateOrderEntryMutation>;
-export type AdminUpdateOrderEntryMutationResult = Apollo.MutationResult<AdminUpdateOrderEntryMutation>;
-export type AdminUpdateOrderEntryMutationOptions = Apollo.BaseMutationOptions<AdminUpdateOrderEntryMutation, AdminUpdateOrderEntryMutationVariables>;
+export type AdminUpdateOrderEntryMutationResult = Apollo.MutationResult<AdminUpdateOrderEntryMutationData>;
+export type AdminUpdateOrderEntryMutationOptions = Apollo.BaseMutationOptions<AdminUpdateOrderEntryMutationData, AdminUpdateOrderEntryMutationVariables>;
 export const UpdateOrderEntryDocument = gql`
     mutation UpdateOrderEntry($input: UpdateOrderEntryInput!) {
   updateOrderEntry(input: $input) {
@@ -651,7 +661,7 @@ export const UpdateOrderEntryDocument = gql`
   }
 }
     ${OrderEntryFieldsFragmentDoc}`;
-export type UpdateOrderEntryMutationFn = Apollo.MutationFunction<UpdateOrderEntryMutation, UpdateOrderEntryMutationVariables>;
+export type UpdateOrderEntryMutationFn = Apollo.MutationFunction<UpdateOrderEntryMutationData, UpdateOrderEntryMutationVariables>;
 
 /**
  * __useUpdateOrderEntryMutation__
@@ -670,12 +680,13 @@ export type UpdateOrderEntryMutationFn = Apollo.MutationFunction<UpdateOrderEntr
  *   },
  * });
  */
-export function useUpdateOrderEntryMutation(baseOptions?: Apollo.MutationHookOptions<UpdateOrderEntryMutation, UpdateOrderEntryMutationVariables>) {
-        return Apollo.useMutation<UpdateOrderEntryMutation, UpdateOrderEntryMutationVariables>(UpdateOrderEntryDocument, baseOptions);
+export function useUpdateOrderEntryMutation(baseOptions?: Apollo.MutationHookOptions<UpdateOrderEntryMutationData, UpdateOrderEntryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateOrderEntryMutationData, UpdateOrderEntryMutationVariables>(UpdateOrderEntryDocument, options);
       }
 export type UpdateOrderEntryMutationHookResult = ReturnType<typeof useUpdateOrderEntryMutation>;
-export type UpdateOrderEntryMutationResult = Apollo.MutationResult<UpdateOrderEntryMutation>;
-export type UpdateOrderEntryMutationOptions = Apollo.BaseMutationOptions<UpdateOrderEntryMutation, UpdateOrderEntryMutationVariables>;
+export type UpdateOrderEntryMutationResult = Apollo.MutationResult<UpdateOrderEntryMutationData>;
+export type UpdateOrderEntryMutationOptions = Apollo.BaseMutationOptions<UpdateOrderEntryMutationData, UpdateOrderEntryMutationVariables>;
 export const DeleteOrderEntryDocument = gql`
     mutation DeleteOrderEntry($input: DeleteOrderEntryInput!) {
   deleteOrderEntry(input: $input) {
@@ -685,7 +696,7 @@ export const DeleteOrderEntryDocument = gql`
   }
 }
     `;
-export type DeleteOrderEntryMutationFn = Apollo.MutationFunction<DeleteOrderEntryMutation, DeleteOrderEntryMutationVariables>;
+export type DeleteOrderEntryMutationFn = Apollo.MutationFunction<DeleteOrderEntryMutationData, DeleteOrderEntryMutationVariables>;
 
 /**
  * __useDeleteOrderEntryMutation__
@@ -704,12 +715,13 @@ export type DeleteOrderEntryMutationFn = Apollo.MutationFunction<DeleteOrderEntr
  *   },
  * });
  */
-export function useDeleteOrderEntryMutation(baseOptions?: Apollo.MutationHookOptions<DeleteOrderEntryMutation, DeleteOrderEntryMutationVariables>) {
-        return Apollo.useMutation<DeleteOrderEntryMutation, DeleteOrderEntryMutationVariables>(DeleteOrderEntryDocument, baseOptions);
+export function useDeleteOrderEntryMutation(baseOptions?: Apollo.MutationHookOptions<DeleteOrderEntryMutationData, DeleteOrderEntryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteOrderEntryMutationData, DeleteOrderEntryMutationVariables>(DeleteOrderEntryDocument, options);
       }
 export type DeleteOrderEntryMutationHookResult = ReturnType<typeof useDeleteOrderEntryMutation>;
-export type DeleteOrderEntryMutationResult = Apollo.MutationResult<DeleteOrderEntryMutation>;
-export type DeleteOrderEntryMutationOptions = Apollo.BaseMutationOptions<DeleteOrderEntryMutation, DeleteOrderEntryMutationVariables>;
+export type DeleteOrderEntryMutationResult = Apollo.MutationResult<DeleteOrderEntryMutationData>;
+export type DeleteOrderEntryMutationOptions = Apollo.BaseMutationOptions<DeleteOrderEntryMutationData, DeleteOrderEntryMutationVariables>;
 export const AdminDeleteOrderEntryDocument = gql`
     mutation AdminDeleteOrderEntry($input: DeleteOrderEntryInput!) {
   deleteOrderEntry(input: $input) {
@@ -722,8 +734,8 @@ export const AdminDeleteOrderEntryDocument = gql`
     }
   }
 }
-    ${AdminOrderFieldsFragmentFragmentDoc}`;
-export type AdminDeleteOrderEntryMutationFn = Apollo.MutationFunction<AdminDeleteOrderEntryMutation, AdminDeleteOrderEntryMutationVariables>;
+    ${AdminOrderFieldsFragmentDoc}`;
+export type AdminDeleteOrderEntryMutationFn = Apollo.MutationFunction<AdminDeleteOrderEntryMutationData, AdminDeleteOrderEntryMutationVariables>;
 
 /**
  * __useAdminDeleteOrderEntryMutation__
@@ -742,12 +754,13 @@ export type AdminDeleteOrderEntryMutationFn = Apollo.MutationFunction<AdminDelet
  *   },
  * });
  */
-export function useAdminDeleteOrderEntryMutation(baseOptions?: Apollo.MutationHookOptions<AdminDeleteOrderEntryMutation, AdminDeleteOrderEntryMutationVariables>) {
-        return Apollo.useMutation<AdminDeleteOrderEntryMutation, AdminDeleteOrderEntryMutationVariables>(AdminDeleteOrderEntryDocument, baseOptions);
+export function useAdminDeleteOrderEntryMutation(baseOptions?: Apollo.MutationHookOptions<AdminDeleteOrderEntryMutationData, AdminDeleteOrderEntryMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AdminDeleteOrderEntryMutationData, AdminDeleteOrderEntryMutationVariables>(AdminDeleteOrderEntryDocument, options);
       }
 export type AdminDeleteOrderEntryMutationHookResult = ReturnType<typeof useAdminDeleteOrderEntryMutation>;
-export type AdminDeleteOrderEntryMutationResult = Apollo.MutationResult<AdminDeleteOrderEntryMutation>;
-export type AdminDeleteOrderEntryMutationOptions = Apollo.BaseMutationOptions<AdminDeleteOrderEntryMutation, AdminDeleteOrderEntryMutationVariables>;
+export type AdminDeleteOrderEntryMutationResult = Apollo.MutationResult<AdminDeleteOrderEntryMutationData>;
+export type AdminDeleteOrderEntryMutationOptions = Apollo.BaseMutationOptions<AdminDeleteOrderEntryMutationData, AdminDeleteOrderEntryMutationVariables>;
 export const SubmitOrderDocument = gql`
     mutation SubmitOrder($input: SubmitOrderInput!) {
   submitOrder(input: $input) {
@@ -758,7 +771,7 @@ export const SubmitOrderDocument = gql`
   }
 }
     `;
-export type SubmitOrderMutationFn = Apollo.MutationFunction<SubmitOrderMutation, SubmitOrderMutationVariables>;
+export type SubmitOrderMutationFn = Apollo.MutationFunction<SubmitOrderMutationData, SubmitOrderMutationVariables>;
 
 /**
  * __useSubmitOrderMutation__
@@ -777,12 +790,13 @@ export type SubmitOrderMutationFn = Apollo.MutationFunction<SubmitOrderMutation,
  *   },
  * });
  */
-export function useSubmitOrderMutation(baseOptions?: Apollo.MutationHookOptions<SubmitOrderMutation, SubmitOrderMutationVariables>) {
-        return Apollo.useMutation<SubmitOrderMutation, SubmitOrderMutationVariables>(SubmitOrderDocument, baseOptions);
+export function useSubmitOrderMutation(baseOptions?: Apollo.MutationHookOptions<SubmitOrderMutationData, SubmitOrderMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SubmitOrderMutationData, SubmitOrderMutationVariables>(SubmitOrderDocument, options);
       }
 export type SubmitOrderMutationHookResult = ReturnType<typeof useSubmitOrderMutation>;
-export type SubmitOrderMutationResult = Apollo.MutationResult<SubmitOrderMutation>;
-export type SubmitOrderMutationOptions = Apollo.BaseMutationOptions<SubmitOrderMutation, SubmitOrderMutationVariables>;
+export type SubmitOrderMutationResult = Apollo.MutationResult<SubmitOrderMutationData>;
+export type SubmitOrderMutationOptions = Apollo.BaseMutationOptions<SubmitOrderMutationData, SubmitOrderMutationVariables>;
 export const AddOrderEntryToCurrentPendingOrderDocument = gql`
     mutation AddOrderEntryToCurrentPendingOrder($productId: Int!, $productVariantId: Int, $quantity: Int!) {
   addOrderEntryToCurrentPendingOrder(
@@ -794,7 +808,7 @@ export const AddOrderEntryToCurrentPendingOrderDocument = gql`
   }
 }
     `;
-export type AddOrderEntryToCurrentPendingOrderMutationFn = Apollo.MutationFunction<AddOrderEntryToCurrentPendingOrderMutation, AddOrderEntryToCurrentPendingOrderMutationVariables>;
+export type AddOrderEntryToCurrentPendingOrderMutationFn = Apollo.MutationFunction<AddOrderEntryToCurrentPendingOrderMutationData, AddOrderEntryToCurrentPendingOrderMutationVariables>;
 
 /**
  * __useAddOrderEntryToCurrentPendingOrderMutation__
@@ -815,12 +829,13 @@ export type AddOrderEntryToCurrentPendingOrderMutationFn = Apollo.MutationFuncti
  *   },
  * });
  */
-export function useAddOrderEntryToCurrentPendingOrderMutation(baseOptions?: Apollo.MutationHookOptions<AddOrderEntryToCurrentPendingOrderMutation, AddOrderEntryToCurrentPendingOrderMutationVariables>) {
-        return Apollo.useMutation<AddOrderEntryToCurrentPendingOrderMutation, AddOrderEntryToCurrentPendingOrderMutationVariables>(AddOrderEntryToCurrentPendingOrderDocument, baseOptions);
+export function useAddOrderEntryToCurrentPendingOrderMutation(baseOptions?: Apollo.MutationHookOptions<AddOrderEntryToCurrentPendingOrderMutationData, AddOrderEntryToCurrentPendingOrderMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<AddOrderEntryToCurrentPendingOrderMutationData, AddOrderEntryToCurrentPendingOrderMutationVariables>(AddOrderEntryToCurrentPendingOrderDocument, options);
       }
 export type AddOrderEntryToCurrentPendingOrderMutationHookResult = ReturnType<typeof useAddOrderEntryToCurrentPendingOrderMutation>;
-export type AddOrderEntryToCurrentPendingOrderMutationResult = Apollo.MutationResult<AddOrderEntryToCurrentPendingOrderMutation>;
-export type AddOrderEntryToCurrentPendingOrderMutationOptions = Apollo.BaseMutationOptions<AddOrderEntryToCurrentPendingOrderMutation, AddOrderEntryToCurrentPendingOrderMutationVariables>;
+export type AddOrderEntryToCurrentPendingOrderMutationResult = Apollo.MutationResult<AddOrderEntryToCurrentPendingOrderMutationData>;
+export type AddOrderEntryToCurrentPendingOrderMutationOptions = Apollo.BaseMutationOptions<AddOrderEntryToCurrentPendingOrderMutationData, AddOrderEntryToCurrentPendingOrderMutationVariables>;
 export const CreateCouponApplicationDocument = gql`
     mutation CreateCouponApplication($orderId: Int!, $couponCode: String!) {
   createCouponApplication(input: {order_id: $orderId, coupon_code: $couponCode}) {
@@ -834,7 +849,7 @@ export const CreateCouponApplicationDocument = gql`
   }
 }
     ${CartOrderFieldsFragmentDoc}`;
-export type CreateCouponApplicationMutationFn = Apollo.MutationFunction<CreateCouponApplicationMutation, CreateCouponApplicationMutationVariables>;
+export type CreateCouponApplicationMutationFn = Apollo.MutationFunction<CreateCouponApplicationMutationData, CreateCouponApplicationMutationVariables>;
 
 /**
  * __useCreateCouponApplicationMutation__
@@ -854,12 +869,13 @@ export type CreateCouponApplicationMutationFn = Apollo.MutationFunction<CreateCo
  *   },
  * });
  */
-export function useCreateCouponApplicationMutation(baseOptions?: Apollo.MutationHookOptions<CreateCouponApplicationMutation, CreateCouponApplicationMutationVariables>) {
-        return Apollo.useMutation<CreateCouponApplicationMutation, CreateCouponApplicationMutationVariables>(CreateCouponApplicationDocument, baseOptions);
+export function useCreateCouponApplicationMutation(baseOptions?: Apollo.MutationHookOptions<CreateCouponApplicationMutationData, CreateCouponApplicationMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateCouponApplicationMutationData, CreateCouponApplicationMutationVariables>(CreateCouponApplicationDocument, options);
       }
 export type CreateCouponApplicationMutationHookResult = ReturnType<typeof useCreateCouponApplicationMutation>;
-export type CreateCouponApplicationMutationResult = Apollo.MutationResult<CreateCouponApplicationMutation>;
-export type CreateCouponApplicationMutationOptions = Apollo.BaseMutationOptions<CreateCouponApplicationMutation, CreateCouponApplicationMutationVariables>;
+export type CreateCouponApplicationMutationResult = Apollo.MutationResult<CreateCouponApplicationMutationData>;
+export type CreateCouponApplicationMutationOptions = Apollo.BaseMutationOptions<CreateCouponApplicationMutationData, CreateCouponApplicationMutationVariables>;
 export const DeleteCouponApplicationDocument = gql`
     mutation DeleteCouponApplication($id: Int!) {
   deleteCouponApplication(input: {id: $id}) {
@@ -873,7 +889,7 @@ export const DeleteCouponApplicationDocument = gql`
   }
 }
     ${CartOrderFieldsFragmentDoc}`;
-export type DeleteCouponApplicationMutationFn = Apollo.MutationFunction<DeleteCouponApplicationMutation, DeleteCouponApplicationMutationVariables>;
+export type DeleteCouponApplicationMutationFn = Apollo.MutationFunction<DeleteCouponApplicationMutationData, DeleteCouponApplicationMutationVariables>;
 
 /**
  * __useDeleteCouponApplicationMutation__
@@ -892,9 +908,10 @@ export type DeleteCouponApplicationMutationFn = Apollo.MutationFunction<DeleteCo
  *   },
  * });
  */
-export function useDeleteCouponApplicationMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCouponApplicationMutation, DeleteCouponApplicationMutationVariables>) {
-        return Apollo.useMutation<DeleteCouponApplicationMutation, DeleteCouponApplicationMutationVariables>(DeleteCouponApplicationDocument, baseOptions);
+export function useDeleteCouponApplicationMutation(baseOptions?: Apollo.MutationHookOptions<DeleteCouponApplicationMutationData, DeleteCouponApplicationMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteCouponApplicationMutationData, DeleteCouponApplicationMutationVariables>(DeleteCouponApplicationDocument, options);
       }
 export type DeleteCouponApplicationMutationHookResult = ReturnType<typeof useDeleteCouponApplicationMutation>;
-export type DeleteCouponApplicationMutationResult = Apollo.MutationResult<DeleteCouponApplicationMutation>;
-export type DeleteCouponApplicationMutationOptions = Apollo.BaseMutationOptions<DeleteCouponApplicationMutation, DeleteCouponApplicationMutationVariables>;
+export type DeleteCouponApplicationMutationResult = Apollo.MutationResult<DeleteCouponApplicationMutationData>;
+export type DeleteCouponApplicationMutationOptions = Apollo.BaseMutationOptions<DeleteCouponApplicationMutationData, DeleteCouponApplicationMutationVariables>;

--- a/app/javascript/Store/orderFields.generated.ts
+++ b/app/javascript/Store/orderFields.generated.ts
@@ -17,7 +17,7 @@ export type CouponApplicationFieldsFragment = (
   ) }
 );
 
-export type AdminOrderFieldsFragmentFragment = (
+export type AdminOrderFieldsFragment = (
   { __typename: 'Order' }
   & Pick<Types.Order, 'id' | 'status' | 'submitted_at' | 'charge_id' | 'payment_note'>
   & { user_con_profile: (
@@ -104,7 +104,7 @@ export const CouponApplicationFieldsFragmentDoc = gql`
   }
 }
     ${CouponFieldsFragmentDoc}`;
-export const AdminOrderFieldsFragmentFragmentDoc = gql`
+export const AdminOrderFieldsFragmentDoc = gql`
     fragment AdminOrderFieldsFragment on Order {
   id
   status

--- a/app/javascript/Store/queries.generated.ts
+++ b/app/javascript/Store/queries.generated.ts
@@ -1,15 +1,16 @@
 /* eslint-disable */
 import * as Types from '../graphqlTypes.generated';
 
-import { AdminOrderFieldsFragmentFragment, OrderEntryFieldsFragment, CartOrderFieldsFragment, CouponApplicationFieldsFragment } from './orderFields.generated';
+import { AdminOrderFieldsFragment, OrderEntryFieldsFragment, CartOrderFieldsFragment, CouponApplicationFieldsFragment } from './orderFields.generated';
 import { AdminProductFieldsFragment } from './adminProductFields.generated';
 import { PricingStructureFieldsFragment } from './pricingStructureFields.generated';
 import { gql } from '@apollo/client';
-import { AdminOrderFieldsFragmentFragmentDoc, OrderEntryFieldsFragmentDoc, CartOrderFieldsFragmentDoc, CouponApplicationFieldsFragmentDoc } from './orderFields.generated';
+import { AdminOrderFieldsFragmentDoc, OrderEntryFieldsFragmentDoc, CartOrderFieldsFragmentDoc, CouponApplicationFieldsFragmentDoc } from './orderFields.generated';
 import { AdminProductFieldsFragmentDoc } from './adminProductFields.generated';
 import { PricingStructureFieldsFragmentDoc } from './pricingStructureFields.generated';
 import * as Apollo from '@apollo/client';
-export type AdminOrdersQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type AdminOrdersQueryVariables = Types.Exact<{
   page?: Types.Maybe<Types.Scalars['Int']>;
   perPage?: Types.Maybe<Types.Scalars['Int']>;
   filters?: Types.Maybe<Types.OrderFiltersInput>;
@@ -17,7 +18,7 @@ export type AdminOrdersQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type AdminOrdersQueryQuery = (
+export type AdminOrdersQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -31,16 +32,16 @@ export type AdminOrdersQueryQuery = (
       & { entries: Array<(
         { __typename: 'Order' }
         & Pick<Types.Order, 'id'>
-        & AdminOrderFieldsFragmentFragment
+        & AdminOrderFieldsFragment
       )> }
     ) }
   ) }
 );
 
-export type AdminProductsQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type AdminProductsQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type AdminProductsQueryQuery = (
+export type AdminProductsQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -59,10 +60,10 @@ export type AdminProductsQueryQuery = (
   ) }
 );
 
-export type AdminStoreAbilityQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type AdminStoreAbilityQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type AdminStoreAbilityQueryQuery = (
+export type AdminStoreAbilityQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -73,10 +74,10 @@ export type AdminStoreAbilityQueryQuery = (
   ) }
 );
 
-export type CartQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CartQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CartQueryQuery = (
+export type CartQueryData = (
   { __typename: 'Query' }
   & { myProfile?: Types.Maybe<(
     { __typename: 'UserConProfile' }
@@ -91,10 +92,10 @@ export type CartQueryQuery = (
   )> }
 );
 
-export type OrderHistoryQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type OrderHistoryQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type OrderHistoryQueryQuery = (
+export type OrderHistoryQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -140,10 +141,10 @@ export type OrderHistoryQueryQuery = (
   )> }
 );
 
-export type OrderSummaryQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type OrderSummaryQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type OrderSummaryQueryQuery = (
+export type OrderSummaryQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -166,12 +167,12 @@ export type OrderSummaryQueryQuery = (
   ) }
 );
 
-export type OrderFormProductQueryQueryVariables = Types.Exact<{
+export type OrderFormProductQueryVariables = Types.Exact<{
   productId: Types.Scalars['Int'];
 }>;
 
 
-export type OrderFormProductQueryQuery = (
+export type OrderFormProductQueryData = (
   { __typename: 'Query' }
   & { currentUser?: Types.Maybe<(
     { __typename: 'User' }
@@ -196,10 +197,10 @@ export type OrderFormProductQueryQuery = (
   ) }
 );
 
-export type CurrentPendingOrderPaymentIntentClientSecretQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CurrentPendingOrderPaymentIntentClientSecretQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CurrentPendingOrderPaymentIntentClientSecretQueryQuery = (
+export type CurrentPendingOrderPaymentIntentClientSecretQueryData = (
   { __typename: 'Query' }
   & Pick<Types.Query, 'currentPendingOrderPaymentIntentClientSecret'>
 );
@@ -230,19 +231,19 @@ export const AdminOrdersQueryDocument = gql`
     }
   }
 }
-    ${AdminOrderFieldsFragmentFragmentDoc}`;
+    ${AdminOrderFieldsFragmentDoc}`;
 
 /**
- * __useAdminOrdersQueryQuery__
+ * __useAdminOrdersQuery__
  *
- * To run a query within a React component, call `useAdminOrdersQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useAdminOrdersQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAdminOrdersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAdminOrdersQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useAdminOrdersQueryQuery({
+ * const { data, loading, error } = useAdminOrdersQuery({
  *   variables: {
  *      page: // value for 'page'
  *      perPage: // value for 'perPage'
@@ -251,15 +252,17 @@ export const AdminOrdersQueryDocument = gql`
  *   },
  * });
  */
-export function useAdminOrdersQueryQuery(baseOptions?: Apollo.QueryHookOptions<AdminOrdersQueryQuery, AdminOrdersQueryQueryVariables>) {
-        return Apollo.useQuery<AdminOrdersQueryQuery, AdminOrdersQueryQueryVariables>(AdminOrdersQueryDocument, baseOptions);
+export function useAdminOrdersQuery(baseOptions?: Apollo.QueryHookOptions<AdminOrdersQueryData, AdminOrdersQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AdminOrdersQueryData, AdminOrdersQueryVariables>(AdminOrdersQueryDocument, options);
       }
-export function useAdminOrdersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminOrdersQueryQuery, AdminOrdersQueryQueryVariables>) {
-          return Apollo.useLazyQuery<AdminOrdersQueryQuery, AdminOrdersQueryQueryVariables>(AdminOrdersQueryDocument, baseOptions);
+export function useAdminOrdersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminOrdersQueryData, AdminOrdersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AdminOrdersQueryData, AdminOrdersQueryVariables>(AdminOrdersQueryDocument, options);
         }
-export type AdminOrdersQueryQueryHookResult = ReturnType<typeof useAdminOrdersQueryQuery>;
+export type AdminOrdersQueryHookResult = ReturnType<typeof useAdminOrdersQuery>;
 export type AdminOrdersQueryLazyQueryHookResult = ReturnType<typeof useAdminOrdersQueryLazyQuery>;
-export type AdminOrdersQueryQueryResult = Apollo.QueryResult<AdminOrdersQueryQuery, AdminOrdersQueryQueryVariables>;
+export type AdminOrdersQueryDataResult = Apollo.QueryResult<AdminOrdersQueryData, AdminOrdersQueryVariables>;
 export const AdminProductsQueryDocument = gql`
     query AdminProductsQuery {
   convention: assertConvention {
@@ -280,29 +283,31 @@ export const AdminProductsQueryDocument = gql`
     ${AdminProductFieldsFragmentDoc}`;
 
 /**
- * __useAdminProductsQueryQuery__
+ * __useAdminProductsQuery__
  *
- * To run a query within a React component, call `useAdminProductsQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useAdminProductsQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAdminProductsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAdminProductsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useAdminProductsQueryQuery({
+ * const { data, loading, error } = useAdminProductsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useAdminProductsQueryQuery(baseOptions?: Apollo.QueryHookOptions<AdminProductsQueryQuery, AdminProductsQueryQueryVariables>) {
-        return Apollo.useQuery<AdminProductsQueryQuery, AdminProductsQueryQueryVariables>(AdminProductsQueryDocument, baseOptions);
+export function useAdminProductsQuery(baseOptions?: Apollo.QueryHookOptions<AdminProductsQueryData, AdminProductsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AdminProductsQueryData, AdminProductsQueryVariables>(AdminProductsQueryDocument, options);
       }
-export function useAdminProductsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminProductsQueryQuery, AdminProductsQueryQueryVariables>) {
-          return Apollo.useLazyQuery<AdminProductsQueryQuery, AdminProductsQueryQueryVariables>(AdminProductsQueryDocument, baseOptions);
+export function useAdminProductsQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminProductsQueryData, AdminProductsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AdminProductsQueryData, AdminProductsQueryVariables>(AdminProductsQueryDocument, options);
         }
-export type AdminProductsQueryQueryHookResult = ReturnType<typeof useAdminProductsQueryQuery>;
+export type AdminProductsQueryHookResult = ReturnType<typeof useAdminProductsQuery>;
 export type AdminProductsQueryLazyQueryHookResult = ReturnType<typeof useAdminProductsQueryLazyQuery>;
-export type AdminProductsQueryQueryResult = Apollo.QueryResult<AdminProductsQueryQuery, AdminProductsQueryQueryVariables>;
+export type AdminProductsQueryDataResult = Apollo.QueryResult<AdminProductsQueryData, AdminProductsQueryVariables>;
 export const AdminStoreAbilityQueryDocument = gql`
     query AdminStoreAbilityQuery {
   currentAbility {
@@ -317,29 +322,31 @@ export const AdminStoreAbilityQueryDocument = gql`
     `;
 
 /**
- * __useAdminStoreAbilityQueryQuery__
+ * __useAdminStoreAbilityQuery__
  *
- * To run a query within a React component, call `useAdminStoreAbilityQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useAdminStoreAbilityQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAdminStoreAbilityQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAdminStoreAbilityQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useAdminStoreAbilityQueryQuery({
+ * const { data, loading, error } = useAdminStoreAbilityQuery({
  *   variables: {
  *   },
  * });
  */
-export function useAdminStoreAbilityQueryQuery(baseOptions?: Apollo.QueryHookOptions<AdminStoreAbilityQueryQuery, AdminStoreAbilityQueryQueryVariables>) {
-        return Apollo.useQuery<AdminStoreAbilityQueryQuery, AdminStoreAbilityQueryQueryVariables>(AdminStoreAbilityQueryDocument, baseOptions);
+export function useAdminStoreAbilityQuery(baseOptions?: Apollo.QueryHookOptions<AdminStoreAbilityQueryData, AdminStoreAbilityQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AdminStoreAbilityQueryData, AdminStoreAbilityQueryVariables>(AdminStoreAbilityQueryDocument, options);
       }
-export function useAdminStoreAbilityQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminStoreAbilityQueryQuery, AdminStoreAbilityQueryQueryVariables>) {
-          return Apollo.useLazyQuery<AdminStoreAbilityQueryQuery, AdminStoreAbilityQueryQueryVariables>(AdminStoreAbilityQueryDocument, baseOptions);
+export function useAdminStoreAbilityQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminStoreAbilityQueryData, AdminStoreAbilityQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AdminStoreAbilityQueryData, AdminStoreAbilityQueryVariables>(AdminStoreAbilityQueryDocument, options);
         }
-export type AdminStoreAbilityQueryQueryHookResult = ReturnType<typeof useAdminStoreAbilityQueryQuery>;
+export type AdminStoreAbilityQueryHookResult = ReturnType<typeof useAdminStoreAbilityQuery>;
 export type AdminStoreAbilityQueryLazyQueryHookResult = ReturnType<typeof useAdminStoreAbilityQueryLazyQuery>;
-export type AdminStoreAbilityQueryQueryResult = Apollo.QueryResult<AdminStoreAbilityQueryQuery, AdminStoreAbilityQueryQueryVariables>;
+export type AdminStoreAbilityQueryDataResult = Apollo.QueryResult<AdminStoreAbilityQueryData, AdminStoreAbilityQueryVariables>;
 export const CartQueryDocument = gql`
     query CartQuery {
   myProfile {
@@ -358,29 +365,31 @@ export const CartQueryDocument = gql`
     ${CartOrderFieldsFragmentDoc}`;
 
 /**
- * __useCartQueryQuery__
+ * __useCartQuery__
  *
- * To run a query within a React component, call `useCartQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCartQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCartQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCartQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCartQueryQuery({
+ * const { data, loading, error } = useCartQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCartQueryQuery(baseOptions?: Apollo.QueryHookOptions<CartQueryQuery, CartQueryQueryVariables>) {
-        return Apollo.useQuery<CartQueryQuery, CartQueryQueryVariables>(CartQueryDocument, baseOptions);
+export function useCartQuery(baseOptions?: Apollo.QueryHookOptions<CartQueryData, CartQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CartQueryData, CartQueryVariables>(CartQueryDocument, options);
       }
-export function useCartQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CartQueryQuery, CartQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CartQueryQuery, CartQueryQueryVariables>(CartQueryDocument, baseOptions);
+export function useCartQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CartQueryData, CartQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CartQueryData, CartQueryVariables>(CartQueryDocument, options);
         }
-export type CartQueryQueryHookResult = ReturnType<typeof useCartQueryQuery>;
+export type CartQueryHookResult = ReturnType<typeof useCartQuery>;
 export type CartQueryLazyQueryHookResult = ReturnType<typeof useCartQueryLazyQuery>;
-export type CartQueryQueryResult = Apollo.QueryResult<CartQueryQuery, CartQueryQueryVariables>;
+export type CartQueryDataResult = Apollo.QueryResult<CartQueryData, CartQueryVariables>;
 export const OrderHistoryQueryDocument = gql`
     query OrderHistoryQuery {
   convention: assertConvention {
@@ -441,29 +450,31 @@ export const OrderHistoryQueryDocument = gql`
     ${CouponApplicationFieldsFragmentDoc}`;
 
 /**
- * __useOrderHistoryQueryQuery__
+ * __useOrderHistoryQuery__
  *
- * To run a query within a React component, call `useOrderHistoryQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useOrderHistoryQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useOrderHistoryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useOrderHistoryQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useOrderHistoryQueryQuery({
+ * const { data, loading, error } = useOrderHistoryQuery({
  *   variables: {
  *   },
  * });
  */
-export function useOrderHistoryQueryQuery(baseOptions?: Apollo.QueryHookOptions<OrderHistoryQueryQuery, OrderHistoryQueryQueryVariables>) {
-        return Apollo.useQuery<OrderHistoryQueryQuery, OrderHistoryQueryQueryVariables>(OrderHistoryQueryDocument, baseOptions);
+export function useOrderHistoryQuery(baseOptions?: Apollo.QueryHookOptions<OrderHistoryQueryData, OrderHistoryQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<OrderHistoryQueryData, OrderHistoryQueryVariables>(OrderHistoryQueryDocument, options);
       }
-export function useOrderHistoryQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OrderHistoryQueryQuery, OrderHistoryQueryQueryVariables>) {
-          return Apollo.useLazyQuery<OrderHistoryQueryQuery, OrderHistoryQueryQueryVariables>(OrderHistoryQueryDocument, baseOptions);
+export function useOrderHistoryQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OrderHistoryQueryData, OrderHistoryQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<OrderHistoryQueryData, OrderHistoryQueryVariables>(OrderHistoryQueryDocument, options);
         }
-export type OrderHistoryQueryQueryHookResult = ReturnType<typeof useOrderHistoryQueryQuery>;
+export type OrderHistoryQueryHookResult = ReturnType<typeof useOrderHistoryQuery>;
 export type OrderHistoryQueryLazyQueryHookResult = ReturnType<typeof useOrderHistoryQueryLazyQuery>;
-export type OrderHistoryQueryQueryResult = Apollo.QueryResult<OrderHistoryQueryQuery, OrderHistoryQueryQueryVariables>;
+export type OrderHistoryQueryDataResult = Apollo.QueryResult<OrderHistoryQueryData, OrderHistoryQueryVariables>;
 export const OrderSummaryQueryDocument = gql`
     query OrderSummaryQuery {
   convention: assertConvention {
@@ -489,29 +500,31 @@ export const OrderSummaryQueryDocument = gql`
     `;
 
 /**
- * __useOrderSummaryQueryQuery__
+ * __useOrderSummaryQuery__
  *
- * To run a query within a React component, call `useOrderSummaryQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useOrderSummaryQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useOrderSummaryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useOrderSummaryQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useOrderSummaryQueryQuery({
+ * const { data, loading, error } = useOrderSummaryQuery({
  *   variables: {
  *   },
  * });
  */
-export function useOrderSummaryQueryQuery(baseOptions?: Apollo.QueryHookOptions<OrderSummaryQueryQuery, OrderSummaryQueryQueryVariables>) {
-        return Apollo.useQuery<OrderSummaryQueryQuery, OrderSummaryQueryQueryVariables>(OrderSummaryQueryDocument, baseOptions);
+export function useOrderSummaryQuery(baseOptions?: Apollo.QueryHookOptions<OrderSummaryQueryData, OrderSummaryQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<OrderSummaryQueryData, OrderSummaryQueryVariables>(OrderSummaryQueryDocument, options);
       }
-export function useOrderSummaryQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OrderSummaryQueryQuery, OrderSummaryQueryQueryVariables>) {
-          return Apollo.useLazyQuery<OrderSummaryQueryQuery, OrderSummaryQueryQueryVariables>(OrderSummaryQueryDocument, baseOptions);
+export function useOrderSummaryQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OrderSummaryQueryData, OrderSummaryQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<OrderSummaryQueryData, OrderSummaryQueryVariables>(OrderSummaryQueryDocument, options);
         }
-export type OrderSummaryQueryQueryHookResult = ReturnType<typeof useOrderSummaryQueryQuery>;
+export type OrderSummaryQueryHookResult = ReturnType<typeof useOrderSummaryQuery>;
 export type OrderSummaryQueryLazyQueryHookResult = ReturnType<typeof useOrderSummaryQueryLazyQuery>;
-export type OrderSummaryQueryQueryResult = Apollo.QueryResult<OrderSummaryQueryQuery, OrderSummaryQueryQueryVariables>;
+export type OrderSummaryQueryDataResult = Apollo.QueryResult<OrderSummaryQueryData, OrderSummaryQueryVariables>;
 export const OrderFormProductQueryDocument = gql`
     query OrderFormProductQuery($productId: Int!) {
   currentUser {
@@ -541,30 +554,32 @@ export const OrderFormProductQueryDocument = gql`
     ${PricingStructureFieldsFragmentDoc}`;
 
 /**
- * __useOrderFormProductQueryQuery__
+ * __useOrderFormProductQuery__
  *
- * To run a query within a React component, call `useOrderFormProductQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useOrderFormProductQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useOrderFormProductQuery` and pass it any options that fit your needs.
+ * When your component renders, `useOrderFormProductQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useOrderFormProductQueryQuery({
+ * const { data, loading, error } = useOrderFormProductQuery({
  *   variables: {
  *      productId: // value for 'productId'
  *   },
  * });
  */
-export function useOrderFormProductQueryQuery(baseOptions: Apollo.QueryHookOptions<OrderFormProductQueryQuery, OrderFormProductQueryQueryVariables>) {
-        return Apollo.useQuery<OrderFormProductQueryQuery, OrderFormProductQueryQueryVariables>(OrderFormProductQueryDocument, baseOptions);
+export function useOrderFormProductQuery(baseOptions: Apollo.QueryHookOptions<OrderFormProductQueryData, OrderFormProductQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<OrderFormProductQueryData, OrderFormProductQueryVariables>(OrderFormProductQueryDocument, options);
       }
-export function useOrderFormProductQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OrderFormProductQueryQuery, OrderFormProductQueryQueryVariables>) {
-          return Apollo.useLazyQuery<OrderFormProductQueryQuery, OrderFormProductQueryQueryVariables>(OrderFormProductQueryDocument, baseOptions);
+export function useOrderFormProductQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<OrderFormProductQueryData, OrderFormProductQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<OrderFormProductQueryData, OrderFormProductQueryVariables>(OrderFormProductQueryDocument, options);
         }
-export type OrderFormProductQueryQueryHookResult = ReturnType<typeof useOrderFormProductQueryQuery>;
+export type OrderFormProductQueryHookResult = ReturnType<typeof useOrderFormProductQuery>;
 export type OrderFormProductQueryLazyQueryHookResult = ReturnType<typeof useOrderFormProductQueryLazyQuery>;
-export type OrderFormProductQueryQueryResult = Apollo.QueryResult<OrderFormProductQueryQuery, OrderFormProductQueryQueryVariables>;
+export type OrderFormProductQueryDataResult = Apollo.QueryResult<OrderFormProductQueryData, OrderFormProductQueryVariables>;
 export const CurrentPendingOrderPaymentIntentClientSecretQueryDocument = gql`
     query CurrentPendingOrderPaymentIntentClientSecretQuery {
   currentPendingOrderPaymentIntentClientSecret
@@ -572,26 +587,28 @@ export const CurrentPendingOrderPaymentIntentClientSecretQueryDocument = gql`
     `;
 
 /**
- * __useCurrentPendingOrderPaymentIntentClientSecretQueryQuery__
+ * __useCurrentPendingOrderPaymentIntentClientSecretQuery__
  *
- * To run a query within a React component, call `useCurrentPendingOrderPaymentIntentClientSecretQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useCurrentPendingOrderPaymentIntentClientSecretQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCurrentPendingOrderPaymentIntentClientSecretQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCurrentPendingOrderPaymentIntentClientSecretQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCurrentPendingOrderPaymentIntentClientSecretQueryQuery({
+ * const { data, loading, error } = useCurrentPendingOrderPaymentIntentClientSecretQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCurrentPendingOrderPaymentIntentClientSecretQueryQuery(baseOptions?: Apollo.QueryHookOptions<CurrentPendingOrderPaymentIntentClientSecretQueryQuery, CurrentPendingOrderPaymentIntentClientSecretQueryQueryVariables>) {
-        return Apollo.useQuery<CurrentPendingOrderPaymentIntentClientSecretQueryQuery, CurrentPendingOrderPaymentIntentClientSecretQueryQueryVariables>(CurrentPendingOrderPaymentIntentClientSecretQueryDocument, baseOptions);
+export function useCurrentPendingOrderPaymentIntentClientSecretQuery(baseOptions?: Apollo.QueryHookOptions<CurrentPendingOrderPaymentIntentClientSecretQueryData, CurrentPendingOrderPaymentIntentClientSecretQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CurrentPendingOrderPaymentIntentClientSecretQueryData, CurrentPendingOrderPaymentIntentClientSecretQueryVariables>(CurrentPendingOrderPaymentIntentClientSecretQueryDocument, options);
       }
-export function useCurrentPendingOrderPaymentIntentClientSecretQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CurrentPendingOrderPaymentIntentClientSecretQueryQuery, CurrentPendingOrderPaymentIntentClientSecretQueryQueryVariables>) {
-          return Apollo.useLazyQuery<CurrentPendingOrderPaymentIntentClientSecretQueryQuery, CurrentPendingOrderPaymentIntentClientSecretQueryQueryVariables>(CurrentPendingOrderPaymentIntentClientSecretQueryDocument, baseOptions);
+export function useCurrentPendingOrderPaymentIntentClientSecretQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CurrentPendingOrderPaymentIntentClientSecretQueryData, CurrentPendingOrderPaymentIntentClientSecretQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CurrentPendingOrderPaymentIntentClientSecretQueryData, CurrentPendingOrderPaymentIntentClientSecretQueryVariables>(CurrentPendingOrderPaymentIntentClientSecretQueryDocument, options);
         }
-export type CurrentPendingOrderPaymentIntentClientSecretQueryQueryHookResult = ReturnType<typeof useCurrentPendingOrderPaymentIntentClientSecretQueryQuery>;
+export type CurrentPendingOrderPaymentIntentClientSecretQueryHookResult = ReturnType<typeof useCurrentPendingOrderPaymentIntentClientSecretQuery>;
 export type CurrentPendingOrderPaymentIntentClientSecretQueryLazyQueryHookResult = ReturnType<typeof useCurrentPendingOrderPaymentIntentClientSecretQueryLazyQuery>;
-export type CurrentPendingOrderPaymentIntentClientSecretQueryQueryResult = Apollo.QueryResult<CurrentPendingOrderPaymentIntentClientSecretQueryQuery, CurrentPendingOrderPaymentIntentClientSecretQueryQueryVariables>;
+export type CurrentPendingOrderPaymentIntentClientSecretQueryDataResult = Apollo.QueryResult<CurrentPendingOrderPaymentIntentClientSecretQueryData, CurrentPendingOrderPaymentIntentClientSecretQueryVariables>;

--- a/app/javascript/TicketTypeAdmin/EditTicketType.tsx
+++ b/app/javascript/TicketTypeAdmin/EditTicketType.tsx
@@ -7,12 +7,12 @@ import ErrorDisplay from '../ErrorDisplay';
 import TicketTypeForm from './TicketTypeForm';
 import useAsyncFunction from '../useAsyncFunction';
 import usePageTitle from '../usePageTitle';
-import { useAdminTicketTypesQueryQuery } from './queries.generated';
+import { useAdminTicketTypesQuery } from './queries.generated';
 import { useUpdateTicketTypeMutation } from './mutations.generated';
 import { LoadSingleValueFromCollectionWrapper } from '../GraphqlLoadingWrappers';
 
 export default LoadSingleValueFromCollectionWrapper(
-  useAdminTicketTypesQueryQuery,
+  useAdminTicketTypesQuery,
   (data, id) => data.convention.ticket_types.find((tt) => tt.id.toString() === id),
   function EditTicketTypeForm({
     value: initialTicketType,

--- a/app/javascript/TicketTypeAdmin/NewTicketType.tsx
+++ b/app/javascript/TicketTypeAdmin/NewTicketType.tsx
@@ -9,7 +9,7 @@ import TicketTypeForm, { EditingTicketType } from './TicketTypeForm';
 import useAsyncFunction from '../useAsyncFunction';
 import usePageTitle from '../usePageTitle';
 import { useCreateTicketTypeMutation } from './mutations.generated';
-import { AdminTicketTypesQueryQuery } from './queries.generated';
+import { AdminTicketTypesQueryData } from './queries.generated';
 
 export type NewTicketTypeProps = {
   ticketName: string;
@@ -32,7 +32,7 @@ function NewTicketType({ ticketName }: NewTicketTypeProps) {
 
   const [mutate] = useCreateTicketTypeMutation({
     update: (proxy, result) => {
-      const data = proxy.readQuery<AdminTicketTypesQueryQuery>({ query: AdminTicketTypesQuery });
+      const data = proxy.readQuery<AdminTicketTypesQueryData>({ query: AdminTicketTypesQuery });
       const newTicketType = result.data?.createTicketType?.ticket_type;
       if (!data || !newTicketType) {
         return;

--- a/app/javascript/TicketTypeAdmin/TicketTypesList.tsx
+++ b/app/javascript/TicketTypeAdmin/TicketTypesList.tsx
@@ -13,9 +13,9 @@ import usePageTitle from '../usePageTitle';
 import { describeAdminPricingStructure } from '../Store/describePricingStructure';
 import { useDeleteMutation } from '../MutationUtils';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { AdminTicketTypesQueryQuery, useAdminTicketTypesQueryQuery } from './queries.generated';
+import { AdminTicketTypesQueryData, useAdminTicketTypesQuery } from './queries.generated';
 
-type TicketTypeType = AdminTicketTypesQueryQuery['convention']['ticket_types'][0];
+type TicketTypeType = AdminTicketTypesQueryData['convention']['ticket_types'][0];
 
 function cardClassForTicketType(ticketType: TicketTypeType) {
   if (ticketType.providing_products.filter((product) => product.available).length > 0) {
@@ -45,97 +45,100 @@ function describeTicketTypeOptions(ticketType: TicketTypeType, ticketName: strin
   return null;
 }
 
-export default LoadQueryWrapper(useAdminTicketTypesQueryQuery, function TicketTypesList({
-  data: {
-    convention: { ticket_name: ticketName, ticket_types: ticketTypes },
-  },
-}) {
-  usePageTitle(`${capitalize(ticketName)} types`);
+export default LoadQueryWrapper(
+  useAdminTicketTypesQuery,
+  function TicketTypesList({
+    data: {
+      convention: { ticket_name: ticketName, ticket_types: ticketTypes },
+    },
+  }) {
+    usePageTitle(`${capitalize(ticketName)} types`);
 
-  const confirm = useConfirm();
-  const deleteTicketType = useDeleteMutation(DeleteTicketType, {
-    query: AdminTicketTypesQuery,
-    idVariablePath: ['input', 'id'],
-    arrayPath: ['convention', 'ticket_types'],
-  });
+    const confirm = useConfirm();
+    const deleteTicketType = useDeleteMutation(DeleteTicketType, {
+      query: AdminTicketTypesQuery,
+      idVariablePath: ['input', 'id'],
+      arrayPath: ['convention', 'ticket_types'],
+    });
 
-  const renderTicketTypeDisplay = (ticketType: TicketTypeType) => (
-    <div
-      className={`card my-4 overflow-hidden ${cardClassForTicketType(ticketType)}`}
-      key={ticketType.id}
-    >
-      <div className="card-header">
-        <div className="row">
-          <div className="col-md-8">
-            <strong>{ticketType.description}</strong>
-            <code> ({ticketType.name})</code>
+    const renderTicketTypeDisplay = (ticketType: TicketTypeType) => (
+      <div
+        className={`card my-4 overflow-hidden ${cardClassForTicketType(ticketType)}`}
+        key={ticketType.id}
+      >
+        <div className="card-header">
+          <div className="row">
+            <div className="col-md-8">
+              <strong>{ticketType.description}</strong>
+              <code> ({ticketType.name})</code>
+            </div>
+            <div className="col-md-4 text-right">
+              <button
+                type="button"
+                className="btn btn-danger btn-sm mx-1"
+                onClick={() =>
+                  confirm({
+                    prompt: `Are you sure you want to delete the ticket type “${ticketType.description}”?`,
+                    action: () => deleteTicketType({ variables: { input: { id: ticketType.id } } }),
+                    renderError: (error) => <ErrorDisplay graphQLError={error} />,
+                  })
+                }
+              >
+                <i className="fa fa-trash-o mr-1" />
+                Delete
+              </button>
+              <Link
+                to={`/ticket_types/${ticketType.id}/edit`}
+                className="btn btn-secondary btn-sm mx-1"
+              >
+                <i className="fa fa-pencil-square-o mr-1" />
+                Edit
+              </Link>
+            </div>
           </div>
-          <div className="col-md-4 text-right">
-            <button
-              type="button"
-              className="btn btn-danger btn-sm mx-1"
-              onClick={() =>
-                confirm({
-                  prompt: `Are you sure you want to delete the ticket type “${ticketType.description}”?`,
-                  action: () => deleteTicketType({ variables: { input: { id: ticketType.id } } }),
-                  renderError: (error) => <ErrorDisplay graphQLError={error} />,
-                })
-              }
-            >
-              <i className="fa fa-trash-o mr-1" />
-              Delete
-            </button>
-            <Link
-              to={`/ticket_types/${ticketType.id}/edit`}
-              className="btn btn-secondary btn-sm mx-1"
-            >
-              <i className="fa fa-pencil-square-o mr-1" />
-              Edit
-            </Link>
+
+          <div className="small font-italic">
+            {describeTicketTypeOptions(ticketType, ticketName)}
+            {!ticketType.counts_towards_convention_maximum && (
+              <div>Does not count towards convention maximum</div>
+            )}
+            {!ticketType.allows_event_signups && <div>Does not allow event signups</div>}
           </div>
         </div>
 
-        <div className="small font-italic">
-          {describeTicketTypeOptions(ticketType, ticketName)}
-          {!ticketType.counts_towards_convention_maximum && (
-            <div>Does not count towards convention maximum</div>
+        <div className="card-body bg-white text-body">
+          <p>
+            <strong>Providing products:</strong>
+          </p>
+          {ticketType.providing_products.length > 0 ? (
+            <ul className="list-unstyled mb-0">
+              {ticketType.providing_products.map((product) => (
+                <li key={product.id}>
+                  <Link to={`/admin_store/products#product-${product.id}`}>{product.name}</Link>{' '}
+                  {product.available ? '(available for purchase)' : '(not available for purchase)'}{' '}
+                  &mdash; {describeAdminPricingStructure(product.pricing_structure)}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            `No products provide this ${ticketName} type`
           )}
-          {!ticketType.allows_event_signups && <div>Does not allow event signups</div>}
         </div>
       </div>
+    );
 
-      <div className="card-body bg-white text-body">
-        <p>
-          <strong>Providing products:</strong>
-        </p>
-        {ticketType.providing_products.length > 0 ? (
-          <ul className="list-unstyled mb-0">
-            {ticketType.providing_products.map((product) => (
-              <li key={product.id}>
-                <Link to={`/admin_store/products#product-${product.id}`}>{product.name}</Link>{' '}
-                {product.available ? '(available for purchase)' : '(not available for purchase)'}{' '}
-                &mdash; {describeAdminPricingStructure(product.pricing_structure)}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          `No products provide this ${ticketName} type`
-        )}
+    const sortedTicketTypes = useMemo(() => sortTicketTypes(ticketTypes), [ticketTypes]);
+
+    return (
+      <div>
+        <h1 className="mb-4">{capitalize(ticketName)} types</h1>
+
+        {sortedTicketTypes.map(renderTicketTypeDisplay)}
+
+        <Link to="/ticket_types/new" className="btn btn-primary">
+          New {ticketName} type
+        </Link>
       </div>
-    </div>
-  );
-
-  const sortedTicketTypes = useMemo(() => sortTicketTypes(ticketTypes), [ticketTypes]);
-
-  return (
-    <div>
-      <h1 className="mb-4">{capitalize(ticketName)} types</h1>
-
-      {sortedTicketTypes.map(renderTicketTypeDisplay)}
-
-      <Link to="/ticket_types/new" className="btn btn-primary">
-        New {ticketName} type
-      </Link>
-    </div>
-  );
-});
+    );
+  },
+);

--- a/app/javascript/TicketTypeAdmin/index.tsx
+++ b/app/javascript/TicketTypeAdmin/index.tsx
@@ -5,9 +5,9 @@ import NewTicketType from './NewTicketType';
 import TicketTypesList from './TicketTypesList';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useAdminTicketTypesQueryQuery } from './queries.generated';
+import { useAdminTicketTypesQuery } from './queries.generated';
 
-export default LoadQueryWrapper(useAdminTicketTypesQueryQuery, function TicketTypeAdmin({ data }) {
+export default LoadQueryWrapper(useAdminTicketTypesQuery, function TicketTypeAdmin({ data }) {
   const authorizationWarning = useAuthorizationRequired('can_manage_ticket_types');
   if (authorizationWarning) return authorizationWarning;
 

--- a/app/javascript/TicketTypeAdmin/mutations.generated.ts
+++ b/app/javascript/TicketTypeAdmin/mutations.generated.ts
@@ -5,12 +5,13 @@ import { TicketTypeAdmin_TicketTypeFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { TicketTypeAdmin_TicketTypeFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateTicketTypeMutationVariables = Types.Exact<{
   input: Types.CreateTicketTypeInput;
 }>;
 
 
-export type CreateTicketTypeMutation = (
+export type CreateTicketTypeMutationData = (
   { __typename: 'Mutation' }
   & { createTicketType?: Types.Maybe<(
     { __typename: 'CreateTicketTypePayload' }
@@ -27,7 +28,7 @@ export type UpdateTicketTypeMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateTicketTypeMutation = (
+export type UpdateTicketTypeMutationData = (
   { __typename: 'Mutation' }
   & { updateTicketType?: Types.Maybe<(
     { __typename: 'UpdateTicketTypePayload' }
@@ -44,7 +45,7 @@ export type DeleteTicketTypeMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteTicketTypeMutation = (
+export type DeleteTicketTypeMutationData = (
   { __typename: 'Mutation' }
   & { deleteTicketType?: Types.Maybe<(
     { __typename: 'DeleteTicketTypePayload' }
@@ -66,7 +67,7 @@ export const CreateTicketTypeDocument = gql`
   }
 }
     ${TicketTypeAdmin_TicketTypeFieldsFragmentDoc}`;
-export type CreateTicketTypeMutationFn = Apollo.MutationFunction<CreateTicketTypeMutation, CreateTicketTypeMutationVariables>;
+export type CreateTicketTypeMutationFn = Apollo.MutationFunction<CreateTicketTypeMutationData, CreateTicketTypeMutationVariables>;
 
 /**
  * __useCreateTicketTypeMutation__
@@ -85,12 +86,13 @@ export type CreateTicketTypeMutationFn = Apollo.MutationFunction<CreateTicketTyp
  *   },
  * });
  */
-export function useCreateTicketTypeMutation(baseOptions?: Apollo.MutationHookOptions<CreateTicketTypeMutation, CreateTicketTypeMutationVariables>) {
-        return Apollo.useMutation<CreateTicketTypeMutation, CreateTicketTypeMutationVariables>(CreateTicketTypeDocument, baseOptions);
+export function useCreateTicketTypeMutation(baseOptions?: Apollo.MutationHookOptions<CreateTicketTypeMutationData, CreateTicketTypeMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateTicketTypeMutationData, CreateTicketTypeMutationVariables>(CreateTicketTypeDocument, options);
       }
 export type CreateTicketTypeMutationHookResult = ReturnType<typeof useCreateTicketTypeMutation>;
-export type CreateTicketTypeMutationResult = Apollo.MutationResult<CreateTicketTypeMutation>;
-export type CreateTicketTypeMutationOptions = Apollo.BaseMutationOptions<CreateTicketTypeMutation, CreateTicketTypeMutationVariables>;
+export type CreateTicketTypeMutationResult = Apollo.MutationResult<CreateTicketTypeMutationData>;
+export type CreateTicketTypeMutationOptions = Apollo.BaseMutationOptions<CreateTicketTypeMutationData, CreateTicketTypeMutationVariables>;
 export const UpdateTicketTypeDocument = gql`
     mutation UpdateTicketType($input: UpdateTicketTypeInput!) {
   updateTicketType(input: $input) {
@@ -101,7 +103,7 @@ export const UpdateTicketTypeDocument = gql`
   }
 }
     ${TicketTypeAdmin_TicketTypeFieldsFragmentDoc}`;
-export type UpdateTicketTypeMutationFn = Apollo.MutationFunction<UpdateTicketTypeMutation, UpdateTicketTypeMutationVariables>;
+export type UpdateTicketTypeMutationFn = Apollo.MutationFunction<UpdateTicketTypeMutationData, UpdateTicketTypeMutationVariables>;
 
 /**
  * __useUpdateTicketTypeMutation__
@@ -120,12 +122,13 @@ export type UpdateTicketTypeMutationFn = Apollo.MutationFunction<UpdateTicketTyp
  *   },
  * });
  */
-export function useUpdateTicketTypeMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTicketTypeMutation, UpdateTicketTypeMutationVariables>) {
-        return Apollo.useMutation<UpdateTicketTypeMutation, UpdateTicketTypeMutationVariables>(UpdateTicketTypeDocument, baseOptions);
+export function useUpdateTicketTypeMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTicketTypeMutationData, UpdateTicketTypeMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateTicketTypeMutationData, UpdateTicketTypeMutationVariables>(UpdateTicketTypeDocument, options);
       }
 export type UpdateTicketTypeMutationHookResult = ReturnType<typeof useUpdateTicketTypeMutation>;
-export type UpdateTicketTypeMutationResult = Apollo.MutationResult<UpdateTicketTypeMutation>;
-export type UpdateTicketTypeMutationOptions = Apollo.BaseMutationOptions<UpdateTicketTypeMutation, UpdateTicketTypeMutationVariables>;
+export type UpdateTicketTypeMutationResult = Apollo.MutationResult<UpdateTicketTypeMutationData>;
+export type UpdateTicketTypeMutationOptions = Apollo.BaseMutationOptions<UpdateTicketTypeMutationData, UpdateTicketTypeMutationVariables>;
 export const DeleteTicketTypeDocument = gql`
     mutation DeleteTicketType($input: DeleteTicketTypeInput!) {
   deleteTicketType(input: $input) {
@@ -135,7 +138,7 @@ export const DeleteTicketTypeDocument = gql`
   }
 }
     `;
-export type DeleteTicketTypeMutationFn = Apollo.MutationFunction<DeleteTicketTypeMutation, DeleteTicketTypeMutationVariables>;
+export type DeleteTicketTypeMutationFn = Apollo.MutationFunction<DeleteTicketTypeMutationData, DeleteTicketTypeMutationVariables>;
 
 /**
  * __useDeleteTicketTypeMutation__
@@ -154,9 +157,10 @@ export type DeleteTicketTypeMutationFn = Apollo.MutationFunction<DeleteTicketTyp
  *   },
  * });
  */
-export function useDeleteTicketTypeMutation(baseOptions?: Apollo.MutationHookOptions<DeleteTicketTypeMutation, DeleteTicketTypeMutationVariables>) {
-        return Apollo.useMutation<DeleteTicketTypeMutation, DeleteTicketTypeMutationVariables>(DeleteTicketTypeDocument, baseOptions);
+export function useDeleteTicketTypeMutation(baseOptions?: Apollo.MutationHookOptions<DeleteTicketTypeMutationData, DeleteTicketTypeMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteTicketTypeMutationData, DeleteTicketTypeMutationVariables>(DeleteTicketTypeDocument, options);
       }
 export type DeleteTicketTypeMutationHookResult = ReturnType<typeof useDeleteTicketTypeMutation>;
-export type DeleteTicketTypeMutationResult = Apollo.MutationResult<DeleteTicketTypeMutation>;
-export type DeleteTicketTypeMutationOptions = Apollo.BaseMutationOptions<DeleteTicketTypeMutation, DeleteTicketTypeMutationVariables>;
+export type DeleteTicketTypeMutationResult = Apollo.MutationResult<DeleteTicketTypeMutationData>;
+export type DeleteTicketTypeMutationOptions = Apollo.BaseMutationOptions<DeleteTicketTypeMutationData, DeleteTicketTypeMutationVariables>;

--- a/app/javascript/TicketTypeAdmin/queries.generated.ts
+++ b/app/javascript/TicketTypeAdmin/queries.generated.ts
@@ -5,6 +5,7 @@ import { PricingStructureFieldsFragment } from '../Store/pricingStructureFields.
 import { gql } from '@apollo/client';
 import { PricingStructureFieldsFragmentDoc } from '../Store/pricingStructureFields.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type TicketTypeAdmin_TicketTypeFieldsFragment = (
   { __typename: 'TicketType' }
   & Pick<Types.TicketType, 'id' | 'name' | 'description' | 'counts_towards_convention_maximum' | 'allows_event_signups' | 'maximum_event_provided_tickets'>
@@ -18,10 +19,10 @@ export type TicketTypeAdmin_TicketTypeFieldsFragment = (
   )> }
 );
 
-export type AdminTicketTypesQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type AdminTicketTypesQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type AdminTicketTypesQueryQuery = (
+export type AdminTicketTypesQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -67,26 +68,28 @@ export const AdminTicketTypesQueryDocument = gql`
     ${TicketTypeAdmin_TicketTypeFieldsFragmentDoc}`;
 
 /**
- * __useAdminTicketTypesQueryQuery__
+ * __useAdminTicketTypesQuery__
  *
- * To run a query within a React component, call `useAdminTicketTypesQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useAdminTicketTypesQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAdminTicketTypesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAdminTicketTypesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useAdminTicketTypesQueryQuery({
+ * const { data, loading, error } = useAdminTicketTypesQuery({
  *   variables: {
  *   },
  * });
  */
-export function useAdminTicketTypesQueryQuery(baseOptions?: Apollo.QueryHookOptions<AdminTicketTypesQueryQuery, AdminTicketTypesQueryQueryVariables>) {
-        return Apollo.useQuery<AdminTicketTypesQueryQuery, AdminTicketTypesQueryQueryVariables>(AdminTicketTypesQueryDocument, baseOptions);
+export function useAdminTicketTypesQuery(baseOptions?: Apollo.QueryHookOptions<AdminTicketTypesQueryData, AdminTicketTypesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AdminTicketTypesQueryData, AdminTicketTypesQueryVariables>(AdminTicketTypesQueryDocument, options);
       }
-export function useAdminTicketTypesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminTicketTypesQueryQuery, AdminTicketTypesQueryQueryVariables>) {
-          return Apollo.useLazyQuery<AdminTicketTypesQueryQuery, AdminTicketTypesQueryQueryVariables>(AdminTicketTypesQueryDocument, baseOptions);
+export function useAdminTicketTypesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AdminTicketTypesQueryData, AdminTicketTypesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AdminTicketTypesQueryData, AdminTicketTypesQueryVariables>(AdminTicketTypesQueryDocument, options);
         }
-export type AdminTicketTypesQueryQueryHookResult = ReturnType<typeof useAdminTicketTypesQueryQuery>;
+export type AdminTicketTypesQueryHookResult = ReturnType<typeof useAdminTicketTypesQuery>;
 export type AdminTicketTypesQueryLazyQueryHookResult = ReturnType<typeof useAdminTicketTypesQueryLazyQuery>;
-export type AdminTicketTypesQueryQueryResult = Apollo.QueryResult<AdminTicketTypesQueryQuery, AdminTicketTypesQueryQueryVariables>;
+export type AdminTicketTypesQueryDataResult = Apollo.QueryResult<AdminTicketTypesQueryData, AdminTicketTypesQueryVariables>;

--- a/app/javascript/UserActivityAlerts/EditUserActivityAlert.tsx
+++ b/app/javascript/UserActivityAlerts/EditUserActivityAlert.tsx
@@ -12,104 +12,105 @@ import UserActivityAlertForm from './UserActivityAlertForm';
 import useAsyncFunction from '../useAsyncFunction';
 import { useDeleteMutation } from '../MutationUtils';
 import usePageTitle from '../usePageTitle';
-import { useUserActivityAlertQueryQuery } from './queries.generated';
+import { useUserActivityAlertQuery } from './queries.generated';
 import { useUpdateUserActivityAlertMutation } from './mutations.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 
 function useLoadUserActivityAlert() {
   const userActivityAlertId = Number.parseInt(useParams<{ id: string }>().id, 10);
-  return useUserActivityAlertQueryQuery({ variables: { id: userActivityAlertId } });
+  return useUserActivityAlertQuery({ variables: { id: userActivityAlertId } });
 }
 
-export default LoadQueryWrapper(useLoadUserActivityAlert, function EditUserActivityAlertForm({
-  data,
-}) {
-  usePageTitle('Editing user activity alert');
-  const history = useHistory();
-  const [userActivityAlert, setUserActivityAlert] = useState(data.convention.user_activity_alert);
-  const [
-    notificationDestinationChangeSet,
-    addNotificationDestination,
-    removeNotificationDestination,
-  ] = useChangeSet<typeof userActivityAlert['notification_destinations'][0]>();
-  const [updateMutate] = useUpdateUserActivityAlertMutation();
-  const [update, updateError, updateInProgress] = useAsyncFunction(updateMutate);
-  const deleteMutate = useDeleteMutation(DeleteUserActivityAlert, {
-    query: UserActivityAlertsAdminQuery,
-    arrayPath: ['convention', 'user_activity_alerts'],
-    idVariablePath: ['id'],
-  });
-  const combinedUserActivityAlert = useMemo(
-    () => ({
-      ...userActivityAlert,
-      notification_destinations: notificationDestinationChangeSet.apply(
-        userActivityAlert.notification_destinations,
-      ),
-    }),
-    [notificationDestinationChangeSet, userActivityAlert],
-  );
-  const confirm = useConfirm();
-
-  const saveClicked = async () => {
-    await update({
-      variables: {
-        id: userActivityAlert.id,
-        userActivityAlert: buildUserActivityAlertInput(userActivityAlert),
-        addNotificationDestinations: notificationDestinationChangeSet
-          .getAddValues()
-          .map((addValue) => {
-            if (addValue.staff_position) {
-              return { staff_position_id: addValue.staff_position.id };
-            }
-            return { user_con_profile_id: addValue.user_con_profile!.id };
-          }),
-        removeNotificationDestinationIds: notificationDestinationChangeSet.getRemoveIds(),
-      },
+export default LoadQueryWrapper(
+  useLoadUserActivityAlert,
+  function EditUserActivityAlertForm({ data }) {
+    usePageTitle('Editing user activity alert');
+    const history = useHistory();
+    const [userActivityAlert, setUserActivityAlert] = useState(data.convention.user_activity_alert);
+    const [
+      notificationDestinationChangeSet,
+      addNotificationDestination,
+      removeNotificationDestination,
+    ] = useChangeSet<typeof userActivityAlert['notification_destinations'][0]>();
+    const [updateMutate] = useUpdateUserActivityAlertMutation();
+    const [update, updateError, updateInProgress] = useAsyncFunction(updateMutate);
+    const deleteMutate = useDeleteMutation(DeleteUserActivityAlert, {
+      query: UserActivityAlertsAdminQuery,
+      arrayPath: ['convention', 'user_activity_alerts'],
+      idVariablePath: ['id'],
     });
+    const combinedUserActivityAlert = useMemo(
+      () => ({
+        ...userActivityAlert,
+        notification_destinations: notificationDestinationChangeSet.apply(
+          userActivityAlert.notification_destinations,
+        ),
+      }),
+      [notificationDestinationChangeSet, userActivityAlert],
+    );
+    const confirm = useConfirm();
 
-    history.push('/user_activity_alerts');
-  };
+    const saveClicked = async () => {
+      await update({
+        variables: {
+          id: userActivityAlert.id,
+          userActivityAlert: buildUserActivityAlertInput(userActivityAlert),
+          addNotificationDestinations: notificationDestinationChangeSet
+            .getAddValues()
+            .map((addValue) => {
+              if (addValue.staff_position) {
+                return { staff_position_id: addValue.staff_position.id };
+              }
+              return { user_con_profile_id: addValue.user_con_profile!.id };
+            }),
+          removeNotificationDestinationIds: notificationDestinationChangeSet.getRemoveIds(),
+        },
+      });
 
-  const deleteClicked = async () => {
-    await deleteMutate({ variables: { id: userActivityAlert.id } });
-    history.push('/');
-  };
+      history.push('/user_activity_alerts');
+    };
 
-  return (
-    <>
-      .{' '}
-      <div className="d-flex align-items-start mb-4">
-        <h1 className="flex-grow-1">Edit user activity alert</h1>
+    const deleteClicked = async () => {
+      await deleteMutate({ variables: { id: userActivityAlert.id } });
+      history.push('/');
+    };
+
+    return (
+      <>
+        .{' '}
+        <div className="d-flex align-items-start mb-4">
+          <h1 className="flex-grow-1">Edit user activity alert</h1>
+          <button
+            className="btn btn-danger"
+            type="button"
+            onClick={() => {
+              confirm({
+                action: deleteClicked,
+                prompt: 'Are you sure you want to delete this alert?',
+              });
+            }}
+          >
+            <i className="fa fa-trash-o" /> Delete
+          </button>
+        </div>
+        <UserActivityAlertForm
+          userActivityAlert={combinedUserActivityAlert}
+          convention={data.convention}
+          onChange={setUserActivityAlert}
+          onAddNotificationDestination={addNotificationDestination}
+          onRemoveNotificationDestination={removeNotificationDestination}
+          disabled={updateInProgress}
+        />
+        <ErrorDisplay graphQLError={updateError as ApolloError} />
         <button
-          className="btn btn-danger"
+          className="btn btn-primary mt-4"
           type="button"
-          onClick={() => {
-            confirm({
-              action: deleteClicked,
-              prompt: 'Are you sure you want to delete this alert?',
-            });
-          }}
+          onClick={saveClicked}
+          disabled={updateInProgress}
         >
-          <i className="fa fa-trash-o" /> Delete
+          Save changes
         </button>
-      </div>
-      <UserActivityAlertForm
-        userActivityAlert={combinedUserActivityAlert}
-        convention={data.convention}
-        onChange={setUserActivityAlert}
-        onAddNotificationDestination={addNotificationDestination}
-        onRemoveNotificationDestination={removeNotificationDestination}
-        disabled={updateInProgress}
-      />
-      <ErrorDisplay graphQLError={updateError as ApolloError} />
-      <button
-        className="btn btn-primary mt-4"
-        type="button"
-        onClick={saveClicked}
-        disabled={updateInProgress}
-      >
-        Save changes
-      </button>
-    </>
-  );
-});
+      </>
+    );
+  },
+);

--- a/app/javascript/UserActivityAlerts/NewUserActivityAlert.tsx
+++ b/app/javascript/UserActivityAlerts/NewUserActivityAlert.tsx
@@ -11,95 +11,93 @@ import UserActivityAlertForm from './UserActivityAlertForm';
 import { useCreateMutation } from '../MutationUtils';
 import useAsyncFunction from '../useAsyncFunction';
 import usePageTitle from '../usePageTitle';
-import {
-  useConventionTicketNameQueryQuery,
-  UserActivityAlertQueryQuery,
-} from './queries.generated';
+import { useConventionTicketNameQuery, UserActivityAlertQueryData } from './queries.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 
-export default LoadQueryWrapper(useConventionTicketNameQueryQuery, function NewUserActivityAlert({
-  data,
-}) {
-  const history = useHistory();
-  usePageTitle('New user activity alert');
+export default LoadQueryWrapper(
+  useConventionTicketNameQuery,
+  function NewUserActivityAlert({ data }) {
+    const history = useHistory();
+    usePageTitle('New user activity alert');
 
-  const [userActivityAlert, setUserActivityAlert] = useState<
-    UserActivityAlertQueryQuery['convention']['user_activity_alert']
-  >({
-    __typename: 'UserActivityAlert',
-    id: 0,
-    email: null,
-    partial_name: null,
-    user: null,
-    trigger_on_ticket_create: true,
-    trigger_on_user_con_profile_create: true,
-    notification_destinations: [],
-  });
-  const [
-    notificationDestinationChangeSet,
-    addNotificationDestination,
-    removeNotificationDestination,
-  ] = useChangeSet<
-    UserActivityAlertQueryQuery['convention']['user_activity_alert']['notification_destinations'][number]
-  >();
-  const [create, createError, createInProgress] = useAsyncFunction(
-    useCreateMutation(CreateUserActivityAlert, {
-      query: UserActivityAlertsAdminQuery,
-      arrayPath: ['convention', 'user_activity_alerts'],
-      newObjectPath: ['createUserActivityAlert', 'user_activity_alert'],
-    }),
-  );
-  const combinedUserActivityAlert = useMemo(
-    () => ({
-      ...userActivityAlert,
-      notification_destinations: notificationDestinationChangeSet.apply(
-        userActivityAlert.notification_destinations,
-      ),
-    }),
-    [notificationDestinationChangeSet, userActivityAlert],
-  );
-
-  const saveClicked = async () => {
-    await create({
-      variables: {
-        userActivityAlert: buildUserActivityAlertInput(userActivityAlert),
-        notificationDestinations: notificationDestinationChangeSet
-          .getAddValues()
-          .map((addValue) => {
-            if (addValue.staff_position) {
-              return { staff_position_id: addValue.staff_position.id };
-            }
-            return { user_con_profile_id: addValue.user_con_profile!.id };
-          }),
-      },
+    const [userActivityAlert, setUserActivityAlert] = useState<
+      UserActivityAlertQueryData['convention']['user_activity_alert']
+    >({
+      __typename: 'UserActivityAlert',
+      id: 0,
+      email: null,
+      partial_name: null,
+      user: null,
+      trigger_on_ticket_create: true,
+      trigger_on_user_con_profile_create: true,
+      notification_destinations: [],
     });
+    const [
+      notificationDestinationChangeSet,
+      addNotificationDestination,
+      removeNotificationDestination,
+    ] = useChangeSet<
+      UserActivityAlertQueryData['convention']['user_activity_alert']['notification_destinations'][number]
+    >();
+    const [create, createError, createInProgress] = useAsyncFunction(
+      useCreateMutation(CreateUserActivityAlert, {
+        query: UserActivityAlertsAdminQuery,
+        arrayPath: ['convention', 'user_activity_alerts'],
+        newObjectPath: ['createUserActivityAlert', 'user_activity_alert'],
+      }),
+    );
+    const combinedUserActivityAlert = useMemo(
+      () => ({
+        ...userActivityAlert,
+        notification_destinations: notificationDestinationChangeSet.apply(
+          userActivityAlert.notification_destinations,
+        ),
+      }),
+      [notificationDestinationChangeSet, userActivityAlert],
+    );
 
-    history.push('/user_activity_alerts');
-  };
+    const saveClicked = async () => {
+      await create({
+        variables: {
+          userActivityAlert: buildUserActivityAlertInput(userActivityAlert),
+          notificationDestinations: notificationDestinationChangeSet
+            .getAddValues()
+            .map((addValue) => {
+              if (addValue.staff_position) {
+                return { staff_position_id: addValue.staff_position.id };
+              }
+              return { user_con_profile_id: addValue.user_con_profile!.id };
+            }),
+        },
+      });
 
-  return (
-    <>
-      <h1 className="mb-4">New user activity alert</h1>
+      history.push('/user_activity_alerts');
+    };
 
-      <UserActivityAlertForm
-        userActivityAlert={combinedUserActivityAlert}
-        convention={data.convention}
-        onChange={setUserActivityAlert}
-        onAddNotificationDestination={addNotificationDestination}
-        onRemoveNotificationDestination={removeNotificationDestination}
-        disabled={createInProgress}
-      />
+    return (
+      <>
+        <h1 className="mb-4">New user activity alert</h1>
 
-      <ErrorDisplay graphQLError={createError as ApolloError} />
+        <UserActivityAlertForm
+          userActivityAlert={combinedUserActivityAlert}
+          convention={data.convention}
+          onChange={setUserActivityAlert}
+          onAddNotificationDestination={addNotificationDestination}
+          onRemoveNotificationDestination={removeNotificationDestination}
+          disabled={createInProgress}
+        />
 
-      <button
-        className="btn btn-primary mt-4"
-        type="button"
-        onClick={saveClicked}
-        disabled={createInProgress}
-      >
-        Create user activity alert
-      </button>
-    </>
-  );
-});
+        <ErrorDisplay graphQLError={createError as ApolloError} />
+
+        <button
+          className="btn btn-primary mt-4"
+          type="button"
+          onClick={saveClicked}
+          disabled={createInProgress}
+        >
+          Create user activity alert
+        </button>
+      </>
+    );
+  },
+);

--- a/app/javascript/UserActivityAlerts/UserActivityAlertForm.tsx
+++ b/app/javascript/UserActivityAlerts/UserActivityAlertForm.tsx
@@ -10,14 +10,14 @@ import UserConProfileSelect from '../BuiltInFormControls/UserConProfileSelect';
 import UserSelect from '../BuiltInFormControls/UserSelect';
 import useUniqueId from '../useUniqueId';
 import { usePropertySetters } from '../usePropertySetters';
-import { DefaultUserConProfilesQueryQuery } from '../BuiltInFormControls/selectDefaultQueries.generated';
-import { UserActivityAlertQueryQuery } from './queries.generated';
+import { DefaultUserConProfilesQueryData } from '../BuiltInFormControls/selectDefaultQueries.generated';
+import { UserActivityAlertQueryData } from './queries.generated';
 
-type AlertType = UserActivityAlertQueryQuery['convention']['user_activity_alert'];
+type AlertType = UserActivityAlertQueryData['convention']['user_activity_alert'];
 
 export type UserActivityAlertFormProps = {
   convention: Pick<
-    UserActivityAlertQueryQuery['convention'],
+    UserActivityAlertQueryData['convention'],
     'ticket_name' | 'ticket_mode' | 'staff_positions'
   >;
   disabled?: boolean;
@@ -50,7 +50,7 @@ function UserActivityAlertForm({
 
   const addUserConProfileDestination = (
     userConProfile: NonNullable<
-      DefaultUserConProfilesQueryQuery['convention']
+      DefaultUserConProfilesQueryData['convention']
     >['user_con_profiles_paginated']['entries'][0],
   ) => {
     onAddNotificationDestination({

--- a/app/javascript/UserActivityAlerts/UserActivityAlertsList.tsx
+++ b/app/javascript/UserActivityAlerts/UserActivityAlertsList.tsx
@@ -4,8 +4,8 @@ import { Link } from 'react-router-dom';
 
 import usePageTitle from '../usePageTitle';
 import {
-  UserActivityAlertsAdminQueryQuery,
-  useUserActivityAlertsAdminQueryQuery,
+  UserActivityAlertsAdminQueryData,
+  useUserActivityAlertsAdminQuery,
 } from './queries.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 
@@ -18,7 +18,7 @@ function renderCriteriaList(criteria: React.ReactNode[], defaultText: React.Reac
 }
 
 function renderAlertMatches(
-  userActivityAlert: UserActivityAlertsAdminQueryQuery['convention']['user_activity_alerts'][number],
+  userActivityAlert: UserActivityAlertsAdminQueryData['convention']['user_activity_alerts'][number],
 ) {
   const matches = [];
 
@@ -50,8 +50,8 @@ function renderAlertMatches(
 }
 
 function renderAlertTriggers(
-  convention: UserActivityAlertsAdminQueryQuery['convention'],
-  userActivityAlert: UserActivityAlertsAdminQueryQuery['convention']['user_activity_alerts'][number],
+  convention: UserActivityAlertsAdminQueryData['convention'],
+  userActivityAlert: UserActivityAlertsAdminQueryData['convention']['user_activity_alerts'][number],
 ) {
   const triggers = [];
 
@@ -67,7 +67,7 @@ function renderAlertTriggers(
 }
 
 function renderAlertNotificationDestinations(
-  userActivityAlert: UserActivityAlertsAdminQueryQuery['convention']['user_activity_alerts'][number],
+  userActivityAlert: UserActivityAlertsAdminQueryData['convention']['user_activity_alerts'][number],
 ) {
   const destinations = userActivityAlert.notification_destinations.map((destination) => {
     if (destination.staff_position) {
@@ -89,7 +89,7 @@ function renderAlertNotificationDestinations(
 }
 
 export default LoadQueryWrapper(
-  useUserActivityAlertsAdminQueryQuery,
+  useUserActivityAlertsAdminQuery,
   function UserActivityAlertsList({ data }) {
     usePageTitle('User activity alerts');
 

--- a/app/javascript/UserActivityAlerts/mutations.generated.ts
+++ b/app/javascript/UserActivityAlerts/mutations.generated.ts
@@ -5,13 +5,14 @@ import { UserActivityAlertFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { UserActivityAlertFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateUserActivityAlertMutationVariables = Types.Exact<{
   userActivityAlert: Types.UserActivityAlertInput;
   notificationDestinations: Array<Types.NotificationDestinationInput> | Types.NotificationDestinationInput;
 }>;
 
 
-export type CreateUserActivityAlertMutation = (
+export type CreateUserActivityAlertMutationData = (
   { __typename: 'Mutation' }
   & { createUserActivityAlert?: Types.Maybe<(
     { __typename: 'CreateUserActivityAlertPayload' }
@@ -31,7 +32,7 @@ export type UpdateUserActivityAlertMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateUserActivityAlertMutation = (
+export type UpdateUserActivityAlertMutationData = (
   { __typename: 'Mutation' }
   & { updateUserActivityAlert?: Types.Maybe<(
     { __typename: 'UpdateUserActivityAlertPayload' }
@@ -48,7 +49,7 @@ export type DeleteUserActivityAlertMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteUserActivityAlertMutation = (
+export type DeleteUserActivityAlertMutationData = (
   { __typename: 'Mutation' }
   & { deleteUserActivityAlert?: Types.Maybe<(
     { __typename: 'DeleteUserActivityAlertPayload' }
@@ -73,7 +74,7 @@ export const CreateUserActivityAlertDocument = gql`
   }
 }
     ${UserActivityAlertFieldsFragmentDoc}`;
-export type CreateUserActivityAlertMutationFn = Apollo.MutationFunction<CreateUserActivityAlertMutation, CreateUserActivityAlertMutationVariables>;
+export type CreateUserActivityAlertMutationFn = Apollo.MutationFunction<CreateUserActivityAlertMutationData, CreateUserActivityAlertMutationVariables>;
 
 /**
  * __useCreateUserActivityAlertMutation__
@@ -93,12 +94,13 @@ export type CreateUserActivityAlertMutationFn = Apollo.MutationFunction<CreateUs
  *   },
  * });
  */
-export function useCreateUserActivityAlertMutation(baseOptions?: Apollo.MutationHookOptions<CreateUserActivityAlertMutation, CreateUserActivityAlertMutationVariables>) {
-        return Apollo.useMutation<CreateUserActivityAlertMutation, CreateUserActivityAlertMutationVariables>(CreateUserActivityAlertDocument, baseOptions);
+export function useCreateUserActivityAlertMutation(baseOptions?: Apollo.MutationHookOptions<CreateUserActivityAlertMutationData, CreateUserActivityAlertMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateUserActivityAlertMutationData, CreateUserActivityAlertMutationVariables>(CreateUserActivityAlertDocument, options);
       }
 export type CreateUserActivityAlertMutationHookResult = ReturnType<typeof useCreateUserActivityAlertMutation>;
-export type CreateUserActivityAlertMutationResult = Apollo.MutationResult<CreateUserActivityAlertMutation>;
-export type CreateUserActivityAlertMutationOptions = Apollo.BaseMutationOptions<CreateUserActivityAlertMutation, CreateUserActivityAlertMutationVariables>;
+export type CreateUserActivityAlertMutationResult = Apollo.MutationResult<CreateUserActivityAlertMutationData>;
+export type CreateUserActivityAlertMutationOptions = Apollo.BaseMutationOptions<CreateUserActivityAlertMutationData, CreateUserActivityAlertMutationVariables>;
 export const UpdateUserActivityAlertDocument = gql`
     mutation UpdateUserActivityAlert($id: Int!, $userActivityAlert: UserActivityAlertInput!, $addNotificationDestinations: [NotificationDestinationInput!]!, $removeNotificationDestinationIds: [Int!]!) {
   updateUserActivityAlert(
@@ -111,7 +113,7 @@ export const UpdateUserActivityAlertDocument = gql`
   }
 }
     ${UserActivityAlertFieldsFragmentDoc}`;
-export type UpdateUserActivityAlertMutationFn = Apollo.MutationFunction<UpdateUserActivityAlertMutation, UpdateUserActivityAlertMutationVariables>;
+export type UpdateUserActivityAlertMutationFn = Apollo.MutationFunction<UpdateUserActivityAlertMutationData, UpdateUserActivityAlertMutationVariables>;
 
 /**
  * __useUpdateUserActivityAlertMutation__
@@ -133,12 +135,13 @@ export type UpdateUserActivityAlertMutationFn = Apollo.MutationFunction<UpdateUs
  *   },
  * });
  */
-export function useUpdateUserActivityAlertMutation(baseOptions?: Apollo.MutationHookOptions<UpdateUserActivityAlertMutation, UpdateUserActivityAlertMutationVariables>) {
-        return Apollo.useMutation<UpdateUserActivityAlertMutation, UpdateUserActivityAlertMutationVariables>(UpdateUserActivityAlertDocument, baseOptions);
+export function useUpdateUserActivityAlertMutation(baseOptions?: Apollo.MutationHookOptions<UpdateUserActivityAlertMutationData, UpdateUserActivityAlertMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateUserActivityAlertMutationData, UpdateUserActivityAlertMutationVariables>(UpdateUserActivityAlertDocument, options);
       }
 export type UpdateUserActivityAlertMutationHookResult = ReturnType<typeof useUpdateUserActivityAlertMutation>;
-export type UpdateUserActivityAlertMutationResult = Apollo.MutationResult<UpdateUserActivityAlertMutation>;
-export type UpdateUserActivityAlertMutationOptions = Apollo.BaseMutationOptions<UpdateUserActivityAlertMutation, UpdateUserActivityAlertMutationVariables>;
+export type UpdateUserActivityAlertMutationResult = Apollo.MutationResult<UpdateUserActivityAlertMutationData>;
+export type UpdateUserActivityAlertMutationOptions = Apollo.BaseMutationOptions<UpdateUserActivityAlertMutationData, UpdateUserActivityAlertMutationVariables>;
 export const DeleteUserActivityAlertDocument = gql`
     mutation DeleteUserActivityAlert($id: Int!) {
   deleteUserActivityAlert(input: {id: $id}) {
@@ -149,7 +152,7 @@ export const DeleteUserActivityAlertDocument = gql`
   }
 }
     ${UserActivityAlertFieldsFragmentDoc}`;
-export type DeleteUserActivityAlertMutationFn = Apollo.MutationFunction<DeleteUserActivityAlertMutation, DeleteUserActivityAlertMutationVariables>;
+export type DeleteUserActivityAlertMutationFn = Apollo.MutationFunction<DeleteUserActivityAlertMutationData, DeleteUserActivityAlertMutationVariables>;
 
 /**
  * __useDeleteUserActivityAlertMutation__
@@ -168,9 +171,10 @@ export type DeleteUserActivityAlertMutationFn = Apollo.MutationFunction<DeleteUs
  *   },
  * });
  */
-export function useDeleteUserActivityAlertMutation(baseOptions?: Apollo.MutationHookOptions<DeleteUserActivityAlertMutation, DeleteUserActivityAlertMutationVariables>) {
-        return Apollo.useMutation<DeleteUserActivityAlertMutation, DeleteUserActivityAlertMutationVariables>(DeleteUserActivityAlertDocument, baseOptions);
+export function useDeleteUserActivityAlertMutation(baseOptions?: Apollo.MutationHookOptions<DeleteUserActivityAlertMutationData, DeleteUserActivityAlertMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteUserActivityAlertMutationData, DeleteUserActivityAlertMutationVariables>(DeleteUserActivityAlertDocument, options);
       }
 export type DeleteUserActivityAlertMutationHookResult = ReturnType<typeof useDeleteUserActivityAlertMutation>;
-export type DeleteUserActivityAlertMutationResult = Apollo.MutationResult<DeleteUserActivityAlertMutation>;
-export type DeleteUserActivityAlertMutationOptions = Apollo.BaseMutationOptions<DeleteUserActivityAlertMutation, DeleteUserActivityAlertMutationVariables>;
+export type DeleteUserActivityAlertMutationResult = Apollo.MutationResult<DeleteUserActivityAlertMutationData>;
+export type DeleteUserActivityAlertMutationOptions = Apollo.BaseMutationOptions<DeleteUserActivityAlertMutationData, DeleteUserActivityAlertMutationVariables>;

--- a/app/javascript/UserActivityAlerts/queries.generated.ts
+++ b/app/javascript/UserActivityAlerts/queries.generated.ts
@@ -3,6 +3,7 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type UserActivityAlertsAdminConventionFieldsFragment = (
   { __typename: 'Convention' }
   & Pick<Types.Convention, 'id' | 'ticket_name' | 'ticket_mode'>
@@ -31,10 +32,10 @@ export type UserActivityAlertFieldsFragment = (
   )> }
 );
 
-export type ConventionTicketNameQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type ConventionTicketNameQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type ConventionTicketNameQueryQuery = (
+export type ConventionTicketNameQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -43,12 +44,12 @@ export type ConventionTicketNameQueryQuery = (
   ) }
 );
 
-export type UserActivityAlertQueryQueryVariables = Types.Exact<{
+export type UserActivityAlertQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type UserActivityAlertQueryQuery = (
+export type UserActivityAlertQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -62,10 +63,10 @@ export type UserActivityAlertQueryQuery = (
   ) }
 );
 
-export type UserActivityAlertsAdminQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type UserActivityAlertsAdminQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type UserActivityAlertsAdminQueryQuery = (
+export type UserActivityAlertsAdminQueryData = (
   { __typename: 'Query' }
   & { convention: (
     { __typename: 'Convention' }
@@ -123,29 +124,31 @@ export const ConventionTicketNameQueryDocument = gql`
     ${UserActivityAlertsAdminConventionFieldsFragmentDoc}`;
 
 /**
- * __useConventionTicketNameQueryQuery__
+ * __useConventionTicketNameQuery__
  *
- * To run a query within a React component, call `useConventionTicketNameQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useConventionTicketNameQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useConventionTicketNameQuery` and pass it any options that fit your needs.
+ * When your component renders, `useConventionTicketNameQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useConventionTicketNameQueryQuery({
+ * const { data, loading, error } = useConventionTicketNameQuery({
  *   variables: {
  *   },
  * });
  */
-export function useConventionTicketNameQueryQuery(baseOptions?: Apollo.QueryHookOptions<ConventionTicketNameQueryQuery, ConventionTicketNameQueryQueryVariables>) {
-        return Apollo.useQuery<ConventionTicketNameQueryQuery, ConventionTicketNameQueryQueryVariables>(ConventionTicketNameQueryDocument, baseOptions);
+export function useConventionTicketNameQuery(baseOptions?: Apollo.QueryHookOptions<ConventionTicketNameQueryData, ConventionTicketNameQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ConventionTicketNameQueryData, ConventionTicketNameQueryVariables>(ConventionTicketNameQueryDocument, options);
       }
-export function useConventionTicketNameQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ConventionTicketNameQueryQuery, ConventionTicketNameQueryQueryVariables>) {
-          return Apollo.useLazyQuery<ConventionTicketNameQueryQuery, ConventionTicketNameQueryQueryVariables>(ConventionTicketNameQueryDocument, baseOptions);
+export function useConventionTicketNameQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ConventionTicketNameQueryData, ConventionTicketNameQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ConventionTicketNameQueryData, ConventionTicketNameQueryVariables>(ConventionTicketNameQueryDocument, options);
         }
-export type ConventionTicketNameQueryQueryHookResult = ReturnType<typeof useConventionTicketNameQueryQuery>;
+export type ConventionTicketNameQueryHookResult = ReturnType<typeof useConventionTicketNameQuery>;
 export type ConventionTicketNameQueryLazyQueryHookResult = ReturnType<typeof useConventionTicketNameQueryLazyQuery>;
-export type ConventionTicketNameQueryQueryResult = Apollo.QueryResult<ConventionTicketNameQueryQuery, ConventionTicketNameQueryQueryVariables>;
+export type ConventionTicketNameQueryDataResult = Apollo.QueryResult<ConventionTicketNameQueryData, ConventionTicketNameQueryVariables>;
 export const UserActivityAlertQueryDocument = gql`
     query UserActivityAlertQuery($id: Int!) {
   convention: assertConvention {
@@ -161,30 +164,32 @@ export const UserActivityAlertQueryDocument = gql`
 ${UserActivityAlertFieldsFragmentDoc}`;
 
 /**
- * __useUserActivityAlertQueryQuery__
+ * __useUserActivityAlertQuery__
  *
- * To run a query within a React component, call `useUserActivityAlertQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useUserActivityAlertQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useUserActivityAlertQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUserActivityAlertQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useUserActivityAlertQueryQuery({
+ * const { data, loading, error } = useUserActivityAlertQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useUserActivityAlertQueryQuery(baseOptions: Apollo.QueryHookOptions<UserActivityAlertQueryQuery, UserActivityAlertQueryQueryVariables>) {
-        return Apollo.useQuery<UserActivityAlertQueryQuery, UserActivityAlertQueryQueryVariables>(UserActivityAlertQueryDocument, baseOptions);
+export function useUserActivityAlertQuery(baseOptions: Apollo.QueryHookOptions<UserActivityAlertQueryData, UserActivityAlertQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<UserActivityAlertQueryData, UserActivityAlertQueryVariables>(UserActivityAlertQueryDocument, options);
       }
-export function useUserActivityAlertQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserActivityAlertQueryQuery, UserActivityAlertQueryQueryVariables>) {
-          return Apollo.useLazyQuery<UserActivityAlertQueryQuery, UserActivityAlertQueryQueryVariables>(UserActivityAlertQueryDocument, baseOptions);
+export function useUserActivityAlertQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserActivityAlertQueryData, UserActivityAlertQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<UserActivityAlertQueryData, UserActivityAlertQueryVariables>(UserActivityAlertQueryDocument, options);
         }
-export type UserActivityAlertQueryQueryHookResult = ReturnType<typeof useUserActivityAlertQueryQuery>;
+export type UserActivityAlertQueryHookResult = ReturnType<typeof useUserActivityAlertQuery>;
 export type UserActivityAlertQueryLazyQueryHookResult = ReturnType<typeof useUserActivityAlertQueryLazyQuery>;
-export type UserActivityAlertQueryQueryResult = Apollo.QueryResult<UserActivityAlertQueryQuery, UserActivityAlertQueryQueryVariables>;
+export type UserActivityAlertQueryDataResult = Apollo.QueryResult<UserActivityAlertQueryData, UserActivityAlertQueryVariables>;
 export const UserActivityAlertsAdminQueryDocument = gql`
     query UserActivityAlertsAdminQuery {
   convention: assertConvention {
@@ -200,26 +205,28 @@ export const UserActivityAlertsAdminQueryDocument = gql`
     ${UserActivityAlertFieldsFragmentDoc}`;
 
 /**
- * __useUserActivityAlertsAdminQueryQuery__
+ * __useUserActivityAlertsAdminQuery__
  *
- * To run a query within a React component, call `useUserActivityAlertsAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useUserActivityAlertsAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useUserActivityAlertsAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUserActivityAlertsAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useUserActivityAlertsAdminQueryQuery({
+ * const { data, loading, error } = useUserActivityAlertsAdminQuery({
  *   variables: {
  *   },
  * });
  */
-export function useUserActivityAlertsAdminQueryQuery(baseOptions?: Apollo.QueryHookOptions<UserActivityAlertsAdminQueryQuery, UserActivityAlertsAdminQueryQueryVariables>) {
-        return Apollo.useQuery<UserActivityAlertsAdminQueryQuery, UserActivityAlertsAdminQueryQueryVariables>(UserActivityAlertsAdminQueryDocument, baseOptions);
+export function useUserActivityAlertsAdminQuery(baseOptions?: Apollo.QueryHookOptions<UserActivityAlertsAdminQueryData, UserActivityAlertsAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<UserActivityAlertsAdminQueryData, UserActivityAlertsAdminQueryVariables>(UserActivityAlertsAdminQueryDocument, options);
       }
-export function useUserActivityAlertsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserActivityAlertsAdminQueryQuery, UserActivityAlertsAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<UserActivityAlertsAdminQueryQuery, UserActivityAlertsAdminQueryQueryVariables>(UserActivityAlertsAdminQueryDocument, baseOptions);
+export function useUserActivityAlertsAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserActivityAlertsAdminQueryData, UserActivityAlertsAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<UserActivityAlertsAdminQueryData, UserActivityAlertsAdminQueryVariables>(UserActivityAlertsAdminQueryDocument, options);
         }
-export type UserActivityAlertsAdminQueryQueryHookResult = ReturnType<typeof useUserActivityAlertsAdminQueryQuery>;
+export type UserActivityAlertsAdminQueryHookResult = ReturnType<typeof useUserActivityAlertsAdminQuery>;
 export type UserActivityAlertsAdminQueryLazyQueryHookResult = ReturnType<typeof useUserActivityAlertsAdminQueryLazyQuery>;
-export type UserActivityAlertsAdminQueryQueryResult = Apollo.QueryResult<UserActivityAlertsAdminQueryQuery, UserActivityAlertsAdminQueryQueryVariables>;
+export type UserActivityAlertsAdminQueryDataResult = Apollo.QueryResult<UserActivityAlertsAdminQueryData, UserActivityAlertsAdminQueryVariables>;

--- a/app/javascript/UserConProfiles/AddAttendeeModal.tsx
+++ b/app/javascript/UserConProfiles/AddAttendeeModal.tsx
@@ -10,7 +10,7 @@ import LoadingIndicator from '../LoadingIndicator';
 import UserSelect from '../BuiltInFormControls/UserSelect';
 import useAsyncFunction from '../useAsyncFunction';
 import { useCreateUserConProfileMutation } from './mutations.generated';
-import { AddAttendeeUsersQueryQuery } from './queries.generated';
+import { AddAttendeeUsersQueryData } from './queries.generated';
 import { FormResponse } from '../FormPresenter/useFormResponse';
 
 export type AddAttendeeModalProps = {
@@ -18,7 +18,7 @@ export type AddAttendeeModalProps = {
   visible: boolean;
 };
 
-type UserType = AddAttendeeUsersQueryQuery['users_paginated']['entries'][0];
+type UserType = AddAttendeeUsersQueryData['users_paginated']['entries'][0];
 
 function AddAttendeeModal({ conventionName, visible }: AddAttendeeModalProps) {
   const { t } = useTranslation();
@@ -78,7 +78,7 @@ function AddAttendeeModal({ conventionName, visible }: AddAttendeeModalProps) {
           )}
         </p>
 
-        <UserSelect<AddAttendeeUsersQueryQuery>
+        <UserSelect<AddAttendeeUsersQueryData>
           value={user}
           onChange={userSelected}
           usersQuery={AddAttendeeUsersQuery}

--- a/app/javascript/UserConProfiles/ConvertToEventProvidedTicketModal.tsx
+++ b/app/javascript/UserConProfiles/ConvertToEventProvidedTicketModal.tsx
@@ -11,11 +11,11 @@ import TicketingStatusDescription from '../EventsApp/TeamMemberAdmin/TicketingSt
 import useAsyncFunction from '../useAsyncFunction';
 import LoadingIndicator from '../LoadingIndicator';
 import {
-  useConvertToEventProvidedTicketQueryQuery,
-  UserConProfileAdminQueryQuery,
+  useConvertToEventProvidedTicketQuery,
+  UserConProfileAdminQueryData,
 } from './queries.generated';
 import { useConvertTicketToEventProvidedMutation } from './mutations.generated';
-import { DefaultEventsQueryQuery } from '../BuiltInFormControls/selectDefaultQueries.generated';
+import { DefaultEventsQueryData } from '../BuiltInFormControls/selectDefaultQueries.generated';
 
 type EventSpecificSectionProps = {
   event: {
@@ -36,7 +36,7 @@ function EventSpecificSection({
   setTicketTypeId,
   disabled,
 }: EventSpecificSectionProps) {
-  const { data, loading, error } = useConvertToEventProvidedTicketQueryQuery({
+  const { data, loading, error } = useConvertToEventProvidedTicketQuery({
     variables: { eventId: event.id },
   });
 
@@ -77,7 +77,7 @@ export type ConvertToEventProvidedTicketModalProps = {
   onClose: () => void;
 };
 type EventType = NonNullable<
-  DefaultEventsQueryQuery['convention']
+  DefaultEventsQueryData['convention']
 >['events_paginated']['entries'][0];
 
 function ConvertToEventProvidedTicketModal({
@@ -103,7 +103,7 @@ function ConvertToEventProvidedTicketModal({
         userConProfileId: userConProfile.id,
       },
       update: (cache, result) => {
-        const cachedData = cache.readQuery<UserConProfileAdminQueryQuery>({
+        const cachedData = cache.readQuery<UserConProfileAdminQueryData>({
           query: UserConProfileAdminQuery,
           variables: { id: userConProfile.id },
         });

--- a/app/javascript/UserConProfiles/EditTicket.tsx
+++ b/app/javascript/UserConProfiles/EditTicket.tsx
@@ -4,10 +4,10 @@ import { useHistory, useParams } from 'react-router-dom';
 import TicketForm from './TicketForm';
 import usePageTitle from '../usePageTitle';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
-import { useUserConProfileAdminQueryQuery } from './queries.generated';
+import { useUserConProfileAdminQuery } from './queries.generated';
 import { useUpdateTicketMutation } from './mutations.generated';
 
-export default LoadQueryWrapper(useUserConProfileAdminQueryQuery, function EditTicket({ data }) {
+export default LoadQueryWrapper(useUserConProfileAdminQuery, function EditTicket({ data }) {
   const userConProfileId = Number.parseInt(useParams<{ id: string }>().id, 10);
   const history = useHistory();
   const [updateTicket] = useUpdateTicketMutation();

--- a/app/javascript/UserConProfiles/EditUserConProfile.tsx
+++ b/app/javascript/UserConProfiles/EditUserConProfile.tsx
@@ -10,13 +10,13 @@ import useAsyncFunction from '../useAsyncFunction';
 import usePageTitle from '../usePageTitle';
 import PageLoadingIndicator from '../PageLoadingIndicator';
 import {
-  useUserConProfileQueryQuery,
-  UserConProfileQueryQuery,
-  UserConProfileAdminQueryQuery,
+  useUserConProfileQuery,
+  UserConProfileQueryData,
+  UserConProfileAdminQueryData,
 } from './queries.generated';
 import { useUpdateUserConProfileMutation } from './mutations.generated';
 
-function EditUserConProfileForm({ data }: { data: UserConProfileQueryQuery }) {
+function EditUserConProfileForm({ data }: { data: UserConProfileQueryData }) {
   const history = useHistory();
   const { userConProfile: initialUserConProfile, convention, form } = buildFormStateFromData(
     data.userConProfile,
@@ -28,9 +28,9 @@ function EditUserConProfileForm({ data }: { data: UserConProfileQueryQuery }) {
   const [mutate] = useUpdateUserConProfileMutation({
     update: (cache, result) => {
       const variables = { id: initialUserConProfile.id };
-      let query: UserConProfileAdminQueryQuery | null = null;
+      let query: UserConProfileAdminQueryData | null = null;
       try {
-        query = cache.readQuery<UserConProfileAdminQueryQuery>({
+        query = cache.readQuery<UserConProfileAdminQueryData>({
           query: UserConProfileAdminQuery,
           variables,
         });
@@ -97,7 +97,7 @@ function EditUserConProfileForm({ data }: { data: UserConProfileQueryQuery }) {
 
 function EditUserConProfile() {
   const id = Number.parseInt(useParams<{ id: string }>().id, 10);
-  const { data, loading, error } = useUserConProfileQueryQuery({ variables: { id } });
+  const { data, loading, error } = useUserConProfileQuery({ variables: { id } });
 
   if (loading) {
     return <PageLoadingIndicator visible />;

--- a/app/javascript/UserConProfiles/NewTicket.tsx
+++ b/app/javascript/UserConProfiles/NewTicket.tsx
@@ -4,19 +4,16 @@ import { useHistory, useParams } from 'react-router-dom';
 import TicketForm from './TicketForm';
 import { UserConProfileAdminQuery } from './queries';
 import usePageTitle from '../usePageTitle';
-import {
-  UserConProfileAdminQueryQuery,
-  useUserConProfileAdminQueryQuery,
-} from './queries.generated';
+import { UserConProfileAdminQueryData, useUserConProfileAdminQuery } from './queries.generated';
 import { useCreateTicketMutation } from './mutations.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 
-export default LoadQueryWrapper(useUserConProfileAdminQueryQuery, function NewTicket({ data }) {
+export default LoadQueryWrapper(useUserConProfileAdminQuery, function NewTicket({ data }) {
   const userConProfileId = Number.parseInt(useParams<{ id: string }>().id, 10);
   const history = useHistory();
   const [createTicket] = useCreateTicketMutation({
     update: (cache, result) => {
-      const cacheData = cache.readQuery<UserConProfileAdminQueryQuery>({
+      const cacheData = cache.readQuery<UserConProfileAdminQueryData>({
         query: UserConProfileAdminQuery,
         variables: { id: userConProfileId },
       });

--- a/app/javascript/UserConProfiles/TicketAdminSection.tsx
+++ b/app/javascript/UserConProfiles/TicketAdminSection.tsx
@@ -21,9 +21,9 @@ import AppRootContext from '../AppRootContext';
 import { Money } from '../graphqlTypes.generated';
 import { useDeleteTicketMutation } from './mutations.generated';
 import {
-  UserConProfileAdminQueryQuery,
-  TicketAdminWithTicketAbilityQueryQuery,
-  TicketAdminWithoutTicketAbilityQueryQuery,
+  UserConProfileAdminQueryData,
+  TicketAdminWithTicketAbilityQueryData,
+  TicketAdminWithoutTicketAbilityQueryData,
 } from './queries.generated';
 import { useAppDateTimeFormat } from '../TimeUtils';
 
@@ -64,7 +64,7 @@ function TicketAdminControls({ convention, userConProfile }: TicketAdminControls
     : TicketAdminWithoutTicketAbilityQuery;
 
   const { data, loading, error } = useQuery<
-    TicketAdminWithTicketAbilityQueryQuery | TicketAdminWithoutTicketAbilityQueryQuery
+    TicketAdminWithTicketAbilityQueryData | TicketAdminWithoutTicketAbilityQueryData
   >(query, {
     variables: { ticketId: (userConProfile.ticket || {}).id },
   });
@@ -80,7 +80,7 @@ function TicketAdminControls({ convention, userConProfile }: TicketAdminControls
       },
       update: (cache) => {
         const variables = { id: userConProfile.id };
-        const cacheData = cache.readQuery<UserConProfileAdminQueryQuery>({
+        const cacheData = cache.readQuery<UserConProfileAdminQueryData>({
           query: UserConProfileAdminQuery,
           variables,
         });
@@ -124,7 +124,7 @@ function TicketAdminControls({ convention, userConProfile }: TicketAdminControls
 
   if (
     ticket &&
-    (currentAbility as TicketAdminWithTicketAbilityQueryQuery['currentAbility']).can_update_ticket
+    (currentAbility as TicketAdminWithTicketAbilityQueryData['currentAbility']).can_update_ticket
   ) {
     buttons.push(
       <Link
@@ -136,7 +136,7 @@ function TicketAdminControls({ convention, userConProfile }: TicketAdminControls
     );
 
     if (
-      (currentAbility as TicketAdminWithTicketAbilityQueryQuery['currentAbility']).can_delete_ticket
+      (currentAbility as TicketAdminWithTicketAbilityQueryData['currentAbility']).can_delete_ticket
     ) {
       if (!ticket.provided_by_event) {
         buttons.push(

--- a/app/javascript/UserConProfiles/TicketForm.tsx
+++ b/app/javascript/UserConProfiles/TicketForm.tsx
@@ -13,11 +13,11 @@ import useModal from '../ModalDialogs/useModal';
 import formatMoney from '../formatMoney';
 import EditOrderModal from '../Store/EditOrderModal';
 import AddOrderToTicketButton, { AddOrderToTicketButtonProps } from './AddOrderToTicketButton';
-import { UserConProfileAdminQueryQuery } from './queries.generated';
+import { UserConProfileAdminQueryData } from './queries.generated';
 import { TicketInput, UserConProfile } from '../graphqlTypes.generated';
 import { parseIntOrNull } from '../ValueUtils';
 
-type TicketFromQuery = NonNullable<UserConProfileAdminQueryQuery['userConProfile']['ticket']>;
+type TicketFromQuery = NonNullable<UserConProfileAdminQueryData['userConProfile']['ticket']>;
 type EditingTicket = Omit<
   TicketFromQuery,
   'id' | 'ticket_type' | 'created_at' | 'updated_at' | '__typename'
@@ -26,7 +26,7 @@ type EditingTicket = Omit<
 
 export type TicketFormProps = {
   initialTicket: EditingTicket;
-  convention: UserConProfileAdminQueryQuery['convention'];
+  convention: UserConProfileAdminQueryData['convention'];
   onSubmit: (ticketInput: TicketInput) => Promise<void>;
   submitCaption: string;
   userConProfile: Pick<UserConProfile, 'id' | 'name_without_nickname'>;

--- a/app/javascript/UserConProfiles/UserConProfileAdminDisplay.tsx
+++ b/app/javascript/UserConProfiles/UserConProfileAdminDisplay.tsx
@@ -12,14 +12,14 @@ import useValueUnless from '../useValueUnless';
 import Gravatar from '../Gravatar';
 import PageLoadingIndicator from '../PageLoadingIndicator';
 import { useDeleteUserConProfileMutation } from './mutations.generated';
-import { useUserConProfileAdminQueryQuery } from './queries.generated';
+import { useUserConProfileAdminQuery } from './queries.generated';
 import deserializeFormResponse from '../Models/deserializeFormResponse';
 import { getSortedParsedFormItems } from '../Models/Form';
 
 function UserConProfileAdminDisplay() {
   const userConProfileId = Number.parseInt(useParams<{ id: string }>().id, 10);
   const history = useHistory();
-  const { data, loading, error } = useUserConProfileAdminQueryQuery({
+  const { data, loading, error } = useUserConProfileAdminQuery({
     variables: { id: userConProfileId },
   });
   const formItems = useMemo(

--- a/app/javascript/UserConProfiles/UserConProfilesTable.tsx
+++ b/app/javascript/UserConProfiles/UserConProfilesTable.tsx
@@ -21,9 +21,9 @@ import useReactTableWithTheWorks, {
 import TableHeader from '../Tables/TableHeader';
 import UserConProfileWithGravatarCell from '../Tables/UserConProfileWithGravatarCell';
 import {
-  UserConProfilesTableUserConProfilesQueryQuery,
-  useUserConProfilesTableUserConProfilesQueryQuery,
-  UserConProfilesTableUserConProfilesQueryQueryVariables,
+  UserConProfilesTableUserConProfilesQueryData,
+  useUserConProfilesTableUserConProfilesQuery,
+  UserConProfilesTableUserConProfilesQueryVariables,
 } from './queries.generated';
 import { FormItemValueType, TypedFormItem } from '../FormAdmin/FormItemUtils';
 import { getSortedParsedFormItems } from '../Models/Form';
@@ -32,10 +32,10 @@ import { formatLCM, getDateTimeFormat } from '../TimeUtils';
 import AppRootContext from '../AppRootContext';
 
 type UserConProfilesTableRow = NonNullable<
-  UserConProfilesTableUserConProfilesQueryQuery['convention']
+  UserConProfilesTableUserConProfilesQueryData['convention']
 >['user_con_profiles_paginated']['entries'][0];
 
-const UserConProfilesTableQueryDataContext = createQueryDataContext<UserConProfilesTableUserConProfilesQueryQuery>();
+const UserConProfilesTableQueryDataContext = createQueryDataContext<UserConProfilesTableUserConProfilesQueryData>();
 
 const { encodeFilterValue, decodeFilterValue } = buildFieldFilterCodecs({
   ticket: FilterCodecs.stringArray,
@@ -121,7 +121,7 @@ const PrivilegesFilter = (props: FilterProps<UserConProfilesTableRow>) => {
 };
 
 function getPossibleColumns(
-  data: UserConProfilesTableUserConProfilesQueryQuery,
+  data: UserConProfilesTableUserConProfilesQueryData,
   t: TFunction,
   formItems: TypedFormItem[],
   timezoneName: string,
@@ -311,7 +311,7 @@ function UserConProfilesTable({ defaultVisibleColumns }: UserConProfilesTablePro
   const { t } = useTranslation();
   const history = useHistory();
   const getPossibleColumnsWithTranslation = useMemo(
-    () => (data: UserConProfilesTableUserConProfilesQueryQuery) =>
+    () => (data: UserConProfilesTableUserConProfilesQueryData) =>
       getPossibleColumns(
         data,
         t,
@@ -321,9 +321,9 @@ function UserConProfilesTable({ defaultVisibleColumns }: UserConProfilesTablePro
     [t, timezoneName],
   );
   const { tableInstance, loading, tableHeaderProps, queryData } = useReactTableWithTheWorks<
-    UserConProfilesTableUserConProfilesQueryQuery,
+    UserConProfilesTableUserConProfilesQueryData,
     UserConProfilesTableRow,
-    UserConProfilesTableUserConProfilesQueryQueryVariables
+    UserConProfilesTableUserConProfilesQueryVariables
   >({
     decodeFilterValue,
     defaultVisibleColumns,
@@ -331,7 +331,7 @@ function UserConProfilesTable({ defaultVisibleColumns }: UserConProfilesTablePro
     getData: ({ data }) => data!.convention!.user_con_profiles_paginated.entries,
     getPages: ({ data }) => data!.convention!.user_con_profiles_paginated.total_pages,
     getPossibleColumns: getPossibleColumnsWithTranslation,
-    useQuery: useUserConProfilesTableUserConProfilesQueryQuery,
+    useQuery: useUserConProfilesTableUserConProfilesQuery,
     storageKeyPrefix: 'userConProfiles',
   });
 

--- a/app/javascript/UserConProfiles/mutations.generated.ts
+++ b/app/javascript/UserConProfiles/mutations.generated.ts
@@ -5,13 +5,14 @@ import { UserConProfileFieldsFragment, UserConProfileAdminTicketFieldsFragment }
 import { gql } from '@apollo/client';
 import { UserConProfileFieldsFragmentDoc, UserConProfileAdminTicketFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type CreateUserConProfileMutationVariables = Types.Exact<{
   user_id: Types.Scalars['Int'];
   user_con_profile: Types.UserConProfileInput;
 }>;
 
 
-export type CreateUserConProfileMutation = (
+export type CreateUserConProfileMutationData = (
   { __typename: 'Mutation' }
   & { createUserConProfile?: Types.Maybe<(
     { __typename: 'CreateUserConProfilePayload' }
@@ -27,7 +28,7 @@ export type UpdateUserConProfileMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateUserConProfileMutation = (
+export type UpdateUserConProfileMutationData = (
   { __typename: 'Mutation' }
   & { updateUserConProfile?: Types.Maybe<(
     { __typename: 'UpdateUserConProfilePayload' }
@@ -44,7 +45,7 @@ export type DeleteUserConProfileMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteUserConProfileMutation = (
+export type DeleteUserConProfileMutationData = (
   { __typename: 'Mutation' }
   & { deleteUserConProfile?: Types.Maybe<(
     { __typename: 'DeleteUserConProfilePayload' }
@@ -61,7 +62,7 @@ export type CreateTicketMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateTicketMutation = (
+export type CreateTicketMutationData = (
   { __typename: 'Mutation' }
   & { createTicket?: Types.Maybe<(
     { __typename: 'CreateTicketPayload' }
@@ -79,7 +80,7 @@ export type UpdateTicketMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateTicketMutation = (
+export type UpdateTicketMutationData = (
   { __typename: 'Mutation' }
   & { updateTicket?: Types.Maybe<(
     { __typename: 'UpdateTicketPayload' }
@@ -97,7 +98,7 @@ export type DeleteTicketMutationVariables = Types.Exact<{
 }>;
 
 
-export type DeleteTicketMutation = (
+export type DeleteTicketMutationData = (
   { __typename: 'Mutation' }
   & { deleteTicket?: Types.Maybe<(
     { __typename: 'DeleteTicketPayload' }
@@ -115,7 +116,7 @@ export type ConvertTicketToEventProvidedMutationVariables = Types.Exact<{
 }>;
 
 
-export type ConvertTicketToEventProvidedMutation = (
+export type ConvertTicketToEventProvidedMutationData = (
   { __typename: 'Mutation' }
   & { convertTicketToEventProvided?: Types.Maybe<(
     { __typename: 'ConvertTicketToEventProvidedPayload' }
@@ -139,7 +140,7 @@ export const CreateUserConProfileDocument = gql`
   }
 }
     `;
-export type CreateUserConProfileMutationFn = Apollo.MutationFunction<CreateUserConProfileMutation, CreateUserConProfileMutationVariables>;
+export type CreateUserConProfileMutationFn = Apollo.MutationFunction<CreateUserConProfileMutationData, CreateUserConProfileMutationVariables>;
 
 /**
  * __useCreateUserConProfileMutation__
@@ -159,12 +160,13 @@ export type CreateUserConProfileMutationFn = Apollo.MutationFunction<CreateUserC
  *   },
  * });
  */
-export function useCreateUserConProfileMutation(baseOptions?: Apollo.MutationHookOptions<CreateUserConProfileMutation, CreateUserConProfileMutationVariables>) {
-        return Apollo.useMutation<CreateUserConProfileMutation, CreateUserConProfileMutationVariables>(CreateUserConProfileDocument, baseOptions);
+export function useCreateUserConProfileMutation(baseOptions?: Apollo.MutationHookOptions<CreateUserConProfileMutationData, CreateUserConProfileMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateUserConProfileMutationData, CreateUserConProfileMutationVariables>(CreateUserConProfileDocument, options);
       }
 export type CreateUserConProfileMutationHookResult = ReturnType<typeof useCreateUserConProfileMutation>;
-export type CreateUserConProfileMutationResult = Apollo.MutationResult<CreateUserConProfileMutation>;
-export type CreateUserConProfileMutationOptions = Apollo.BaseMutationOptions<CreateUserConProfileMutation, CreateUserConProfileMutationVariables>;
+export type CreateUserConProfileMutationResult = Apollo.MutationResult<CreateUserConProfileMutationData>;
+export type CreateUserConProfileMutationOptions = Apollo.BaseMutationOptions<CreateUserConProfileMutationData, CreateUserConProfileMutationVariables>;
 export const UpdateUserConProfileDocument = gql`
     mutation UpdateUserConProfile($input: UpdateUserConProfileInput!) {
   updateUserConProfile(input: $input) {
@@ -175,7 +177,7 @@ export const UpdateUserConProfileDocument = gql`
   }
 }
     ${UserConProfileFieldsFragmentDoc}`;
-export type UpdateUserConProfileMutationFn = Apollo.MutationFunction<UpdateUserConProfileMutation, UpdateUserConProfileMutationVariables>;
+export type UpdateUserConProfileMutationFn = Apollo.MutationFunction<UpdateUserConProfileMutationData, UpdateUserConProfileMutationVariables>;
 
 /**
  * __useUpdateUserConProfileMutation__
@@ -194,12 +196,13 @@ export type UpdateUserConProfileMutationFn = Apollo.MutationFunction<UpdateUserC
  *   },
  * });
  */
-export function useUpdateUserConProfileMutation(baseOptions?: Apollo.MutationHookOptions<UpdateUserConProfileMutation, UpdateUserConProfileMutationVariables>) {
-        return Apollo.useMutation<UpdateUserConProfileMutation, UpdateUserConProfileMutationVariables>(UpdateUserConProfileDocument, baseOptions);
+export function useUpdateUserConProfileMutation(baseOptions?: Apollo.MutationHookOptions<UpdateUserConProfileMutationData, UpdateUserConProfileMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateUserConProfileMutationData, UpdateUserConProfileMutationVariables>(UpdateUserConProfileDocument, options);
       }
 export type UpdateUserConProfileMutationHookResult = ReturnType<typeof useUpdateUserConProfileMutation>;
-export type UpdateUserConProfileMutationResult = Apollo.MutationResult<UpdateUserConProfileMutation>;
-export type UpdateUserConProfileMutationOptions = Apollo.BaseMutationOptions<UpdateUserConProfileMutation, UpdateUserConProfileMutationVariables>;
+export type UpdateUserConProfileMutationResult = Apollo.MutationResult<UpdateUserConProfileMutationData>;
+export type UpdateUserConProfileMutationOptions = Apollo.BaseMutationOptions<UpdateUserConProfileMutationData, UpdateUserConProfileMutationVariables>;
 export const DeleteUserConProfileDocument = gql`
     mutation DeleteUserConProfile($userConProfileId: Int!) {
   deleteUserConProfile(input: {id: $userConProfileId}) {
@@ -209,7 +212,7 @@ export const DeleteUserConProfileDocument = gql`
   }
 }
     `;
-export type DeleteUserConProfileMutationFn = Apollo.MutationFunction<DeleteUserConProfileMutation, DeleteUserConProfileMutationVariables>;
+export type DeleteUserConProfileMutationFn = Apollo.MutationFunction<DeleteUserConProfileMutationData, DeleteUserConProfileMutationVariables>;
 
 /**
  * __useDeleteUserConProfileMutation__
@@ -228,12 +231,13 @@ export type DeleteUserConProfileMutationFn = Apollo.MutationFunction<DeleteUserC
  *   },
  * });
  */
-export function useDeleteUserConProfileMutation(baseOptions?: Apollo.MutationHookOptions<DeleteUserConProfileMutation, DeleteUserConProfileMutationVariables>) {
-        return Apollo.useMutation<DeleteUserConProfileMutation, DeleteUserConProfileMutationVariables>(DeleteUserConProfileDocument, baseOptions);
+export function useDeleteUserConProfileMutation(baseOptions?: Apollo.MutationHookOptions<DeleteUserConProfileMutationData, DeleteUserConProfileMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteUserConProfileMutationData, DeleteUserConProfileMutationVariables>(DeleteUserConProfileDocument, options);
       }
 export type DeleteUserConProfileMutationHookResult = ReturnType<typeof useDeleteUserConProfileMutation>;
-export type DeleteUserConProfileMutationResult = Apollo.MutationResult<DeleteUserConProfileMutation>;
-export type DeleteUserConProfileMutationOptions = Apollo.BaseMutationOptions<DeleteUserConProfileMutation, DeleteUserConProfileMutationVariables>;
+export type DeleteUserConProfileMutationResult = Apollo.MutationResult<DeleteUserConProfileMutationData>;
+export type DeleteUserConProfileMutationOptions = Apollo.BaseMutationOptions<DeleteUserConProfileMutationData, DeleteUserConProfileMutationVariables>;
 export const CreateTicketDocument = gql`
     mutation CreateTicket($userConProfileId: Int!, $ticket: TicketInput!) {
   createTicket(input: {user_con_profile_id: $userConProfileId, ticket: $ticket}) {
@@ -244,7 +248,7 @@ export const CreateTicketDocument = gql`
   }
 }
     ${UserConProfileAdminTicketFieldsFragmentDoc}`;
-export type CreateTicketMutationFn = Apollo.MutationFunction<CreateTicketMutation, CreateTicketMutationVariables>;
+export type CreateTicketMutationFn = Apollo.MutationFunction<CreateTicketMutationData, CreateTicketMutationVariables>;
 
 /**
  * __useCreateTicketMutation__
@@ -264,12 +268,13 @@ export type CreateTicketMutationFn = Apollo.MutationFunction<CreateTicketMutatio
  *   },
  * });
  */
-export function useCreateTicketMutation(baseOptions?: Apollo.MutationHookOptions<CreateTicketMutation, CreateTicketMutationVariables>) {
-        return Apollo.useMutation<CreateTicketMutation, CreateTicketMutationVariables>(CreateTicketDocument, baseOptions);
+export function useCreateTicketMutation(baseOptions?: Apollo.MutationHookOptions<CreateTicketMutationData, CreateTicketMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateTicketMutationData, CreateTicketMutationVariables>(CreateTicketDocument, options);
       }
 export type CreateTicketMutationHookResult = ReturnType<typeof useCreateTicketMutation>;
-export type CreateTicketMutationResult = Apollo.MutationResult<CreateTicketMutation>;
-export type CreateTicketMutationOptions = Apollo.BaseMutationOptions<CreateTicketMutation, CreateTicketMutationVariables>;
+export type CreateTicketMutationResult = Apollo.MutationResult<CreateTicketMutationData>;
+export type CreateTicketMutationOptions = Apollo.BaseMutationOptions<CreateTicketMutationData, CreateTicketMutationVariables>;
 export const UpdateTicketDocument = gql`
     mutation UpdateTicket($id: Int!, $ticket: TicketInput!) {
   updateTicket(input: {id: $id, ticket: $ticket}) {
@@ -280,7 +285,7 @@ export const UpdateTicketDocument = gql`
   }
 }
     ${UserConProfileAdminTicketFieldsFragmentDoc}`;
-export type UpdateTicketMutationFn = Apollo.MutationFunction<UpdateTicketMutation, UpdateTicketMutationVariables>;
+export type UpdateTicketMutationFn = Apollo.MutationFunction<UpdateTicketMutationData, UpdateTicketMutationVariables>;
 
 /**
  * __useUpdateTicketMutation__
@@ -300,12 +305,13 @@ export type UpdateTicketMutationFn = Apollo.MutationFunction<UpdateTicketMutatio
  *   },
  * });
  */
-export function useUpdateTicketMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTicketMutation, UpdateTicketMutationVariables>) {
-        return Apollo.useMutation<UpdateTicketMutation, UpdateTicketMutationVariables>(UpdateTicketDocument, baseOptions);
+export function useUpdateTicketMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTicketMutationData, UpdateTicketMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateTicketMutationData, UpdateTicketMutationVariables>(UpdateTicketDocument, options);
       }
 export type UpdateTicketMutationHookResult = ReturnType<typeof useUpdateTicketMutation>;
-export type UpdateTicketMutationResult = Apollo.MutationResult<UpdateTicketMutation>;
-export type UpdateTicketMutationOptions = Apollo.BaseMutationOptions<UpdateTicketMutation, UpdateTicketMutationVariables>;
+export type UpdateTicketMutationResult = Apollo.MutationResult<UpdateTicketMutationData>;
+export type UpdateTicketMutationOptions = Apollo.BaseMutationOptions<UpdateTicketMutationData, UpdateTicketMutationVariables>;
 export const DeleteTicketDocument = gql`
     mutation DeleteTicket($ticketId: Int!, $refund: Boolean!) {
   deleteTicket(input: {id: $ticketId, refund: $refund}) {
@@ -315,7 +321,7 @@ export const DeleteTicketDocument = gql`
   }
 }
     `;
-export type DeleteTicketMutationFn = Apollo.MutationFunction<DeleteTicketMutation, DeleteTicketMutationVariables>;
+export type DeleteTicketMutationFn = Apollo.MutationFunction<DeleteTicketMutationData, DeleteTicketMutationVariables>;
 
 /**
  * __useDeleteTicketMutation__
@@ -335,12 +341,13 @@ export type DeleteTicketMutationFn = Apollo.MutationFunction<DeleteTicketMutatio
  *   },
  * });
  */
-export function useDeleteTicketMutation(baseOptions?: Apollo.MutationHookOptions<DeleteTicketMutation, DeleteTicketMutationVariables>) {
-        return Apollo.useMutation<DeleteTicketMutation, DeleteTicketMutationVariables>(DeleteTicketDocument, baseOptions);
+export function useDeleteTicketMutation(baseOptions?: Apollo.MutationHookOptions<DeleteTicketMutationData, DeleteTicketMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DeleteTicketMutationData, DeleteTicketMutationVariables>(DeleteTicketDocument, options);
       }
 export type DeleteTicketMutationHookResult = ReturnType<typeof useDeleteTicketMutation>;
-export type DeleteTicketMutationResult = Apollo.MutationResult<DeleteTicketMutation>;
-export type DeleteTicketMutationOptions = Apollo.BaseMutationOptions<DeleteTicketMutation, DeleteTicketMutationVariables>;
+export type DeleteTicketMutationResult = Apollo.MutationResult<DeleteTicketMutationData>;
+export type DeleteTicketMutationOptions = Apollo.BaseMutationOptions<DeleteTicketMutationData, DeleteTicketMutationVariables>;
 export const ConvertTicketToEventProvidedDocument = gql`
     mutation ConvertTicketToEventProvided($eventId: Int!, $ticketTypeId: Int!, $userConProfileId: Int!) {
   convertTicketToEventProvided(
@@ -353,7 +360,7 @@ export const ConvertTicketToEventProvidedDocument = gql`
   }
 }
     ${UserConProfileAdminTicketFieldsFragmentDoc}`;
-export type ConvertTicketToEventProvidedMutationFn = Apollo.MutationFunction<ConvertTicketToEventProvidedMutation, ConvertTicketToEventProvidedMutationVariables>;
+export type ConvertTicketToEventProvidedMutationFn = Apollo.MutationFunction<ConvertTicketToEventProvidedMutationData, ConvertTicketToEventProvidedMutationVariables>;
 
 /**
  * __useConvertTicketToEventProvidedMutation__
@@ -374,9 +381,10 @@ export type ConvertTicketToEventProvidedMutationFn = Apollo.MutationFunction<Con
  *   },
  * });
  */
-export function useConvertTicketToEventProvidedMutation(baseOptions?: Apollo.MutationHookOptions<ConvertTicketToEventProvidedMutation, ConvertTicketToEventProvidedMutationVariables>) {
-        return Apollo.useMutation<ConvertTicketToEventProvidedMutation, ConvertTicketToEventProvidedMutationVariables>(ConvertTicketToEventProvidedDocument, baseOptions);
+export function useConvertTicketToEventProvidedMutation(baseOptions?: Apollo.MutationHookOptions<ConvertTicketToEventProvidedMutationData, ConvertTicketToEventProvidedMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ConvertTicketToEventProvidedMutationData, ConvertTicketToEventProvidedMutationVariables>(ConvertTicketToEventProvidedDocument, options);
       }
 export type ConvertTicketToEventProvidedMutationHookResult = ReturnType<typeof useConvertTicketToEventProvidedMutation>;
-export type ConvertTicketToEventProvidedMutationResult = Apollo.MutationResult<ConvertTicketToEventProvidedMutation>;
-export type ConvertTicketToEventProvidedMutationOptions = Apollo.BaseMutationOptions<ConvertTicketToEventProvidedMutation, ConvertTicketToEventProvidedMutationVariables>;
+export type ConvertTicketToEventProvidedMutationResult = Apollo.MutationResult<ConvertTicketToEventProvidedMutationData>;
+export type ConvertTicketToEventProvidedMutationOptions = Apollo.BaseMutationOptions<ConvertTicketToEventProvidedMutationData, ConvertTicketToEventProvidedMutationVariables>;

--- a/app/javascript/UserConProfiles/queries.generated.ts
+++ b/app/javascript/UserConProfiles/queries.generated.ts
@@ -2,13 +2,14 @@
 import * as Types from '../graphqlTypes.generated';
 
 import { CommonFormFieldsFragment, CommonFormSectionFieldsFragment, CommonFormItemFieldsFragment } from '../Models/commonFormFragments.generated';
-import { AdminOrderFieldsFragmentFragment, OrderEntryFieldsFragment, CartOrderFieldsFragment, CouponApplicationFieldsFragment } from '../Store/orderFields.generated';
+import { AdminOrderFieldsFragment, OrderEntryFieldsFragment, CartOrderFieldsFragment, CouponApplicationFieldsFragment } from '../Store/orderFields.generated';
 import { AdminProductFieldsFragment } from '../Store/adminProductFields.generated';
 import { gql } from '@apollo/client';
 import { CommonFormFieldsFragmentDoc, CommonFormSectionFieldsFragmentDoc, CommonFormItemFieldsFragmentDoc } from '../Models/commonFormFragments.generated';
-import { AdminOrderFieldsFragmentFragmentDoc, OrderEntryFieldsFragmentDoc, CartOrderFieldsFragmentDoc, CouponApplicationFieldsFragmentDoc } from '../Store/orderFields.generated';
+import { AdminOrderFieldsFragmentDoc, OrderEntryFieldsFragmentDoc, CartOrderFieldsFragmentDoc, CouponApplicationFieldsFragmentDoc } from '../Store/orderFields.generated';
 import { AdminProductFieldsFragmentDoc } from '../Store/adminProductFields.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type UserConProfileFormDataFragment = (
   { __typename: 'Convention' }
   & Pick<Types.Convention, 'id' | 'starts_at' | 'ends_at' | 'timezone_name' | 'timezone_mode'>
@@ -33,7 +34,7 @@ export type UserConProfileAdminTicketFieldsFragment = (
     & { order: (
       { __typename: 'Order' }
       & Pick<Types.Order, 'id'>
-      & AdminOrderFieldsFragmentFragment
+      & AdminOrderFieldsFragment
     ), price_per_item: (
       { __typename: 'Money' }
       & Pick<Types.Money, 'fractional' | 'currency_code'>
@@ -47,12 +48,12 @@ export type UserConProfileAdminTicketFieldsFragment = (
   )> }
 );
 
-export type UserConProfileQueryQueryVariables = Types.Exact<{
+export type UserConProfileQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type UserConProfileQueryQuery = (
+export type UserConProfileQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -65,12 +66,12 @@ export type UserConProfileQueryQuery = (
   ) }
 );
 
-export type UserConProfileAdminQueryQueryVariables = Types.Exact<{
+export type UserConProfileAdminQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type UserConProfileAdminQueryQuery = (
+export type UserConProfileAdminQueryData = (
   { __typename: 'Query' }
   & { myProfile?: Types.Maybe<(
     { __typename: 'UserConProfile' }
@@ -114,7 +115,7 @@ export type UserConProfileAdminQueryQuery = (
   ) }
 );
 
-export type UserConProfilesTableUserConProfilesQueryQueryVariables = Types.Exact<{
+export type UserConProfilesTableUserConProfilesQueryVariables = Types.Exact<{
   page?: Types.Maybe<Types.Scalars['Int']>;
   perPage?: Types.Maybe<Types.Scalars['Int']>;
   filters?: Types.Maybe<Types.UserConProfileFiltersInput>;
@@ -122,7 +123,7 @@ export type UserConProfilesTableUserConProfilesQueryQueryVariables = Types.Exact
 }>;
 
 
-export type UserConProfilesTableUserConProfilesQueryQuery = (
+export type UserConProfilesTableUserConProfilesQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -174,12 +175,12 @@ export type UserConProfilesTableUserConProfilesQueryQuery = (
   ) }
 );
 
-export type ConvertToEventProvidedTicketQueryQueryVariables = Types.Exact<{
+export type ConvertToEventProvidedTicketQueryVariables = Types.Exact<{
   eventId: Types.Scalars['Int'];
 }>;
 
 
-export type ConvertToEventProvidedTicketQueryQuery = (
+export type ConvertToEventProvidedTicketQueryData = (
   { __typename: 'Query' }
   & { convention?: Types.Maybe<(
     { __typename: 'Convention' }
@@ -205,12 +206,12 @@ export type ConvertToEventProvidedTicketQueryQuery = (
   ) }
 );
 
-export type AddAttendeeUsersQueryQueryVariables = Types.Exact<{
+export type AddAttendeeUsersQueryVariables = Types.Exact<{
   name?: Types.Maybe<Types.Scalars['String']>;
 }>;
 
 
-export type AddAttendeeUsersQueryQuery = (
+export type AddAttendeeUsersQueryData = (
   { __typename: 'Query' }
   & { users_paginated: (
     { __typename: 'UsersPagination' }
@@ -221,10 +222,10 @@ export type AddAttendeeUsersQueryQuery = (
   ) }
 );
 
-export type TicketAdminWithoutTicketAbilityQueryQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type TicketAdminWithoutTicketAbilityQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type TicketAdminWithoutTicketAbilityQueryQuery = (
+export type TicketAdminWithoutTicketAbilityQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -232,12 +233,12 @@ export type TicketAdminWithoutTicketAbilityQueryQuery = (
   ) }
 );
 
-export type TicketAdminWithTicketAbilityQueryQueryVariables = Types.Exact<{
+export type TicketAdminWithTicketAbilityQueryVariables = Types.Exact<{
   ticketId: Types.Scalars['Int'];
 }>;
 
 
-export type TicketAdminWithTicketAbilityQueryQuery = (
+export type TicketAdminWithTicketAbilityQueryData = (
   { __typename: 'Query' }
   & { currentAbility: (
     { __typename: 'Ability' }
@@ -293,7 +294,7 @@ export const UserConProfileAdminTicketFieldsFragmentDoc = gql`
     title
   }
 }
-    ${AdminOrderFieldsFragmentFragmentDoc}`;
+    ${AdminOrderFieldsFragmentDoc}`;
 export const UserConProfileQueryDocument = gql`
     query UserConProfileQuery($id: Int!) {
   convention {
@@ -309,30 +310,32 @@ export const UserConProfileQueryDocument = gql`
 ${UserConProfileFieldsFragmentDoc}`;
 
 /**
- * __useUserConProfileQueryQuery__
+ * __useUserConProfileQuery__
  *
- * To run a query within a React component, call `useUserConProfileQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useUserConProfileQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useUserConProfileQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUserConProfileQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useUserConProfileQueryQuery({
+ * const { data, loading, error } = useUserConProfileQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useUserConProfileQueryQuery(baseOptions: Apollo.QueryHookOptions<UserConProfileQueryQuery, UserConProfileQueryQueryVariables>) {
-        return Apollo.useQuery<UserConProfileQueryQuery, UserConProfileQueryQueryVariables>(UserConProfileQueryDocument, baseOptions);
+export function useUserConProfileQuery(baseOptions: Apollo.QueryHookOptions<UserConProfileQueryData, UserConProfileQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<UserConProfileQueryData, UserConProfileQueryVariables>(UserConProfileQueryDocument, options);
       }
-export function useUserConProfileQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserConProfileQueryQuery, UserConProfileQueryQueryVariables>) {
-          return Apollo.useLazyQuery<UserConProfileQueryQuery, UserConProfileQueryQueryVariables>(UserConProfileQueryDocument, baseOptions);
+export function useUserConProfileQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserConProfileQueryData, UserConProfileQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<UserConProfileQueryData, UserConProfileQueryVariables>(UserConProfileQueryDocument, options);
         }
-export type UserConProfileQueryQueryHookResult = ReturnType<typeof useUserConProfileQueryQuery>;
+export type UserConProfileQueryHookResult = ReturnType<typeof useUserConProfileQuery>;
 export type UserConProfileQueryLazyQueryHookResult = ReturnType<typeof useUserConProfileQueryLazyQuery>;
-export type UserConProfileQueryQueryResult = Apollo.QueryResult<UserConProfileQueryQuery, UserConProfileQueryQueryVariables>;
+export type UserConProfileQueryDataResult = Apollo.QueryResult<UserConProfileQueryData, UserConProfileQueryVariables>;
 export const UserConProfileAdminQueryDocument = gql`
     query UserConProfileAdminQuery($id: Int!) {
   myProfile {
@@ -395,30 +398,32 @@ ${AdminProductFieldsFragmentDoc}
 ${UserConProfileAdminTicketFieldsFragmentDoc}`;
 
 /**
- * __useUserConProfileAdminQueryQuery__
+ * __useUserConProfileAdminQuery__
  *
- * To run a query within a React component, call `useUserConProfileAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useUserConProfileAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useUserConProfileAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUserConProfileAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useUserConProfileAdminQueryQuery({
+ * const { data, loading, error } = useUserConProfileAdminQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useUserConProfileAdminQueryQuery(baseOptions: Apollo.QueryHookOptions<UserConProfileAdminQueryQuery, UserConProfileAdminQueryQueryVariables>) {
-        return Apollo.useQuery<UserConProfileAdminQueryQuery, UserConProfileAdminQueryQueryVariables>(UserConProfileAdminQueryDocument, baseOptions);
+export function useUserConProfileAdminQuery(baseOptions: Apollo.QueryHookOptions<UserConProfileAdminQueryData, UserConProfileAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<UserConProfileAdminQueryData, UserConProfileAdminQueryVariables>(UserConProfileAdminQueryDocument, options);
       }
-export function useUserConProfileAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserConProfileAdminQueryQuery, UserConProfileAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<UserConProfileAdminQueryQuery, UserConProfileAdminQueryQueryVariables>(UserConProfileAdminQueryDocument, baseOptions);
+export function useUserConProfileAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserConProfileAdminQueryData, UserConProfileAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<UserConProfileAdminQueryData, UserConProfileAdminQueryVariables>(UserConProfileAdminQueryDocument, options);
         }
-export type UserConProfileAdminQueryQueryHookResult = ReturnType<typeof useUserConProfileAdminQueryQuery>;
+export type UserConProfileAdminQueryHookResult = ReturnType<typeof useUserConProfileAdminQuery>;
 export type UserConProfileAdminQueryLazyQueryHookResult = ReturnType<typeof useUserConProfileAdminQueryLazyQuery>;
-export type UserConProfileAdminQueryQueryResult = Apollo.QueryResult<UserConProfileAdminQueryQuery, UserConProfileAdminQueryQueryVariables>;
+export type UserConProfileAdminQueryDataResult = Apollo.QueryResult<UserConProfileAdminQueryData, UserConProfileAdminQueryVariables>;
 export const UserConProfilesTableUserConProfilesQueryDocument = gql`
     query UserConProfilesTableUserConProfilesQuery($page: Int, $perPage: Int, $filters: UserConProfileFiltersInput, $sort: [SortInput!]) {
   convention {
@@ -495,16 +500,16 @@ export const UserConProfilesTableUserConProfilesQueryDocument = gql`
     ${CommonFormFieldsFragmentDoc}`;
 
 /**
- * __useUserConProfilesTableUserConProfilesQueryQuery__
+ * __useUserConProfilesTableUserConProfilesQuery__
  *
- * To run a query within a React component, call `useUserConProfilesTableUserConProfilesQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useUserConProfilesTableUserConProfilesQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useUserConProfilesTableUserConProfilesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUserConProfilesTableUserConProfilesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useUserConProfilesTableUserConProfilesQueryQuery({
+ * const { data, loading, error } = useUserConProfilesTableUserConProfilesQuery({
  *   variables: {
  *      page: // value for 'page'
  *      perPage: // value for 'perPage'
@@ -513,15 +518,17 @@ export const UserConProfilesTableUserConProfilesQueryDocument = gql`
  *   },
  * });
  */
-export function useUserConProfilesTableUserConProfilesQueryQuery(baseOptions?: Apollo.QueryHookOptions<UserConProfilesTableUserConProfilesQueryQuery, UserConProfilesTableUserConProfilesQueryQueryVariables>) {
-        return Apollo.useQuery<UserConProfilesTableUserConProfilesQueryQuery, UserConProfilesTableUserConProfilesQueryQueryVariables>(UserConProfilesTableUserConProfilesQueryDocument, baseOptions);
+export function useUserConProfilesTableUserConProfilesQuery(baseOptions?: Apollo.QueryHookOptions<UserConProfilesTableUserConProfilesQueryData, UserConProfilesTableUserConProfilesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<UserConProfilesTableUserConProfilesQueryData, UserConProfilesTableUserConProfilesQueryVariables>(UserConProfilesTableUserConProfilesQueryDocument, options);
       }
-export function useUserConProfilesTableUserConProfilesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserConProfilesTableUserConProfilesQueryQuery, UserConProfilesTableUserConProfilesQueryQueryVariables>) {
-          return Apollo.useLazyQuery<UserConProfilesTableUserConProfilesQueryQuery, UserConProfilesTableUserConProfilesQueryQueryVariables>(UserConProfilesTableUserConProfilesQueryDocument, baseOptions);
+export function useUserConProfilesTableUserConProfilesQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserConProfilesTableUserConProfilesQueryData, UserConProfilesTableUserConProfilesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<UserConProfilesTableUserConProfilesQueryData, UserConProfilesTableUserConProfilesQueryVariables>(UserConProfilesTableUserConProfilesQueryDocument, options);
         }
-export type UserConProfilesTableUserConProfilesQueryQueryHookResult = ReturnType<typeof useUserConProfilesTableUserConProfilesQueryQuery>;
+export type UserConProfilesTableUserConProfilesQueryHookResult = ReturnType<typeof useUserConProfilesTableUserConProfilesQuery>;
 export type UserConProfilesTableUserConProfilesQueryLazyQueryHookResult = ReturnType<typeof useUserConProfilesTableUserConProfilesQueryLazyQuery>;
-export type UserConProfilesTableUserConProfilesQueryQueryResult = Apollo.QueryResult<UserConProfilesTableUserConProfilesQueryQuery, UserConProfilesTableUserConProfilesQueryQueryVariables>;
+export type UserConProfilesTableUserConProfilesQueryDataResult = Apollo.QueryResult<UserConProfilesTableUserConProfilesQueryData, UserConProfilesTableUserConProfilesQueryVariables>;
 export const ConvertToEventProvidedTicketQueryDocument = gql`
     query ConvertToEventProvidedTicketQuery($eventId: Int!) {
   convention {
@@ -553,30 +560,32 @@ export const ConvertToEventProvidedTicketQueryDocument = gql`
     `;
 
 /**
- * __useConvertToEventProvidedTicketQueryQuery__
+ * __useConvertToEventProvidedTicketQuery__
  *
- * To run a query within a React component, call `useConvertToEventProvidedTicketQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useConvertToEventProvidedTicketQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useConvertToEventProvidedTicketQuery` and pass it any options that fit your needs.
+ * When your component renders, `useConvertToEventProvidedTicketQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useConvertToEventProvidedTicketQueryQuery({
+ * const { data, loading, error } = useConvertToEventProvidedTicketQuery({
  *   variables: {
  *      eventId: // value for 'eventId'
  *   },
  * });
  */
-export function useConvertToEventProvidedTicketQueryQuery(baseOptions: Apollo.QueryHookOptions<ConvertToEventProvidedTicketQueryQuery, ConvertToEventProvidedTicketQueryQueryVariables>) {
-        return Apollo.useQuery<ConvertToEventProvidedTicketQueryQuery, ConvertToEventProvidedTicketQueryQueryVariables>(ConvertToEventProvidedTicketQueryDocument, baseOptions);
+export function useConvertToEventProvidedTicketQuery(baseOptions: Apollo.QueryHookOptions<ConvertToEventProvidedTicketQueryData, ConvertToEventProvidedTicketQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ConvertToEventProvidedTicketQueryData, ConvertToEventProvidedTicketQueryVariables>(ConvertToEventProvidedTicketQueryDocument, options);
       }
-export function useConvertToEventProvidedTicketQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ConvertToEventProvidedTicketQueryQuery, ConvertToEventProvidedTicketQueryQueryVariables>) {
-          return Apollo.useLazyQuery<ConvertToEventProvidedTicketQueryQuery, ConvertToEventProvidedTicketQueryQueryVariables>(ConvertToEventProvidedTicketQueryDocument, baseOptions);
+export function useConvertToEventProvidedTicketQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ConvertToEventProvidedTicketQueryData, ConvertToEventProvidedTicketQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ConvertToEventProvidedTicketQueryData, ConvertToEventProvidedTicketQueryVariables>(ConvertToEventProvidedTicketQueryDocument, options);
         }
-export type ConvertToEventProvidedTicketQueryQueryHookResult = ReturnType<typeof useConvertToEventProvidedTicketQueryQuery>;
+export type ConvertToEventProvidedTicketQueryHookResult = ReturnType<typeof useConvertToEventProvidedTicketQuery>;
 export type ConvertToEventProvidedTicketQueryLazyQueryHookResult = ReturnType<typeof useConvertToEventProvidedTicketQueryLazyQuery>;
-export type ConvertToEventProvidedTicketQueryQueryResult = Apollo.QueryResult<ConvertToEventProvidedTicketQueryQuery, ConvertToEventProvidedTicketQueryQueryVariables>;
+export type ConvertToEventProvidedTicketQueryDataResult = Apollo.QueryResult<ConvertToEventProvidedTicketQueryData, ConvertToEventProvidedTicketQueryVariables>;
 export const AddAttendeeUsersQueryDocument = gql`
     query AddAttendeeUsersQuery($name: String) {
   users_paginated(filters: {name: $name}, per_page: 50) {
@@ -592,30 +601,32 @@ export const AddAttendeeUsersQueryDocument = gql`
     `;
 
 /**
- * __useAddAttendeeUsersQueryQuery__
+ * __useAddAttendeeUsersQuery__
  *
- * To run a query within a React component, call `useAddAttendeeUsersQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useAddAttendeeUsersQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAddAttendeeUsersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAddAttendeeUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useAddAttendeeUsersQueryQuery({
+ * const { data, loading, error } = useAddAttendeeUsersQuery({
  *   variables: {
  *      name: // value for 'name'
  *   },
  * });
  */
-export function useAddAttendeeUsersQueryQuery(baseOptions?: Apollo.QueryHookOptions<AddAttendeeUsersQueryQuery, AddAttendeeUsersQueryQueryVariables>) {
-        return Apollo.useQuery<AddAttendeeUsersQueryQuery, AddAttendeeUsersQueryQueryVariables>(AddAttendeeUsersQueryDocument, baseOptions);
+export function useAddAttendeeUsersQuery(baseOptions?: Apollo.QueryHookOptions<AddAttendeeUsersQueryData, AddAttendeeUsersQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AddAttendeeUsersQueryData, AddAttendeeUsersQueryVariables>(AddAttendeeUsersQueryDocument, options);
       }
-export function useAddAttendeeUsersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AddAttendeeUsersQueryQuery, AddAttendeeUsersQueryQueryVariables>) {
-          return Apollo.useLazyQuery<AddAttendeeUsersQueryQuery, AddAttendeeUsersQueryQueryVariables>(AddAttendeeUsersQueryDocument, baseOptions);
+export function useAddAttendeeUsersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AddAttendeeUsersQueryData, AddAttendeeUsersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AddAttendeeUsersQueryData, AddAttendeeUsersQueryVariables>(AddAttendeeUsersQueryDocument, options);
         }
-export type AddAttendeeUsersQueryQueryHookResult = ReturnType<typeof useAddAttendeeUsersQueryQuery>;
+export type AddAttendeeUsersQueryHookResult = ReturnType<typeof useAddAttendeeUsersQuery>;
 export type AddAttendeeUsersQueryLazyQueryHookResult = ReturnType<typeof useAddAttendeeUsersQueryLazyQuery>;
-export type AddAttendeeUsersQueryQueryResult = Apollo.QueryResult<AddAttendeeUsersQueryQuery, AddAttendeeUsersQueryQueryVariables>;
+export type AddAttendeeUsersQueryDataResult = Apollo.QueryResult<AddAttendeeUsersQueryData, AddAttendeeUsersQueryVariables>;
 export const TicketAdminWithoutTicketAbilityQueryDocument = gql`
     query TicketAdminWithoutTicketAbilityQuery {
   currentAbility {
@@ -625,29 +636,31 @@ export const TicketAdminWithoutTicketAbilityQueryDocument = gql`
     `;
 
 /**
- * __useTicketAdminWithoutTicketAbilityQueryQuery__
+ * __useTicketAdminWithoutTicketAbilityQuery__
  *
- * To run a query within a React component, call `useTicketAdminWithoutTicketAbilityQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useTicketAdminWithoutTicketAbilityQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useTicketAdminWithoutTicketAbilityQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTicketAdminWithoutTicketAbilityQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useTicketAdminWithoutTicketAbilityQueryQuery({
+ * const { data, loading, error } = useTicketAdminWithoutTicketAbilityQuery({
  *   variables: {
  *   },
  * });
  */
-export function useTicketAdminWithoutTicketAbilityQueryQuery(baseOptions?: Apollo.QueryHookOptions<TicketAdminWithoutTicketAbilityQueryQuery, TicketAdminWithoutTicketAbilityQueryQueryVariables>) {
-        return Apollo.useQuery<TicketAdminWithoutTicketAbilityQueryQuery, TicketAdminWithoutTicketAbilityQueryQueryVariables>(TicketAdminWithoutTicketAbilityQueryDocument, baseOptions);
+export function useTicketAdminWithoutTicketAbilityQuery(baseOptions?: Apollo.QueryHookOptions<TicketAdminWithoutTicketAbilityQueryData, TicketAdminWithoutTicketAbilityQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TicketAdminWithoutTicketAbilityQueryData, TicketAdminWithoutTicketAbilityQueryVariables>(TicketAdminWithoutTicketAbilityQueryDocument, options);
       }
-export function useTicketAdminWithoutTicketAbilityQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TicketAdminWithoutTicketAbilityQueryQuery, TicketAdminWithoutTicketAbilityQueryQueryVariables>) {
-          return Apollo.useLazyQuery<TicketAdminWithoutTicketAbilityQueryQuery, TicketAdminWithoutTicketAbilityQueryQueryVariables>(TicketAdminWithoutTicketAbilityQueryDocument, baseOptions);
+export function useTicketAdminWithoutTicketAbilityQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TicketAdminWithoutTicketAbilityQueryData, TicketAdminWithoutTicketAbilityQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TicketAdminWithoutTicketAbilityQueryData, TicketAdminWithoutTicketAbilityQueryVariables>(TicketAdminWithoutTicketAbilityQueryDocument, options);
         }
-export type TicketAdminWithoutTicketAbilityQueryQueryHookResult = ReturnType<typeof useTicketAdminWithoutTicketAbilityQueryQuery>;
+export type TicketAdminWithoutTicketAbilityQueryHookResult = ReturnType<typeof useTicketAdminWithoutTicketAbilityQuery>;
 export type TicketAdminWithoutTicketAbilityQueryLazyQueryHookResult = ReturnType<typeof useTicketAdminWithoutTicketAbilityQueryLazyQuery>;
-export type TicketAdminWithoutTicketAbilityQueryQueryResult = Apollo.QueryResult<TicketAdminWithoutTicketAbilityQueryQuery, TicketAdminWithoutTicketAbilityQueryQueryVariables>;
+export type TicketAdminWithoutTicketAbilityQueryDataResult = Apollo.QueryResult<TicketAdminWithoutTicketAbilityQueryData, TicketAdminWithoutTicketAbilityQueryVariables>;
 export const TicketAdminWithTicketAbilityQueryDocument = gql`
     query TicketAdminWithTicketAbilityQuery($ticketId: Int!) {
   currentAbility {
@@ -659,27 +672,29 @@ export const TicketAdminWithTicketAbilityQueryDocument = gql`
     `;
 
 /**
- * __useTicketAdminWithTicketAbilityQueryQuery__
+ * __useTicketAdminWithTicketAbilityQuery__
  *
- * To run a query within a React component, call `useTicketAdminWithTicketAbilityQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useTicketAdminWithTicketAbilityQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useTicketAdminWithTicketAbilityQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTicketAdminWithTicketAbilityQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useTicketAdminWithTicketAbilityQueryQuery({
+ * const { data, loading, error } = useTicketAdminWithTicketAbilityQuery({
  *   variables: {
  *      ticketId: // value for 'ticketId'
  *   },
  * });
  */
-export function useTicketAdminWithTicketAbilityQueryQuery(baseOptions: Apollo.QueryHookOptions<TicketAdminWithTicketAbilityQueryQuery, TicketAdminWithTicketAbilityQueryQueryVariables>) {
-        return Apollo.useQuery<TicketAdminWithTicketAbilityQueryQuery, TicketAdminWithTicketAbilityQueryQueryVariables>(TicketAdminWithTicketAbilityQueryDocument, baseOptions);
+export function useTicketAdminWithTicketAbilityQuery(baseOptions: Apollo.QueryHookOptions<TicketAdminWithTicketAbilityQueryData, TicketAdminWithTicketAbilityQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TicketAdminWithTicketAbilityQueryData, TicketAdminWithTicketAbilityQueryVariables>(TicketAdminWithTicketAbilityQueryDocument, options);
       }
-export function useTicketAdminWithTicketAbilityQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TicketAdminWithTicketAbilityQueryQuery, TicketAdminWithTicketAbilityQueryQueryVariables>) {
-          return Apollo.useLazyQuery<TicketAdminWithTicketAbilityQueryQuery, TicketAdminWithTicketAbilityQueryQueryVariables>(TicketAdminWithTicketAbilityQueryDocument, baseOptions);
+export function useTicketAdminWithTicketAbilityQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TicketAdminWithTicketAbilityQueryData, TicketAdminWithTicketAbilityQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TicketAdminWithTicketAbilityQueryData, TicketAdminWithTicketAbilityQueryVariables>(TicketAdminWithTicketAbilityQueryDocument, options);
         }
-export type TicketAdminWithTicketAbilityQueryQueryHookResult = ReturnType<typeof useTicketAdminWithTicketAbilityQueryQuery>;
+export type TicketAdminWithTicketAbilityQueryHookResult = ReturnType<typeof useTicketAdminWithTicketAbilityQuery>;
 export type TicketAdminWithTicketAbilityQueryLazyQueryHookResult = ReturnType<typeof useTicketAdminWithTicketAbilityQueryLazyQuery>;
-export type TicketAdminWithTicketAbilityQueryQueryResult = Apollo.QueryResult<TicketAdminWithTicketAbilityQueryQuery, TicketAdminWithTicketAbilityQueryQueryVariables>;
+export type TicketAdminWithTicketAbilityQueryDataResult = Apollo.QueryResult<TicketAdminWithTicketAbilityQueryData, TicketAdminWithTicketAbilityQueryVariables>;

--- a/app/javascript/Users/MergeUsersModal.tsx
+++ b/app/javascript/Users/MergeUsersModal.tsx
@@ -11,7 +11,7 @@ import ChoiceSet from '../BuiltInFormControls/ChoiceSet';
 import ErrorDisplay from '../ErrorDisplay';
 import LoadingIndicator from '../LoadingIndicator';
 import pluralizeWithCount from '../pluralizeWithCount';
-import { MergeUsersModalQueryQuery, useMergeUsersModalQueryQuery } from './queries.generated';
+import { MergeUsersModalQueryData, useMergeUsersModalQuery } from './queries.generated';
 import { useMergeUsersMutation } from './mutations.generated';
 
 function renderIfQueryReady(
@@ -29,7 +29,7 @@ function renderIfQueryReady(
   return render();
 }
 
-type UserType = MergeUsersModalQueryQuery['users'][0];
+type UserType = MergeUsersModalQueryData['users'][0];
 type UserConProfileType = UserType['user_con_profiles'][0];
 type ConventionType = UserConProfileType['convention'];
 
@@ -40,7 +40,7 @@ export type MergeUsersModalProps = {
 };
 
 function MergeUsersModal({ closeModal, visible, userIds }: MergeUsersModalProps) {
-  const { data, loading, error } = useMergeUsersModalQueryQuery({
+  const { data, loading, error } = useMergeUsersModalQuery({
     variables: { ids: userIds || [] },
   });
   const [winningUserId, setWinningUserId] = useState<number>();

--- a/app/javascript/Users/UserAdminDisplay.tsx
+++ b/app/javascript/Users/UserAdminDisplay.tsx
@@ -5,16 +5,16 @@ import sortBy from 'lodash/sortBy';
 import { useParams } from 'react-router-dom';
 
 import usePageTitle from '../usePageTitle';
-import { UserAdminQueryQuery, useUserAdminQueryQuery } from './queries.generated';
+import { UserAdminQueryData, useUserAdminQuery } from './queries.generated';
 import { LoadQueryWrapper } from '../GraphqlLoadingWrappers';
 import { timespanFromConvention } from '../TimespanUtils';
 import { useAppDateTimeFormat } from '../TimeUtils';
 
-function sortByConventionDate(profiles: UserAdminQueryQuery['user']['user_con_profiles']) {
+function sortByConventionDate(profiles: UserAdminQueryData['user']['user_con_profiles']) {
   return reverse(sortBy(profiles, (profile) => profile.convention.starts_at));
 }
 
-function buildProfileUrl(profile: UserAdminQueryQuery['user']['user_con_profiles'][0]) {
+function buildProfileUrl(profile: UserAdminQueryData['user']['user_con_profiles'][0]) {
   const profileUrl = new URL(
     `//${profile.convention.domain}/user_con_profiles/${profile.id}`,
     window.location.href,
@@ -25,11 +25,11 @@ function buildProfileUrl(profile: UserAdminQueryQuery['user']['user_con_profiles
 
 function useLoadUserAdminData() {
   const userId = Number.parseInt(useParams<{ id: string }>().id, 10);
-  return useUserAdminQueryQuery({ variables: { id: userId } });
+  return useUserAdminQuery({ variables: { id: userId } });
 }
 
 function renderProfileConventionYear(
-  profile: UserAdminQueryQuery['user']['user_con_profiles'][number],
+  profile: UserAdminQueryData['user']['user_con_profiles'][number],
   format: ReturnType<typeof useAppDateTimeFormat>,
 ) {
   const { start } = timespanFromConvention(profile.convention);

--- a/app/javascript/Users/UsersAdmin.tsx
+++ b/app/javascript/Users/UsersAdmin.tsx
@@ -6,11 +6,11 @@ import LoadingIndicator from '../LoadingIndicator';
 import BreadcrumbItem from '../Breadcrumbs/BreadcrumbItem';
 import RouteActivatedBreadcrumbItem from '../Breadcrumbs/RouteActivatedBreadcrumbItem';
 import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
-import { useUserAdminQueryQuery } from './queries.generated';
+import { useUserAdminQuery } from './queries.generated';
 
 function UserBreadcrumbItem() {
   const id = Number.parseInt(useParams<{ id: string }>().id, 10);
-  const { data, loading, error } = useUserAdminQueryQuery({ variables: { id } });
+  const { data, loading, error } = useUserAdminQuery({ variables: { id } });
 
   if (loading) {
     return (

--- a/app/javascript/Users/UsersTable.tsx
+++ b/app/javascript/Users/UsersTable.tsx
@@ -11,13 +11,13 @@ import useModal from '../ModalDialogs/useModal';
 import MergeUsersModal from './MergeUsersModal';
 import usePageTitle from '../usePageTitle';
 import {
-  UsersTableUsersQueryQuery,
-  UsersTableUsersQueryQueryVariables,
-  useUsersTableUsersQueryQuery,
+  UsersTableUsersQueryData,
+  UsersTableUsersQueryVariables,
+  useUsersTableUsersQuery,
 } from './queries.generated';
 import ReactTableWithTheWorks from '../Tables/ReactTableWithTheWorks';
 
-type UserType = UsersTableUsersQueryQuery['users_paginated']['entries'][0];
+type UserType = UsersTableUsersQueryData['users_paginated']['entries'][0];
 
 const { encodeFilterValue, decodeFilterValue } = buildFieldFilterCodecs({});
 
@@ -73,9 +73,9 @@ function UsersTable() {
   usePageTitle('Users');
 
   const { tableInstance, refetch, tableHeaderProps, loading } = useReactTableWithTheWorks<
-    UsersTableUsersQueryQuery,
+    UsersTableUsersQueryData,
     UserType,
-    UsersTableUsersQueryQueryVariables
+    UsersTableUsersQueryVariables
   >({
     decodeFilterValue,
     defaultVisibleColumns,
@@ -85,7 +85,7 @@ function UsersTable() {
     getPossibleColumns,
     rowSelect: true,
     storageKeyPrefix: 'users',
-    useQuery: useUsersTableUsersQueryQuery,
+    useQuery: useUsersTableUsersQuery,
   });
 
   return (

--- a/app/javascript/Users/mutations.generated.ts
+++ b/app/javascript/Users/mutations.generated.ts
@@ -5,6 +5,7 @@ import { DetailedUserFieldsFragment } from './queries.generated';
 import { gql } from '@apollo/client';
 import { DetailedUserFieldsFragmentDoc } from './queries.generated';
 import * as Apollo from '@apollo/client';
+const defaultOptions =  {}
 export type MergeUsersMutationVariables = Types.Exact<{
   userIds: Array<Types.Scalars['Int']> | Types.Scalars['Int'];
   winningUserId: Types.Scalars['Int'];
@@ -12,7 +13,7 @@ export type MergeUsersMutationVariables = Types.Exact<{
 }>;
 
 
-export type MergeUsersMutation = (
+export type MergeUsersMutationData = (
   { __typename: 'Mutation' }
   & { mergeUsers?: Types.Maybe<(
     { __typename: 'MergeUsersPayload' }
@@ -37,7 +38,7 @@ export const MergeUsersDocument = gql`
   }
 }
     ${DetailedUserFieldsFragmentDoc}`;
-export type MergeUsersMutationFn = Apollo.MutationFunction<MergeUsersMutation, MergeUsersMutationVariables>;
+export type MergeUsersMutationFn = Apollo.MutationFunction<MergeUsersMutationData, MergeUsersMutationVariables>;
 
 /**
  * __useMergeUsersMutation__
@@ -58,9 +59,10 @@ export type MergeUsersMutationFn = Apollo.MutationFunction<MergeUsersMutation, M
  *   },
  * });
  */
-export function useMergeUsersMutation(baseOptions?: Apollo.MutationHookOptions<MergeUsersMutation, MergeUsersMutationVariables>) {
-        return Apollo.useMutation<MergeUsersMutation, MergeUsersMutationVariables>(MergeUsersDocument, baseOptions);
+export function useMergeUsersMutation(baseOptions?: Apollo.MutationHookOptions<MergeUsersMutationData, MergeUsersMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<MergeUsersMutationData, MergeUsersMutationVariables>(MergeUsersDocument, options);
       }
 export type MergeUsersMutationHookResult = ReturnType<typeof useMergeUsersMutation>;
-export type MergeUsersMutationResult = Apollo.MutationResult<MergeUsersMutation>;
-export type MergeUsersMutationOptions = Apollo.BaseMutationOptions<MergeUsersMutation, MergeUsersMutationVariables>;
+export type MergeUsersMutationResult = Apollo.MutationResult<MergeUsersMutationData>;
+export type MergeUsersMutationOptions = Apollo.BaseMutationOptions<MergeUsersMutationData, MergeUsersMutationVariables>;

--- a/app/javascript/Users/queries.generated.ts
+++ b/app/javascript/Users/queries.generated.ts
@@ -3,7 +3,8 @@ import * as Types from '../graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type UsersTableUsersQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type UsersTableUsersQueryVariables = Types.Exact<{
   page?: Types.Maybe<Types.Scalars['Int']>;
   perPage?: Types.Maybe<Types.Scalars['Int']>;
   filters?: Types.Maybe<Types.UserFiltersInput>;
@@ -11,7 +12,7 @@ export type UsersTableUsersQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type UsersTableUsersQueryQuery = (
+export type UsersTableUsersQueryData = (
   { __typename: 'Query' }
   & { users_paginated: (
     { __typename: 'UsersPagination' }
@@ -48,12 +49,12 @@ export type DetailedUserFieldsFragment = (
   )> }
 );
 
-export type UserAdminQueryQueryVariables = Types.Exact<{
+export type UserAdminQueryVariables = Types.Exact<{
   id: Types.Scalars['Int'];
 }>;
 
 
-export type UserAdminQueryQuery = (
+export type UserAdminQueryData = (
   { __typename: 'Query' }
   & { user: (
     { __typename: 'User' }
@@ -62,12 +63,12 @@ export type UserAdminQueryQuery = (
   ) }
 );
 
-export type MergeUsersModalQueryQueryVariables = Types.Exact<{
+export type MergeUsersModalQueryVariables = Types.Exact<{
   ids: Array<Types.Scalars['Int']> | Types.Scalars['Int'];
 }>;
 
 
-export type MergeUsersModalQueryQuery = (
+export type MergeUsersModalQueryData = (
   { __typename: 'Query' }
   & { users: Array<(
     { __typename: 'User' }
@@ -133,16 +134,16 @@ export const UsersTableUsersQueryDocument = gql`
     `;
 
 /**
- * __useUsersTableUsersQueryQuery__
+ * __useUsersTableUsersQuery__
  *
- * To run a query within a React component, call `useUsersTableUsersQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useUsersTableUsersQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useUsersTableUsersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUsersTableUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useUsersTableUsersQueryQuery({
+ * const { data, loading, error } = useUsersTableUsersQuery({
  *   variables: {
  *      page: // value for 'page'
  *      perPage: // value for 'perPage'
@@ -151,15 +152,17 @@ export const UsersTableUsersQueryDocument = gql`
  *   },
  * });
  */
-export function useUsersTableUsersQueryQuery(baseOptions?: Apollo.QueryHookOptions<UsersTableUsersQueryQuery, UsersTableUsersQueryQueryVariables>) {
-        return Apollo.useQuery<UsersTableUsersQueryQuery, UsersTableUsersQueryQueryVariables>(UsersTableUsersQueryDocument, baseOptions);
+export function useUsersTableUsersQuery(baseOptions?: Apollo.QueryHookOptions<UsersTableUsersQueryData, UsersTableUsersQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<UsersTableUsersQueryData, UsersTableUsersQueryVariables>(UsersTableUsersQueryDocument, options);
       }
-export function useUsersTableUsersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UsersTableUsersQueryQuery, UsersTableUsersQueryQueryVariables>) {
-          return Apollo.useLazyQuery<UsersTableUsersQueryQuery, UsersTableUsersQueryQueryVariables>(UsersTableUsersQueryDocument, baseOptions);
+export function useUsersTableUsersQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UsersTableUsersQueryData, UsersTableUsersQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<UsersTableUsersQueryData, UsersTableUsersQueryVariables>(UsersTableUsersQueryDocument, options);
         }
-export type UsersTableUsersQueryQueryHookResult = ReturnType<typeof useUsersTableUsersQueryQuery>;
+export type UsersTableUsersQueryHookResult = ReturnType<typeof useUsersTableUsersQuery>;
 export type UsersTableUsersQueryLazyQueryHookResult = ReturnType<typeof useUsersTableUsersQueryLazyQuery>;
-export type UsersTableUsersQueryQueryResult = Apollo.QueryResult<UsersTableUsersQueryQuery, UsersTableUsersQueryQueryVariables>;
+export type UsersTableUsersQueryDataResult = Apollo.QueryResult<UsersTableUsersQueryData, UsersTableUsersQueryVariables>;
 export const UserAdminQueryDocument = gql`
     query UserAdminQuery($id: Int!) {
   user(id: $id) {
@@ -170,30 +173,32 @@ export const UserAdminQueryDocument = gql`
     ${DetailedUserFieldsFragmentDoc}`;
 
 /**
- * __useUserAdminQueryQuery__
+ * __useUserAdminQuery__
  *
- * To run a query within a React component, call `useUserAdminQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useUserAdminQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useUserAdminQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUserAdminQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useUserAdminQueryQuery({
+ * const { data, loading, error } = useUserAdminQuery({
  *   variables: {
  *      id: // value for 'id'
  *   },
  * });
  */
-export function useUserAdminQueryQuery(baseOptions: Apollo.QueryHookOptions<UserAdminQueryQuery, UserAdminQueryQueryVariables>) {
-        return Apollo.useQuery<UserAdminQueryQuery, UserAdminQueryQueryVariables>(UserAdminQueryDocument, baseOptions);
+export function useUserAdminQuery(baseOptions: Apollo.QueryHookOptions<UserAdminQueryData, UserAdminQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<UserAdminQueryData, UserAdminQueryVariables>(UserAdminQueryDocument, options);
       }
-export function useUserAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserAdminQueryQuery, UserAdminQueryQueryVariables>) {
-          return Apollo.useLazyQuery<UserAdminQueryQuery, UserAdminQueryQueryVariables>(UserAdminQueryDocument, baseOptions);
+export function useUserAdminQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<UserAdminQueryData, UserAdminQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<UserAdminQueryData, UserAdminQueryVariables>(UserAdminQueryDocument, options);
         }
-export type UserAdminQueryQueryHookResult = ReturnType<typeof useUserAdminQueryQuery>;
+export type UserAdminQueryHookResult = ReturnType<typeof useUserAdminQuery>;
 export type UserAdminQueryLazyQueryHookResult = ReturnType<typeof useUserAdminQueryLazyQuery>;
-export type UserAdminQueryQueryResult = Apollo.QueryResult<UserAdminQueryQuery, UserAdminQueryQueryVariables>;
+export type UserAdminQueryDataResult = Apollo.QueryResult<UserAdminQueryData, UserAdminQueryVariables>;
 export const MergeUsersModalQueryDocument = gql`
     query MergeUsersModalQuery($ids: [Int!]!) {
   users(ids: $ids) {
@@ -204,27 +209,29 @@ export const MergeUsersModalQueryDocument = gql`
     ${DetailedUserFieldsFragmentDoc}`;
 
 /**
- * __useMergeUsersModalQueryQuery__
+ * __useMergeUsersModalQuery__
  *
- * To run a query within a React component, call `useMergeUsersModalQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useMergeUsersModalQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useMergeUsersModalQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMergeUsersModalQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useMergeUsersModalQueryQuery({
+ * const { data, loading, error } = useMergeUsersModalQuery({
  *   variables: {
  *      ids: // value for 'ids'
  *   },
  * });
  */
-export function useMergeUsersModalQueryQuery(baseOptions: Apollo.QueryHookOptions<MergeUsersModalQueryQuery, MergeUsersModalQueryQueryVariables>) {
-        return Apollo.useQuery<MergeUsersModalQueryQuery, MergeUsersModalQueryQueryVariables>(MergeUsersModalQueryDocument, baseOptions);
+export function useMergeUsersModalQuery(baseOptions: Apollo.QueryHookOptions<MergeUsersModalQueryData, MergeUsersModalQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MergeUsersModalQueryData, MergeUsersModalQueryVariables>(MergeUsersModalQueryDocument, options);
       }
-export function useMergeUsersModalQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MergeUsersModalQueryQuery, MergeUsersModalQueryQueryVariables>) {
-          return Apollo.useLazyQuery<MergeUsersModalQueryQuery, MergeUsersModalQueryQueryVariables>(MergeUsersModalQueryDocument, baseOptions);
+export function useMergeUsersModalQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MergeUsersModalQueryData, MergeUsersModalQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MergeUsersModalQueryData, MergeUsersModalQueryVariables>(MergeUsersModalQueryDocument, options);
         }
-export type MergeUsersModalQueryQueryHookResult = ReturnType<typeof useMergeUsersModalQueryQuery>;
+export type MergeUsersModalQueryHookResult = ReturnType<typeof useMergeUsersModalQuery>;
 export type MergeUsersModalQueryLazyQueryHookResult = ReturnType<typeof useMergeUsersModalQueryLazyQuery>;
-export type MergeUsersModalQueryQueryResult = Apollo.QueryResult<MergeUsersModalQueryQuery, MergeUsersModalQueryQueryVariables>;
+export type MergeUsersModalQueryDataResult = Apollo.QueryResult<MergeUsersModalQueryData, MergeUsersModalQueryVariables>;

--- a/app/javascript/appRootQueries.generated.ts
+++ b/app/javascript/appRootQueries.generated.ts
@@ -3,12 +3,13 @@ import * as Types from './graphqlTypes.generated';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
-export type AppRootQueryQueryVariables = Types.Exact<{
+const defaultOptions =  {}
+export type AppRootQueryVariables = Types.Exact<{
   path: Types.Scalars['String'];
 }>;
 
 
-export type AppRootQueryQuery = (
+export type AppRootQueryData = (
   { __typename: 'Query' }
   & { effectiveCmsLayout: (
     { __typename: 'CmsLayout' }
@@ -170,27 +171,29 @@ export const AppRootQueryDocument = gql`
     `;
 
 /**
- * __useAppRootQueryQuery__
+ * __useAppRootQuery__
  *
- * To run a query within a React component, call `useAppRootQueryQuery` and pass it any options that fit your needs.
- * When your component renders, `useAppRootQueryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAppRootQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAppRootQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useAppRootQueryQuery({
+ * const { data, loading, error } = useAppRootQuery({
  *   variables: {
  *      path: // value for 'path'
  *   },
  * });
  */
-export function useAppRootQueryQuery(baseOptions: Apollo.QueryHookOptions<AppRootQueryQuery, AppRootQueryQueryVariables>) {
-        return Apollo.useQuery<AppRootQueryQuery, AppRootQueryQueryVariables>(AppRootQueryDocument, baseOptions);
+export function useAppRootQuery(baseOptions: Apollo.QueryHookOptions<AppRootQueryData, AppRootQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<AppRootQueryData, AppRootQueryVariables>(AppRootQueryDocument, options);
       }
-export function useAppRootQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AppRootQueryQuery, AppRootQueryQueryVariables>) {
-          return Apollo.useLazyQuery<AppRootQueryQuery, AppRootQueryQueryVariables>(AppRootQueryDocument, baseOptions);
+export function useAppRootQueryLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AppRootQueryData, AppRootQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<AppRootQueryData, AppRootQueryVariables>(AppRootQueryDocument, options);
         }
-export type AppRootQueryQueryHookResult = ReturnType<typeof useAppRootQueryQuery>;
+export type AppRootQueryHookResult = ReturnType<typeof useAppRootQuery>;
 export type AppRootQueryLazyQueryHookResult = ReturnType<typeof useAppRootQueryLazyQuery>;
-export type AppRootQueryQueryResult = Apollo.QueryResult<AppRootQueryQuery, AppRootQueryQueryVariables>;
+export type AppRootQueryDataResult = Apollo.QueryResult<AppRootQueryData, AppRootQueryVariables>;

--- a/codegen.yml
+++ b/codegen.yml
@@ -31,3 +31,5 @@ generates:
       documentMode: graphQLTag
       gqlImport: '@apollo/client#gql'
       nonOptionalTypename: true
+      dedupeOperationSuffix: true
+      operationResultSuffix: Data


### PR DESCRIPTION
I found out about graphql-code-generator/typescript-operations's `dedupeOperationSuffix` option, which is what I've been looking for this whole time.  Let's redo all the type names!!!!!