### PR TITLE
Fix cloudwatch_scheduler queue name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/nbudin/cloudwatch_scheduler.git
-  revision: 7482682e5de6dea84600f366a54ca696fcffabb2
+  revision: 3c4a06c3bf6596663f45d05f524ddddafc09e542
   branch: ruby3_rails7_compat
   specs:
     cloudwatch_scheduler (1.1.1)
@@ -127,7 +127,7 @@ GEM
       graphql (>= 1.8)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.566.0)
+    aws-partitions (1.568.0)
     aws-record (2.6.0)
       aws-sdk-dynamodb (~> 1.18)
     aws-sdk-cloudwatchevents (1.57.0)
@@ -330,7 +330,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.14.0)
+    loofah (2.15.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     macaddr (1.7.2)


### PR DESCRIPTION
cloudwatch_scheduler didn't agree with itself: it provisioned things to go to an unprefixed queue name, but then read jobs from a prefixed queue name.  Womp womp.

This fixes that.