### PR TITLE
Event specific tickets part 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem 'phonelib'
 gem 'shoryuken'
 gem 'aws-sdk-sqs'
 gem 'whenever'
+gem 'cloudwatch_scheduler', require: false
 
 # Privacy-respecting metrics
 gem 'ahoy_matey'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,9 @@ GEM
     aws-partitions (1.495.0)
     aws-record (2.6.0)
       aws-sdk-dynamodb (~> 1.18)
+    aws-sdk-cloudwatchevents (1.51.0)
+      aws-sdk-core (~> 3, >= 3.120.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-cloudwatchlogs (1.45.0)
       aws-sdk-core (~> 3, >= 3.120.0)
       aws-sigv4 (~> 1.1)
@@ -175,6 +178,11 @@ GEM
       cadmus
       rails (>= 5.0.0)
     chronic (0.10.2)
+    cloudwatch_scheduler (1.1.0)
+      aws-sdk-cloudwatchevents (~> 1.13)
+      aws-sdk-sqs (~> 1.10)
+      rails (>= 4.2.0)
+      shoryuken (>= 2.0)
     cloudwatchlogger (0.3.0)
       aws-sdk-cloudwatchlogs (~> 1)
       multi_json (~> 1)
@@ -623,6 +631,7 @@ DEPENDENCIES
   cadmus (~> 0.7.1)
   cadmus_navbar (~> 0.1.0)
   civil_service!
+  cloudwatch_scheduler
   cloudwatchlogger
   dalli
   dead_end

--- a/app/graphql/types/signup_state_type.rb
+++ b/app/graphql/types/signup_state_type.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 class Types::SignupStateType < Types::BaseEnum
-  value('confirmed')
-  value('waitlisted')
-  value('withdrawn')
+  value(
+    'ticket_purchase_hold',
+    'Attendee\'s spot is held temporarily while the attendee finishes paying for their ticket'
+  )
+  value('confirmed', 'Attendee\'s spot is confirmed')
+  value('waitlisted', 'Attendee is on the waitlist for this event and may be pulled in automatically')
+  value('withdrawn', 'Attendee has withdrawn from this event (and this signup is no longer valid)')
 end

--- a/app/javascript/EventsApp/SignupAdmin/SignupUtils.ts
+++ b/app/javascript/EventsApp/SignupAdmin/SignupUtils.ts
@@ -89,6 +89,8 @@ export function formatSignupState(state: SignupState | undefined | null, t: TFun
   }
 
   switch (state) {
+    case SignupState.TicketPurchaseHold:
+      return t('signups.states.ticketPurchaseHold', 'Held temporarily while awaiting payment');
     case SignupState.Confirmed:
       return t('signups.states.confirmed', 'Confirmed');
     case SignupState.Waitlisted:

--- a/app/javascript/Tables/SignupStateCell.tsx
+++ b/app/javascript/Tables/SignupStateCell.tsx
@@ -18,17 +18,15 @@ const SignupStateCell = ({ value, strikeThrough }: SignupStateCellProps): JSX.El
     text = t('signups.states.waitlisted', 'Waitlisted');
   } else if (value === 'withdrawn') {
     text = t('signups.states.withdrawn', 'Withdrawn');
+  } else if (value === 'ticket_purchase_hold') {
+    text = t('signups.states.ticketPurchaseHold', 'Held temporarily while awaiting payment');
   } else if (value == null) {
     text = t('signups.states.notSignedUp', 'Not signed up');
   } else {
     assertNever(value, true);
   }
 
-  return (
-    <div className={`badge bg-signup-state-color-${value}`}>
-      {strikeThrough ? <s>{text}</s> : text}
-    </div>
-  );
+  return <div className={`badge bg-signup-state-color-${value}`}>{strikeThrough ? <s>{text}</s> : text}</div>;
 };
 
 export default SignupStateCell;

