### PR TITLE
Fix permissions UI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -524,7 +524,7 @@ GEM
     skylight (5.1.1)
       activesupport (>= 5.2.0)
     slop (3.6.0)
-    solargraph (0.44.2)
+    solargraph (0.44.3)
       backport (~> 1.2)
       benchmark
       bundler (>= 1.17.2)

--- a/app/graphql/types/permission_input_type.rb
+++ b/app/graphql/types/permission_input_type.rb
@@ -22,7 +22,7 @@ class Types::PermissionInputType < Types::BaseInputObject
       .group_by { |input| input[type_field] }
       .flat_map do |record_type, inputs|
         record_class = record_type.safe_constantize
-        records_by_id = record_class.find(inputs.map { |input| input[id_field] }).index_by(&:id)
+        records_by_id = record_class.find(inputs.map { |input| input[id_field] }).index_by { |record| record.id.to_s }
         inputs.map { |input| { association_name => records_by_id[input[id_field]], :permission => input[:permission] } }
       end
   end

--- a/app/javascript/ChangeSet.ts
+++ b/app/javascript/ChangeSet.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { ActionMeta } from 'react-select';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -86,21 +86,23 @@ class ChangeSet<T extends ChangeTrackable> {
 
 export default ChangeSet;
 
-export function useChangeSet<T extends ChangeTrackable>(): [
+export function useChangeSet<T extends ChangeTrackable>(): readonly [
   changeSet: ChangeSet<T>,
   add: (...addArgs: Parameters<ChangeSet<T>['add']>) => void,
   remove: (...removeArgs: Parameters<ChangeSet<T>['remove']>) => void,
+  reset: () => void,
 ] {
   const [changeSet, setChangeSet] = useState(new ChangeSet<T>());
 
-  const add = (...addArgs: Parameters<ChangeSet<T>['add']>) => {
-    setChangeSet(changeSet.add(...addArgs));
-  };
-  const remove = (...removeArgs: Parameters<ChangeSet<T>['remove']>) => {
-    setChangeSet(changeSet.remove(...removeArgs));
-  };
+  const add = useCallback((...addArgs: Parameters<ChangeSet<T>['add']>) => {
+    setChangeSet((prevChangeSet) => prevChangeSet.add(...addArgs));
+  }, []);
+  const remove = useCallback((...removeArgs: Parameters<ChangeSet<T>['remove']>) => {
+    setChangeSet((prevChangeSet) => prevChangeSet.remove(...removeArgs));
+  }, []);
+  const reset = useCallback(() => setChangeSet(new ChangeSet<T>()), []);
 
-  return [changeSet, add, remove];
+  return [changeSet, add, remove, reset] as const;
 }
 
 export function useChangeSetWithSelect<T extends ChangeTrackable>(): [

--- a/app/javascript/Permissions/PermissionCheckBox.tsx
+++ b/app/javascript/Permissions/PermissionCheckBox.tsx
@@ -1,20 +1,22 @@
+import { useUniqueId } from '@neinteractiveliterature/litform';
+
 export type PermissionCheckBoxProps = {
   hasPermission: boolean;
 };
 
 function PermissionCheckBox({ hasPermission }: PermissionCheckBoxProps): JSX.Element {
-  if (hasPermission) {
-    return (
-      <i className="bi-check-square">
-        <span className="visually-hidden">Permitted</span>
-      </i>
-    );
-  }
+  const checkboxId = useUniqueId('permitted-');
 
   return (
-    <i className="bi-square">
-      <span className="visually-hidden">Not permitted</span>
-    </i>
+    <div className="form-check form-switch">
+      <input
+        className="form-check-input"
+        type="checkbox"
+        id={checkboxId}
+        checked={hasPermission}
+        aria-label="Permitted"
+      />
+    </div>
   );
 }
 

--- a/app/javascript/Permissions/PermissionsListInput.tsx
+++ b/app/javascript/Permissions/PermissionsListInput.tsx
@@ -6,7 +6,7 @@ import usePermissionsChangeSet, { UsePermissionsChangeSetOptions } from './usePe
 import usePermissionToggle, { UsePermissionToggleOptions } from './usePermissionToggle';
 import { permissionEquals, PolymorphicPermission } from './PermissionUtils';
 
-type PermissionsListRowProps = Omit<UsePermissionToggleOptions, 'role'> & {
+type PermissionsListRowProps = UsePermissionToggleOptions & {
   name: string;
 };
 
@@ -14,6 +14,7 @@ function PermissionsListRow({
   grantPermission,
   revokePermission,
   model,
+  role,
   permission,
   name,
   initialPermissions,
@@ -25,6 +26,7 @@ function PermissionsListRow({
     grantPermission,
     revokePermission,
     model,
+    role,
     permission,
     initialPermissions,
     changeSet,
@@ -74,6 +76,7 @@ function PermissionsListRow({
 
 export type PermissionsListInputProps = UsePermissionsChangeSetOptions & {
   model: PolymorphicPermission['model'];
+  role: PolymorphicPermission['role'];
   permissionNames: { permission: string; name: string }[];
   reset: () => void;
   header?: React.ReactNode;
@@ -84,6 +87,7 @@ function PermissionsListInput({
   permissionNames,
   initialPermissions,
   model,
+  role,
   changeSet,
   add,
   remove,
@@ -102,29 +106,33 @@ function PermissionsListInput({
     (permitted) => {
       permissionNames.forEach(({ permission }) => {
         if (permitted) {
-          grantPermission({ permission, model });
+          grantPermission({ permission, model, role });
         } else {
-          revokePermission({ permission, model });
+          revokePermission({ permission, model, role });
         }
       });
     },
-    [permissionNames, grantPermission, revokePermission, model],
+    [permissionNames, grantPermission, revokePermission, model, role],
   );
 
   const allPermitted = useMemo(
     () =>
       permissionNames.every(({ permission }) =>
-        currentPermissions.some((currentPermission) => permissionEquals(currentPermission, { permission, model })),
+        currentPermissions.some((currentPermission) =>
+          permissionEquals(currentPermission, { permission, model, role }),
+        ),
       ),
-    [permissionNames, currentPermissions, model],
+    [permissionNames, currentPermissions, model, role],
   );
 
   const nonePermitted = useMemo(
     () =>
       !permissionNames.some(({ permission }) =>
-        currentPermissions.some((currentPermission) => permissionEquals(currentPermission, { permission, model })),
+        currentPermissions.some((currentPermission) =>
+          permissionEquals(currentPermission, { permission, model, role }),
+        ),
       ),
-    [permissionNames, currentPermissions, model],
+    [permissionNames, currentPermissions, model, role],
   );
 
   return (
@@ -169,6 +177,7 @@ function PermissionsListInput({
             currentPermissions={currentPermissions}
             changeSet={changeSet}
             model={model}
+            role={role}
             permission={permission}
             name={name}
             grantPermission={grantPermission}

--- a/app/javascript/Permissions/PermissionsListInput.tsx
+++ b/app/javascript/Permissions/PermissionsListInput.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import capitalize from 'lodash/capitalize';
+import { useUniqueId } from '@neinteractiveliterature/litform';
 
-import PermissionCheckBox from './PermissionCheckBox';
 import usePermissionsChangeSet, { UsePermissionsChangeSetOptions } from './usePermissionsChangeSet';
 import usePermissionToggle, { UsePermissionToggleOptions } from './usePermissionToggle';
-import { PolymorphicPermission } from './PermissionUtils';
+import { permissionEquals, PolymorphicPermission } from './PermissionUtils';
 
 type PermissionsListRowProps = Omit<UsePermissionToggleOptions, 'role'> & {
   name: string;
@@ -20,8 +20,8 @@ function PermissionsListRow({
   changeSet,
   currentPermissions,
   readOnly,
-}: PermissionsListRowProps): JSX.Element {
-  const { toggle, hasPermission, className } = usePermissionToggle({
+}: PermissionsListRowProps) {
+  const { toggle, hasPermission, className, granted, revoked } = usePermissionToggle({
     grantPermission,
     revokePermission,
     model,
@@ -31,23 +31,42 @@ function PermissionsListRow({
     currentPermissions,
     readOnly,
   });
+  const checkboxId = useUniqueId(`${permission}-`);
 
   return (
-    <tr
-      className={`${className} cursor-pointer`}
-      tabIndex={0}
-      onClick={toggle}
-      onKeyDown={(event) => {
-        if (event.keyCode === 32 || event.keyCode === 13) {
-          toggle();
-        }
-      }}
-    >
+    <tr className={className}>
       <th scope="row" className="text-start fw-normal pe-4">
-        {capitalize(name)}
+        <label className="form-label" htmlFor={checkboxId}>
+          {capitalize(name)}
+        </label>
       </th>
       <td>
-        <PermissionCheckBox hasPermission={hasPermission} />
+        <div className="d-flex justify-content-end">
+          <div className="form-check form-switch">
+            <input
+              className="form-check-input"
+              type="checkbox"
+              id={checkboxId}
+              checked={hasPermission}
+              aria-label="Permitted"
+              onChange={toggle}
+            />
+          </div>
+        </div>
+      </td>
+      <td>
+        {granted && (
+          <>
+            <i className="bi-plus-square" />
+            <span className="visually-hidden">Permission added</span>
+          </>
+        )}
+        {revoked && (
+          <>
+            <i className="bi-dash-square" />
+            <span className="visually-hidden">Permission removed</span>
+          </>
+        )}
       </td>
     </tr>
   );
@@ -56,6 +75,7 @@ function PermissionsListRow({
 export type PermissionsListInputProps = UsePermissionsChangeSetOptions & {
   model: PolymorphicPermission['model'];
   permissionNames: { permission: string; name: string }[];
+  reset: () => void;
   header?: React.ReactNode;
   readOnly?: boolean;
 };
@@ -67,6 +87,7 @@ function PermissionsListInput({
   changeSet,
   add,
   remove,
+  reset,
   header,
   readOnly,
 }: PermissionsListInputProps): JSX.Element {
@@ -77,11 +98,66 @@ function PermissionsListInput({
     remove,
   });
 
+  const setAllPermitted = useCallback(
+    (permitted) => {
+      permissionNames.forEach(({ permission }) => {
+        if (permitted) {
+          grantPermission({ permission, model });
+        } else {
+          revokePermission({ permission, model });
+        }
+      });
+    },
+    [permissionNames, grantPermission, revokePermission, model],
+  );
+
+  const allPermitted = useMemo(
+    () =>
+      permissionNames.every(({ permission }) =>
+        currentPermissions.some((currentPermission) => permissionEquals(currentPermission, { permission, model })),
+      ),
+    [permissionNames, currentPermissions, model],
+  );
+
+  const nonePermitted = useMemo(
+    () =>
+      !permissionNames.some(({ permission }) =>
+        currentPermissions.some((currentPermission) => permissionEquals(currentPermission, { permission, model })),
+      ),
+    [permissionNames, currentPermissions, model],
+  );
+
   return (
     <table className="table table-hover table-sm table-striped w-auto" role="grid">
       <thead>
         <tr>
-          <th colSpan={2}>{header}</th>
+          <th>{header}</th>
+          <td colSpan={2}>
+            <button
+              className="btn btn-sm btn-outline-success"
+              type="button"
+              disabled={allPermitted}
+              onClick={() => setAllPermitted(true)}
+            >
+              <i className="bi-hand-thumbs-up-fill" /> Grant all
+            </button>{' '}
+            <button
+              className="btn btn-sm btn-outline-danger"
+              type="button"
+              disabled={nonePermitted}
+              onClick={() => setAllPermitted(false)}
+            >
+              <i className="bi-hand-thumbs-down-fill" /> Revoke all
+            </button>{' '}
+            <button
+              className="btn btn-sm btn-outline-info"
+              type="button"
+              disabled={changeSet?.changes.length === 0}
+              onClick={reset}
+            >
+              <i className="bi-arrow-repeat" /> Reset
+            </button>
+          </td>
         </tr>
       </thead>
 

--- a/app/javascript/StaffPositionAdmin/EditStaffPositionPermissions.tsx
+++ b/app/javascript/StaffPositionAdmin/EditStaffPositionPermissions.tsx
@@ -25,10 +25,8 @@ export default LoadSingleValueFromCollectionWrapper(
   function EditStaffPositionPermissions({ value: staffPosition, data: { convention } }) {
     const navigate = useNavigate();
     const [conventionChangeSet, conventionAdd, conventionRemove, conventionReset] = useChangeSet<PermissionWithId>();
-    const [eventCategoriesChangeSet, eventCategoriesAdd, eventCategoriesRemove, eventCategoriesReset] =
-      useChangeSet<PermissionWithId>();
-    const [contentGroupsChangeSet, contentGroupsAdd, contentGroupsRemove, contentGroupsReset] =
-      useChangeSet<PermissionWithId>();
+    const [eventCategoriesChangeSet, eventCategoriesAdd, eventCategoriesRemove] = useChangeSet<PermissionWithId>();
+    const [contentGroupsChangeSet, contentGroupsAdd, contentGroupsRemove] = useChangeSet<PermissionWithId>();
 
     const [error, setError] = useState<ApolloError>();
     const [mutationInProgress, setMutationInProgress] = useState(false);
@@ -41,6 +39,7 @@ export default LoadSingleValueFromCollectionWrapper(
           <PermissionsListInput
             permissionNames={ConventionPermissionNames}
             initialPermissions={staffPosition.permissions}
+            role={staffPosition}
             model={convention}
             changeSet={conventionChangeSet}
             add={conventionAdd}

--- a/app/javascript/StaffPositionAdmin/EditStaffPositionPermissions.tsx
+++ b/app/javascript/StaffPositionAdmin/EditStaffPositionPermissions.tsx
@@ -6,7 +6,7 @@ import { useTabs, TabList, TabBody, notEmpty, ErrorDisplay } from '@neinteractiv
 import { getEventCategoryStyles } from '../EventsApp/ScheduleGrid/StylingUtils';
 import PermissionsListInput from '../Permissions/PermissionsListInput';
 import PermissionsTableInput from '../Permissions/PermissionsTableInput';
-import { useChangeSet } from '../ChangeSet';
+import ChangeSet, { useChangeSet } from '../ChangeSet';
 import usePageTitle from '../usePageTitle';
 import { getPermissionNamesForModelType, buildPermissionInput } from '../Permissions/PermissionUtils';
 import { PermissionedModelTypeIndicator } from '../graphqlTypes.generated';
@@ -24,7 +24,12 @@ export default LoadSingleValueFromCollectionWrapper(
   (data, id) => data.convention.staff_positions.find((sp) => sp.id === id),
   function EditStaffPositionPermissions({ value: staffPosition, data: { convention } }) {
     const navigate = useNavigate();
-    const [changeSet, add, remove] = useChangeSet<PermissionWithId>();
+    const [conventionChangeSet, conventionAdd, conventionRemove, conventionReset] = useChangeSet<PermissionWithId>();
+    const [eventCategoriesChangeSet, eventCategoriesAdd, eventCategoriesRemove, eventCategoriesReset] =
+      useChangeSet<PermissionWithId>();
+    const [contentGroupsChangeSet, contentGroupsAdd, contentGroupsRemove, contentGroupsReset] =
+      useChangeSet<PermissionWithId>();
+
     const [error, setError] = useState<ApolloError>();
     const [mutationInProgress, setMutationInProgress] = useState(false);
     const [mutate] = useUpdateStaffPositionPermissionsMutation();
@@ -37,9 +42,10 @@ export default LoadSingleValueFromCollectionWrapper(
             permissionNames={ConventionPermissionNames}
             initialPermissions={staffPosition.permissions}
             model={convention}
-            changeSet={changeSet}
-            add={add}
-            remove={remove}
+            changeSet={conventionChangeSet}
+            add={conventionAdd}
+            remove={conventionRemove}
+            reset={conventionReset}
             header={convention.name}
           />
         ),
@@ -52,11 +58,11 @@ export default LoadSingleValueFromCollectionWrapper(
             permissionNames={EventCategoryPermissionNames}
             initialPermissions={staffPosition.permissions}
             rowType="model"
-            rows={convention.event_categories}
             role={staffPosition}
-            changeSet={changeSet}
-            add={add}
-            remove={remove}
+            rows={convention.event_categories}
+            changeSet={eventCategoriesChangeSet}
+            add={eventCategoriesAdd}
+            remove={eventCategoriesRemove}
             rowsHeader="Event Category"
             formatRowHeader={(eventCategory) => (
               <span className="p-1 rounded" style={getEventCategoryStyles({ eventCategory, variant: 'default' })}>
@@ -74,11 +80,11 @@ export default LoadSingleValueFromCollectionWrapper(
             permissionNames={CmsContentGroupPermissionNames}
             initialPermissions={staffPosition.permissions}
             rowType="model"
-            rows={convention.cmsContentGroups}
             role={staffPosition}
-            changeSet={changeSet}
-            add={add}
-            remove={remove}
+            rows={convention.cmsContentGroups}
+            changeSet={contentGroupsChangeSet}
+            add={contentGroupsAdd}
+            remove={contentGroupsRemove}
             rowsHeader="CMS Content Group"
             formatRowHeader={(contentGroup) => contentGroup.name}
           />
@@ -89,13 +95,18 @@ export default LoadSingleValueFromCollectionWrapper(
     usePageTitle(`Editing permissions for “${staffPosition.name}”`);
 
     const saveChangesClicked = async () => {
+      const combinedChangeSet = new ChangeSet([
+        ...conventionChangeSet.changes,
+        ...eventCategoriesChangeSet.changes,
+        ...contentGroupsChangeSet.changes,
+      ]);
       setMutationInProgress(true);
       try {
         await mutate({
           variables: {
             staffPositionId: staffPosition.id,
-            grantPermissions: changeSet.getAddValues().map(buildPermissionInput),
-            revokePermissions: changeSet
+            grantPermissions: combinedChangeSet.getAddValues().map(buildPermissionInput),
+            revokePermissions: combinedChangeSet
               .getRemoveIds()
               .map((removeId) => {
                 const existingPermission = staffPosition.permissions.find((p) => p.id === removeId);

--- a/cms_content_sets/single_event/pages/root.liquid
+++ b/cms_content_sets/single_event/pages/root.liquid
@@ -6,7 +6,7 @@ skip_clickwrap_agreement: false
 <h1 class="mb-4">{{ event.title }}</h1>
 
 <div class="d-block d-md-flex">
-  <div class="flex-grow-md-1">
+  <div class="flex-grow-md-1 pe-2">
     {% long_form_event_details event.id %}
   </div>
 


### PR DESCRIPTION
This adds a new set of permissions UI controls that:

* Uses standard Bootstrap toggle controls rather than a homegrown one
* Adds "grant all", "remove all", and "reset" buttons on the list UI
* Fixes some existing API bugs introduced by the ID type change

Additionally, I'm sneaking in a gem upgrade and a small fix for padding in the single-event template.