--- a/app/javascript/enumTypes.json
+++ b/app/javascript/enumTypes.json
@@ -514,20 +514,26 @@
     "interfaces": null,
     "enumValues": [
       {
+        "name": "ticket_purchase_hold",
+        "description": "Attendee's spot is held temporarily while the attendee finishes paying for their ticket",
+        "isDeprecated": false,
+        "deprecationReason": null
+      },
+      {
         "name": "confirmed",
-        "description": null,
+        "description": "Attendee's spot is confirmed",
         "isDeprecated": false,
         "deprecationReason": null
       },
       {
         "name": "waitlisted",
-        "description": null,
+        "description": "Attendee is on the waitlist for this event and may be pulled in automatically",
         "isDeprecated": false,
         "deprecationReason": null
       },
       {
         "name": "withdrawn",
-        "description": null,
+        "description": "Attendee has withdrawn from this event (and this signup is no longer valid)",
         "isDeprecated": false,
         "deprecationReason": null
       }

--- a/app/javascript/graphqlTypes.generated.ts
+++ b/app/javascript/graphqlTypes.generated.ts
@@ -4423,8 +4423,13 @@ export type SignupRequestsPagination = PaginationInterface & {
 };
 
 export enum SignupState {
+  /** Attendee's spot is confirmed */
   Confirmed = 'confirmed',
+  /** Attendee's spot is held temporarily while the attendee finishes paying for their ticket */
+  TicketPurchaseHold = 'ticket_purchase_hold',
+  /** Attendee is on the waitlist for this event and may be pulled in automatically */
   Waitlisted = 'waitlisted',
+  /** Attendee has withdrawn from this event (and this signup is no longer valid) */
   Withdrawn = 'withdrawn'
 }
 

--- a/app/services/cleanup_db_service.rb
+++ b/app/services/cleanup_db_service.rb
@@ -1,0 +1,39 @@
+class CleanupDbService < CivilService::Service
+  private
+
+  def inner_call
+    cleaner = Doorkeeper::StaleRecordsCleaner.new(Doorkeeper.config.access_token_model)
+    cleaner.clean_revoked
+
+    custom_doorkeeper_token_cleanup
+
+    cleaner = Doorkeeper::StaleRecordsCleaner.new(Doorkeeper.config.access_grant_model)
+    cleaner.clean_revoked
+
+    cleaner = Doorkeeper::StaleRecordsCleaner.new(Doorkeeper.config.access_grant_model)
+    cleaner.clean_expired(Doorkeeper.config.authorization_code_expires_in)
+
+    trim_sessions
+
+    success
+  end
+
+  # Don't delete the most recently generated token for each user
+  def custom_doorkeeper_token_cleanup
+    expirable_tokens = Doorkeeper::AccessToken.where(refresh_token: nil).where(Arel.sql(<<~SQL))
+      created_at != (
+        SELECT MAX(created_at) FROM #{Doorkeeper::AccessToken.table_name} tokens2
+        WHERE #{Doorkeeper::AccessToken.table_name}.resource_owner_id = tokens2.resource_owner_id
+        AND #{Doorkeeper::AccessToken.table_name}.application_id = tokens2.application_id
+      )
+    SQL
+    cleaner = Doorkeeper::StaleRecordsCleaner.new(expirable_tokens)
+    cleaner.clean_expired(Doorkeeper.configuration.access_token_expires_in)
+  end
+
+  # Copy/pasted from activerecord-session_store
+  def trim_sessions
+    cutoff_period = (ENV['SESSION_DAYS_TRIM_THRESHOLD'] || 30).to_i.days.ago
+    ActiveRecord::SessionStore::Session.where('updated_at < ?', cutoff_period).delete_all
+  end
+end

--- a/app/services/run_notifications_service.rb
+++ b/app/services/run_notifications_service.rb
@@ -1,0 +1,8 @@
+class RunNotificationsService < CivilService::Service
+  private
+
+  def inner_call
+    [NotifyEventProposalChangesJob, NotifyEventChangesJob, RemindDraftEventProposalsJob].each(&:perform_later)
+    success
+  end
+end

--- a/config/initializers/cloudwatch_scheduler.rb
+++ b/config/initializers/cloudwatch_scheduler.rb
@@ -1,0 +1,13 @@
+require 'cloudwatch_scheduler'
+
+CloudwatchScheduler() do |_config|
+  # every hour at 10 minutes past the hour
+  task 'run_notifications', cron: '10 * * * *' do
+    RunNotificationsService.new.call!
+  end
+
+  # every day at 5:00am
+  task 'cleanup', cron: '0 5 * * *' do
+    CleanupDbService.new.call!
+  end
+end

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -11,4 +11,8 @@ groups:
     concurrency: 5
     queues:
       - ahoy
+  cloudwatch_scheduler:
+    concurrency: 1
+    queues:
+      - cloudwatch_scheduler
 timeout: 2

--- a/db/migrate/20220313171517_add_expires_at_to_signups.rb
+++ b/db/migrate/20220313171517_add_expires_at_to_signups.rb
@@ -1,0 +1,6 @@
+class AddExpiresAtToSignups < ActiveRecord::Migration[7.0]
+  def change
+    add_column :signups, :expires_at, :timestamp, null: true
+    add_index :signups, :expires_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2522,7 +2522,8 @@ CREATE TABLE public.signups (
     user_con_profile_id integer NOT NULL,
     state character varying DEFAULT 'confirmed'::character varying NOT NULL,
     counted boolean,
-    requested_bucket_key character varying
+    requested_bucket_key character varying,
+    expires_at timestamp without time zone
 );
 
 
@@ -4588,6 +4589,13 @@ CREATE INDEX index_signup_requests_on_user_con_profile_id ON public.signup_reque
 
 
 --
+-- Name: index_signups_on_expires_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_signups_on_expires_at ON public.signups USING btree (expires_at);
+
+
+--
 -- Name: index_signups_on_run_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5705,6 +5713,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220122172525'),
 ('20220122174528'),
 ('20220226170101'),
-('20220226170448');
+('20220226170448'),
+('20220313171517');
 
 

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,28 +1,4 @@
 desc 'Clean authentication/authorization tables'
-task :cleanup do
-  %w[intercode:custom_doorkeeper_cleanup db:sessions:trim].each do |task|
-    puts "Running #{task}"
-    Rake::Task[task].invoke
-  end
-end
-
-namespace :intercode do
-  task custom_doorkeeper_cleanup: [
-    'doorkeeper:db:cleanup:revoked_tokens',
-    'intercode:custom_token_cleanup',
-    'doorkeeper:db:cleanup:revoked_grants',
-    'doorkeeper:db:cleanup:expired_grants'
-  ]
-
-  task :custom_token_cleanup do
-    expirable_tokens = Doorkeeper::AccessToken.where(refresh_token: nil).where(Arel.sql(<<~SQL))
-      created_at != (
-        SELECT MAX(created_at) FROM #{Doorkeeper::AccessToken.table_name} tokens2
-        WHERE #{Doorkeeper::AccessToken.table_name}.resource_owner_id = tokens2.resource_owner_id
-        AND #{Doorkeeper::AccessToken.table_name}.application_id = tokens2.application_id
-      )
-    SQL
-    cleaner = Doorkeeper::StaleRecordsCleaner.new(expirable_tokens)
-    cleaner.clean_expired(Doorkeeper.configuration.access_token_expires_in)
-  end
+task cleanup: :environment do
+  CleanupDbService.new.call!
 end

--- a/lib/tasks/run_notifications.rake
+++ b/lib/tasks/run_notifications.rake
@@ -1,8 +1,4 @@
 desc 'Enqueue all notification jobs'
 task run_notifications: :environment do
-  [
-    NotifyEventProposalChangesJob,
-    NotifyEventChangesJob,
-    RemindDraftEventProposalsJob
-  ].each(&:perform_later)
+  RunNotificationsService.new.call!
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5317,8 +5317,24 @@ type SignupRequestsPagination implements PaginationInterface {
 }
 
 enum SignupState {
+  """
+  Attendee's spot is confirmed
+  """
   confirmed
+
+  """
+  Attendee's spot is held temporarily while the attendee finishes paying for their ticket
+  """
+  ticket_purchase_hold
+
+  """
+  Attendee is on the waitlist for this event and may be pulled in automatically
+  """
   waitlisted
+
+  """
+  Attendee has withdrawn from this event (and this signup is no longer valid)
+  """
   withdrawn
 }
 

--- a/schema.json
+++ b/schema.json
@@ -28830,20 +28830,26 @@
           "interfaces": null,
           "enumValues": [
             {
+              "name": "ticket_purchase_hold",
+              "description": "Attendee's spot is held temporarily while the attendee finishes paying for their ticket",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "confirmed",
-              "description": null,
+              "description": "Attendee's spot is confirmed",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "waitlisted",
-              "description": null,
+              "description": "Attendee is on the waitlist for this event and may be pulled in automatically",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "withdrawn",
-              "description": null,
+              "description": "Attendee has withdrawn from this event (and this signup is no longer valid)",
               "isDeprecated": false,
               "deprecationReason": null
             }

--- a/test/factories/signups.rb
+++ b/test/factories/signups.rb
@@ -6,6 +6,7 @@
 #  id                   :integer          not null, primary key
 #  bucket_key           :string
 #  counted              :boolean
+#  expires_at           :datetime
 #  requested_bucket_key :string
 #  state                :string           default("confirmed"), not null
 #  created_at           :datetime         not null
@@ -16,6 +17,7 @@
 #
 # Indexes
 #
+#  index_signups_on_expires_at           (expires_at)
 #  index_signups_on_run_id               (run_id)
 #  index_signups_on_updated_by_id        (updated_by_id)
 #  index_signups_on_user_con_profile_id  (user_con_profile_id)
@@ -27,7 +29,6 @@
 #  fk_rails_...  (user_con_profile_id => user_con_profiles.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :signup do
     state { 'confirmed' }

--- a/test/models/signup_test.rb
+++ b/test/models/signup_test.rb
@@ -6,6 +6,7 @@
 #  id                   :integer          not null, primary key
 #  bucket_key           :string
 #  counted              :boolean
+#  expires_at           :datetime
 #  requested_bucket_key :string
 #  state                :string           default("confirmed"), not null
 #  created_at           :datetime         not null
@@ -16,6 +17,7 @@
 #
 # Indexes
 #
+#  index_signups_on_expires_at           (expires_at)
 #  index_signups_on_run_id               (run_id)
 #  index_signups_on_updated_by_id        (updated_by_id)
 #  index_signups_on_user_con_profile_id  (user_con_profile_id)
@@ -27,7 +29,6 @@
 #  fk_rails_...  (user_con_profile_id => user_con_profiles.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class SignupTest < ActiveSupport::TestCase


### PR DESCRIPTION
Still dark, but moving towards something sustainable.  This PR does three things:

* Adds a (for-now, unreachable) signup state called `ticket_purchase_hold`
* Adds an `expires_at` column for signups
* Sets up cloudwatch_scheduler to run the jobs that everyone should be running (possibly will extend this to cover the cert refresh job if I can figure out a way to do it that doesn't break non-Heroku hosts)