### PR TITLE
Schema consistency fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         load: ${{ github.event_name != 'push' || github.event.ref != 'refs/heads/main' }}
         platforms: linux/amd64
         target: production
-        tags: "${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' ? \"ghcr.io/neinteractiveliterature/intercode:${{ github.sha }}\" : 'tmp-pr-image' }}"
+        tags: "${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && \"ghcr.io/neinteractiveliterature/intercode:${{ github.sha }}\" || 'tmp-pr-image' }}"
         build-args: |
           RUBY_VERSION=${{ steps.ruby-version.outputs.ruby-version }}
           NODE_VERSION=${{ steps.node-version.outputs.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
       with:
         context: .
         push: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
+        load: ${{ github.event_name != 'push' || github.event.ref != 'refs/heads/main' }}
         platforms: linux/amd64
         target: production
         tags: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         tags: |
           ghcr.io/neinteractiveliterature/intercode-assets:${{ github.sha }}
         build-args: |
-          BASEIMAGE=${{ steps.main-container-build.outputs.metadata["image.name"] }}
+          BASEIMAGE=${{ steps.main-container-build.outputs.metadata[image.name] }}
         cache-from: type=gha,scope=${{ github.workflow }}
         cache-to: type=gha,mode=max,scope=${{ github.workflow }}
   doc-site:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,6 @@ jobs:
       run: echo "::set-output name=node-version::$(cat .node-version)"
     - name: Build (and push to Docker Hub, if on main)
       uses: docker/build-push-action@v2
-      id: main-container-build
       with:
         context: .
         push: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
@@ -148,7 +147,7 @@ jobs:
         tags: |
           ghcr.io/neinteractiveliterature/intercode-assets:${{ github.sha }}
         build-args: |
-          BASEIMAGE=${{ fromJSON(steps.main-container-build.outputs.metadata)['image.name'] }}
+          BASEIMAGE=${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && format('ghcr.io/neinteractiveliterature/intercode:{0}', github.sha) || 'tmp-pr-image' }}
         cache-from: type=gha,scope=${{ github.workflow }}
         cache-to: type=gha,mode=max,scope=${{ github.workflow }}
   doc-site:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         context: .
         file: Dockerfile.assets
         push: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         tags: |
           ghcr.io/neinteractiveliterature/intercode-assets:${{ github.sha }}
         build-args: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
       run: echo "::set-output name=node-version::$(cat .node-version)"
     - name: Build (and push to Docker Hub, if on main)
       uses: docker/build-push-action@v2
+      id: main-container-build
       with:
         context: .
         push: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
@@ -148,8 +149,7 @@ jobs:
         tags: |
           ghcr.io/neinteractiveliterature/intercode-assets:${{ github.sha }}
         build-args: |
-          SHA1=${{ github.sha }}
-          BASEIMAGE=ghcr.io/neinteractiveliterature/intercode
+          BASEIMAGE=${{ steps.main-container-build.outputs.imageid }}
         cache-from: type=gha,scope=${{ github.workflow }}
         cache-to: type=gha,mode=max,scope=${{ github.workflow }}
   doc-site:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,7 @@ jobs:
         load: ${{ github.event_name != 'push' || github.event.ref != 'refs/heads/main' }}
         platforms: linux/amd64
         target: production
-        tags: |
-          ghcr.io/neinteractiveliterature/intercode:${{ github.sha }}
+        tags: "${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' ? \"ghcr.io/neinteractiveliterature/intercode:${{ github.sha }}\" : 'tmp-pr-image' }}"
         build-args: |
           RUBY_VERSION=${{ steps.ruby-version.outputs.ruby-version }}
           NODE_VERSION=${{ steps.node-version.outputs.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         tags: |
           ghcr.io/neinteractiveliterature/intercode-assets:${{ github.sha }}
         build-args: |
-          BASEIMAGE=${{ steps.main-container-build.outputs.imageid }}
+          BASEIMAGE=${{ steps.main-container-build.outputs.metadata["image.name"] }}
         cache-from: type=gha,scope=${{ github.workflow }}
         cache-to: type=gha,mode=max,scope=${{ github.workflow }}
   doc-site:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         tags: |
           ghcr.io/neinteractiveliterature/intercode-assets:${{ github.sha }}
         build-args: |
-          BASEIMAGE=${{ steps.main-container-build.outputs.metadata[image.name] }}
+          BASEIMAGE=${{ steps.main-container-build.outputs.metadata['image.name'] }}
         cache-from: type=gha,scope=${{ github.workflow }}
         cache-to: type=gha,mode=max,scope=${{ github.workflow }}
   doc-site:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,10 +128,10 @@ jobs:
       with:
         context: .
         push: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
-        load: ${{ github.event_name != 'push' || github.event.ref != 'refs/heads/main' }}
         platforms: linux/amd64
         target: production
-        tags: "${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && format('ghcr.io/neinteractiveliterature/intercode:{0}', github.sha) || 'tmp-pr-image' }}"
+        tags: |
+          ghcr.io/neinteractiveliterature/intercode:${{ github.sha }}
         build-args: |
           RUBY_VERSION=${{ steps.ruby-version.outputs.ruby-version }}
           NODE_VERSION=${{ steps.node-version.outputs.node-version }}
@@ -139,6 +139,7 @@ jobs:
         cache-to: type=gha,mode=max,scope=${{ github.workflow }}
     - name: Build assets only (and push to Docker Hub, if on main)
       uses: docker/build-push-action@v2
+      if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
       with:
         context: .
         file: Dockerfile.assets
@@ -147,7 +148,7 @@ jobs:
         tags: |
           ghcr.io/neinteractiveliterature/intercode-assets:${{ github.sha }}
         build-args: |
-          BASEIMAGE=${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && format('ghcr.io/neinteractiveliterature/intercode:{0}', github.sha) || 'tmp-pr-image' }}
+          BASEIMAGE=ghcr.io/neinteractiveliterature/intercode:${{ github.sha }}
         cache-from: type=gha,scope=${{ github.workflow }}
         cache-to: type=gha,mode=max,scope=${{ github.workflow }}
   doc-site:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         tags: |
           ghcr.io/neinteractiveliterature/intercode-assets:${{ github.sha }}
         build-args: |
-          BASEIMAGE=${{ steps.main-container-build.outputs.metadata['image.name'] }}
+          BASEIMAGE=${{ fromJSON(steps.main-container-build.outputs.metadata)['image.name'] }}
         cache-from: type=gha,scope=${{ github.workflow }}
         cache-to: type=gha,mode=max,scope=${{ github.workflow }}
   doc-site:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         load: ${{ github.event_name != 'push' || github.event.ref != 'refs/heads/main' }}
         platforms: linux/amd64
         target: production
-        tags: "${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && \"ghcr.io/neinteractiveliterature/intercode:${{ github.sha }}\" || 'tmp-pr-image' }}"
+        tags: "${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && format('ghcr.io/neinteractiveliterature/intercode:{0}', github.sha) || 'tmp-pr-image' }}"
         build-args: |
           RUBY_VERSION=${{ steps.ruby-version.outputs.ruby-version }}
           NODE_VERSION=${{ steps.node-version.outputs.node-version }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,3 +62,7 @@ Metrics/MethodLength:
   Max: 20 # default is 10
   Exclude:
     - db/migrate/**/*.rb
+
+# prettier and rubocop are fighting about this one, let prettier win
+Style/StringLiteralsInInterpolation:
+  Enabled: false

--- a/Dockerfile.assets
+++ b/Dockerfile.assets
@@ -1,7 +1,6 @@
-ARG SHA1
 ARG BASEIMAGE
 
-FROM ${BASEIMAGE}:${SHA1} as code
+FROM ${BASEIMAGE} as code
 # Make assets readable
 USER root
 RUN chown root.root -R /usr/src/intercode/public

--- a/app/models/cms_file.rb
+++ b/app/models/cms_file.rb
@@ -9,7 +9,7 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  parent_id   :integer
-#  uploader_id :integer
+#  uploader_id :bigint
 #
 # Indexes
 #

--- a/app/models/convention.rb
+++ b/app/models/convention.rb
@@ -4,7 +4,7 @@
 #
 # Table name: conventions
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  accepting_proposals            :boolean
 #  canceled                       :boolean          default(FALSE), not null
 #  clickwrap_agreement            :text
@@ -37,9 +37,9 @@
 #  catch_all_staff_position_id    :bigint
 #  default_layout_id              :bigint
 #  organization_id                :bigint
-#  root_page_id                   :integer
+#  root_page_id                   :bigint
 #  stripe_account_id              :text
-#  updated_by_id                  :integer
+#  updated_by_id                  :bigint
 #  user_con_profile_form_id       :bigint
 #
 # Indexes

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,7 @@
 #
 # Table name: events
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  additional_info              :jsonb
 #  admin_notes                  :text
 #  age_restrictions_description :text
@@ -28,10 +28,10 @@
 #  url                          :text
 #  created_at                   :datetime
 #  updated_at                   :datetime
-#  convention_id                :integer
+#  convention_id                :bigint
 #  event_category_id            :bigint           not null
-#  owner_id                     :integer
-#  updated_by_id                :integer
+#  owner_id                     :bigint
+#  updated_by_id                :bigint
 #
 # Indexes
 #

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -4,7 +4,7 @@
 #
 # Table name: pages
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  admin_notes              :text
 #  content                  :text
 #  hidden_from_search       :boolean          default(FALSE), not null

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -4,11 +4,11 @@
 #
 # Table name: rooms
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  convention_id :integer
+#  convention_id :bigint
 #
 # Indexes
 #

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -4,15 +4,15 @@
 #
 # Table name: runs
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  schedule_note    :text
 #  starts_at        :datetime
 #  timespan_tsrange :tsrange          not null
 #  title_suffix     :string
 #  created_at       :datetime
 #  updated_at       :datetime
-#  event_id         :integer
-#  updated_by_id    :integer
+#  event_id         :bigint
+#  updated_by_id    :bigint
 #
 # Indexes
 #

--- a/app/models/signup.rb
+++ b/app/models/signup.rb
@@ -4,7 +4,7 @@
 #
 # Table name: signups
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  bucket_key           :string
 #  counted              :boolean
 #  expires_at           :datetime
@@ -12,9 +12,9 @@
 #  state                :string           default("confirmed"), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  run_id               :integer
-#  updated_by_id        :integer
-#  user_con_profile_id  :integer          not null
+#  run_id               :bigint
+#  updated_by_id        :bigint
+#  user_con_profile_id  :bigint           not null
 #
 # Indexes
 #

--- a/app/models/staff_position.rb
+++ b/app/models/staff_position.rb
@@ -4,7 +4,7 @@
 #
 # Table name: staff_positions
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  cc_addresses  :text             default([]), not null, is an Array
 #  email         :text
 #  email_aliases :text             default([]), not null, is an Array
@@ -12,7 +12,7 @@
 #  visible       :boolean
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  convention_id :integer
+#  convention_id :bigint
 #
 # Indexes
 #

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -11,9 +11,9 @@
 #  show_email           :boolean
 #  created_at           :datetime
 #  updated_at           :datetime
-#  event_id             :integer
+#  event_id             :bigint
 #  updated_by_id        :integer
-#  user_con_profile_id  :integer          not null
+#  user_con_profile_id  :bigint           not null
 #
 # Indexes
 #

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -9,9 +9,9 @@
 #  updated_at           :datetime         not null
 #  event_id             :bigint
 #  order_entry_id       :bigint
-#  provided_by_event_id :integer
-#  ticket_type_id       :integer
-#  user_con_profile_id  :integer
+#  provided_by_event_id :bigint
+#  ticket_type_id       :bigint
+#  user_con_profile_id  :bigint
 #
 # Indexes
 #

--- a/app/models/ticket_type.rb
+++ b/app/models/ticket_type.rb
@@ -4,7 +4,7 @@
 #
 # Table name: ticket_types
 #
-#  id                                :integer          not null, primary key
+#  id                                :bigint           not null, primary key
 #  allows_event_signups              :boolean          default(TRUE), not null
 #  counts_towards_convention_maximum :boolean          default(TRUE), not null
 #  description                       :text
@@ -12,7 +12,7 @@
 #  name                              :text             not null
 #  created_at                        :datetime         not null
 #  updated_at                        :datetime         not null
-#  convention_id                     :integer
+#  convention_id                     :bigint
 #  event_id                          :bigint
 #
 # Indexes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@
 #
 # Table name: users
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  current_sign_in_at        :datetime
 #  current_sign_in_ip        :string
 #  email                     :string           default(""), not null

--- a/app/models/user_con_profile.rb
+++ b/app/models/user_con_profile.rb
@@ -4,7 +4,7 @@
 #
 # Table name: user_con_profiles
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  accepted_clickwrap_agreement :boolean          default(FALSE), not null
 #  additional_info              :jsonb
 #  address                      :text
@@ -31,8 +31,8 @@
 #  zipcode                      :string
 #  created_at                   :datetime
 #  updated_at                   :datetime
-#  convention_id                :integer          not null
-#  user_id                      :integer          not null
+#  convention_id                :bigint           not null
+#  user_id                      :bigint           not null
 #
 # Indexes
 #

--- a/db/migrate/20220502182655_make_id_columns_bigints.rb
+++ b/db/migrate/20220502182655_make_id_columns_bigints.rb
@@ -1,0 +1,43 @@
+class MakeIdColumnsBigints < ActiveRecord::Migration[7.0]
+  COLUMNS = {
+    cms_files: %w[uploader_id],
+    conventions: %w[id updated_by_id root_page_id],
+    events: %w[id updated_by_id owner_id convention_id],
+    maximum_event_provided_tickets_overrides: %w[ticket_type_id],
+    notification_destinations: %w[staff_position_id],
+    pages: %w[id],
+    permissions: %w[staff_position_id],
+    products: %w[provides_ticket_type_id],
+    rooms: %w[id convention_id],
+    rooms_runs: %w[room_id run_id],
+    root_sites: %w[root_page_id],
+    runs: %w[id updated_by_id event_id],
+    signup_changes: %w[signup_id],
+    signup_requests: %w[result_signup_id replace_signup_id],
+    signups: %w[id user_con_profile_id updated_by_id run_id],
+    staff_positions: %w[id convention_id],
+    team_members: %w[event_id user_con_profile_id],
+    ticket_types: %w[id convention_id],
+    tickets: %w[user_con_profile_id provided_by_event_id ticket_type_id],
+    users: %w[id],
+    user_con_profiles: %w[id user_id convention_id]
+  }
+
+  def up
+    COLUMNS.each do |table, columns|
+      alters = columns.map { |col| "ALTER COLUMN #{col} TYPE bigint" }
+      execute <<~SQL
+      ALTER TABLE #{table} #{alters.join(', ')};
+      SQL
+    end
+  end
+
+  def down
+    COLUMNS.each do |table, columns|
+      alters = columns.map { |col| "ALTER COLUMN #{col} TYPE integer" }
+      execute <<~SQL
+      ALTER TABLE #{table} #{alters.join(', ')};
+      SQL
+    end
+  end
+end

--- a/db/migrate/20220503164309_add_primary_keys_on_join_tables.rb
+++ b/db/migrate/20220503164309_add_primary_keys_on_join_tables.rb
@@ -1,0 +1,31 @@
+class AddPrimaryKeysOnJoinTables < ActiveRecord::Migration[7.0]
+  JOIN_TABLES = {
+    cms_files_layouts: %w[cms_file_id cms_layout_id],
+    cms_files_pages: %w[cms_file_id page_id],
+    cms_layouts_partials: %w[cms_layout_id cms_partial_id],
+    cms_partials_pages: %w[cms_partial_id page_id],
+    organization_roles_users: %w[organization_role_id user_id],
+    rooms_runs: %w[room_id run_id],
+    staff_positions_user_con_profiles: %w[staff_position_id user_con_profile_id]
+  }
+
+  def up
+    execute <<~SQL
+    DELETE   FROM staff_positions_user_con_profiles T1
+    USING       staff_positions_user_con_profiles T2
+    WHERE  T1.ctid    < T2.ctid
+    AND  T1.staff_position_id = T2.staff_position_id
+    AND  T1.user_con_profile_id = T2.user_con_profile_id;
+    SQL
+
+    JOIN_TABLES.each { |table, columns| execute <<~SQL }
+      ALTER TABLE #{table} ADD PRIMARY KEY (#{columns.join(', ')});
+      SQL
+  end
+
+  def down
+    JOIN_TABLES.each { |table, _columns| execute <<~SQL }
+      ALTER TABLE #{table} DROP PRIMARY KEY;
+      SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -904,7 +904,7 @@ ALTER SEQUENCE public.cms_content_groups_id_seq OWNED BY public.cms_content_grou
 CREATE TABLE public.cms_files (
     id integer NOT NULL,
     parent_id integer,
-    uploader_id integer,
+    uploader_id bigint,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     parent_type character varying
@@ -1152,15 +1152,15 @@ ALTER SEQUENCE public.cms_variables_id_seq OWNED BY public.cms_variables.id;
 --
 
 CREATE TABLE public.conventions (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     show_schedule character varying DEFAULT 'no'::character varying NOT NULL,
     accepting_proposals boolean,
-    updated_by_id integer,
+    updated_by_id bigint,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     starts_at timestamp without time zone,
     ends_at timestamp without time zone,
-    root_page_id integer,
+    root_page_id bigint,
     name character varying,
     domain character varying NOT NULL,
     timezone_name character varying,
@@ -1510,7 +1510,7 @@ ALTER SEQUENCE public.event_ratings_id_seq OWNED BY public.event_ratings.id;
 --
 
 CREATE TABLE public.events (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     title character varying NOT NULL,
     author character varying,
     email character varying,
@@ -1521,11 +1521,11 @@ CREATE TABLE public.events (
     con_mail_destination character varying,
     description text,
     short_blurb text,
-    updated_by_id integer,
+    updated_by_id bigint,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    convention_id integer,
-    owner_id integer,
+    convention_id bigint,
+    owner_id bigint,
     status character varying DEFAULT 'active'::character varying NOT NULL,
     registration_policy jsonb,
     participant_communications text,
@@ -2098,7 +2098,7 @@ ALTER SEQUENCE public.organizations_id_seq OWNED BY public.organizations.id;
 --
 
 CREATE TABLE public.pages (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     name text,
     slug character varying,
     content text,
@@ -2286,8 +2286,8 @@ ALTER SEQUENCE public.products_id_seq OWNED BY public.products.id;
 --
 
 CREATE TABLE public.rooms (
-    id integer NOT NULL,
-    convention_id integer,
+    id bigint NOT NULL,
+    convention_id bigint,
     name character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
@@ -2318,8 +2318,8 @@ ALTER SEQUENCE public.rooms_id_seq OWNED BY public.rooms.id;
 --
 
 CREATE TABLE public.rooms_runs (
-    room_id integer NOT NULL,
-    run_id integer NOT NULL
+    room_id bigint NOT NULL,
+    run_id bigint NOT NULL
 );
 
 
@@ -2359,12 +2359,12 @@ ALTER SEQUENCE public.root_sites_id_seq OWNED BY public.root_sites.id;
 --
 
 CREATE TABLE public.runs (
-    id integer NOT NULL,
-    event_id integer,
+    id bigint NOT NULL,
+    event_id bigint,
     starts_at timestamp without time zone,
     title_suffix character varying,
     schedule_note text,
-    updated_by_id integer,
+    updated_by_id bigint,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     timespan_tsrange tsrange NOT NULL
@@ -2513,13 +2513,13 @@ ALTER SEQUENCE public.signup_requests_id_seq OWNED BY public.signup_requests.id;
 --
 
 CREATE TABLE public.signups (
-    id integer NOT NULL,
-    run_id integer,
+    id bigint NOT NULL,
+    run_id bigint,
     bucket_key character varying,
-    updated_by_id integer,
+    updated_by_id bigint,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    user_con_profile_id integer NOT NULL,
+    user_con_profile_id bigint NOT NULL,
     state character varying DEFAULT 'confirmed'::character varying NOT NULL,
     counted boolean,
     requested_bucket_key character varying,
@@ -2551,8 +2551,8 @@ ALTER SEQUENCE public.signups_id_seq OWNED BY public.signups.id;
 --
 
 CREATE TABLE public.staff_positions (
-    id integer NOT NULL,
-    convention_id integer,
+    id bigint NOT NULL,
+    convention_id bigint,
     name text,
     email text,
     created_at timestamp without time zone NOT NULL,
@@ -2598,14 +2598,14 @@ CREATE TABLE public.staff_positions_user_con_profiles (
 
 CREATE TABLE public.team_members (
     id integer NOT NULL,
-    event_id integer,
+    event_id bigint,
     updated_at timestamp without time zone,
     updated_by_id integer,
     display boolean,
     show_email boolean,
     receive_con_email boolean,
     created_at timestamp without time zone,
-    user_con_profile_id integer NOT NULL,
+    user_con_profile_id bigint NOT NULL,
     receive_signup_email character varying DEFAULT 'no'::character varying NOT NULL
 );
 
@@ -2634,8 +2634,8 @@ ALTER SEQUENCE public.team_members_id_seq OWNED BY public.team_members.id;
 --
 
 CREATE TABLE public.ticket_types (
-    id integer NOT NULL,
-    convention_id integer,
+    id bigint NOT NULL,
+    convention_id bigint,
     name text NOT NULL,
     description text,
     created_at timestamp without time zone NOT NULL,
@@ -2673,11 +2673,11 @@ ALTER SEQUENCE public.ticket_types_id_seq OWNED BY public.ticket_types.id;
 
 CREATE TABLE public.tickets (
     id integer NOT NULL,
-    user_con_profile_id integer,
-    ticket_type_id integer,
+    user_con_profile_id bigint,
+    ticket_type_id bigint,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    provided_by_event_id integer,
+    provided_by_event_id bigint,
     order_entry_id bigint,
     event_id bigint
 );
@@ -2743,9 +2743,9 @@ ALTER SEQUENCE public.user_activity_alerts_id_seq OWNED BY public.user_activity_
 --
 
 CREATE TABLE public.user_con_profiles (
-    id integer NOT NULL,
-    user_id integer NOT NULL,
-    convention_id integer NOT NULL,
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    convention_id bigint NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     first_name character varying NOT NULL,
@@ -2799,7 +2799,7 @@ ALTER SEQUENCE public.user_con_profiles_id_seq OWNED BY public.user_con_profiles
 --
 
 CREATE TABLE public.users (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     first_name character varying NOT NULL,
     last_name character varying NOT NULL,
     site_admin boolean,
@@ -3334,6 +3334,22 @@ ALTER TABLE ONLY public.cms_content_groups
 
 
 --
+-- Name: cms_files_layouts cms_files_layouts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_files_layouts
+    ADD CONSTRAINT cms_files_layouts_pkey PRIMARY KEY (cms_file_id, cms_layout_id);
+
+
+--
+-- Name: cms_files_pages cms_files_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_files_pages
+    ADD CONSTRAINT cms_files_pages_pkey PRIMARY KEY (cms_file_id, page_id);
+
+
+--
 -- Name: cms_files cms_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3350,6 +3366,14 @@ ALTER TABLE ONLY public.cms_graphql_queries
 
 
 --
+-- Name: cms_layouts_partials cms_layouts_partials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_layouts_partials
+    ADD CONSTRAINT cms_layouts_partials_pkey PRIMARY KEY (cms_layout_id, cms_partial_id);
+
+
+--
 -- Name: cms_layouts cms_layouts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3363,6 +3387,14 @@ ALTER TABLE ONLY public.cms_layouts
 
 ALTER TABLE ONLY public.cms_navigation_items
     ADD CONSTRAINT cms_navigation_items_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: cms_partials_pages cms_partials_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_partials_pages
+    ADD CONSTRAINT cms_partials_pages_pkey PRIMARY KEY (cms_partial_id, page_id);
 
 
 --
@@ -3574,6 +3606,14 @@ ALTER TABLE ONLY public.organization_roles
 
 
 --
+-- Name: organization_roles_users organization_roles_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_roles_users
+    ADD CONSTRAINT organization_roles_users_pkey PRIMARY KEY (organization_role_id, user_id);
+
+
+--
 -- Name: organizations organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3627,6 +3667,14 @@ ALTER TABLE ONLY public.products
 
 ALTER TABLE ONLY public.rooms
     ADD CONSTRAINT rooms_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rooms_runs rooms_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rooms_runs
+    ADD CONSTRAINT rooms_runs_pkey PRIMARY KEY (room_id, run_id);
 
 
 --
@@ -3691,6 +3739,14 @@ ALTER TABLE ONLY public.signups
 
 ALTER TABLE ONLY public.staff_positions
     ADD CONSTRAINT staff_positions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: staff_positions_user_con_profiles staff_positions_user_con_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.staff_positions_user_con_profiles
+    ADD CONSTRAINT staff_positions_user_con_profiles_pkey PRIMARY KEY (staff_position_id, user_con_profile_id);
 
 
 --
@@ -5714,6 +5770,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220122174528'),
 ('20220226170101'),
 ('20220226170448'),
-('20220313171517');
+('20220313171517'),
+('20220502182655'),
+('20220503164309');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4878,6 +4878,14 @@ ALTER TABLE ONLY public.signup_requests
 
 
 --
+-- Name: staff_positions_user_con_profiles fk_rails_1a2987d136; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.staff_positions_user_con_profiles
+    ADD CONSTRAINT fk_rails_1a2987d136 FOREIGN KEY (user_con_profile_id) REFERENCES public.user_con_profiles(id);
+
+
+--
 -- Name: permissions fk_rails_1c6be1bb15; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4926,6 +4934,22 @@ ALTER TABLE ONLY public.conventions
 
 
 --
+-- Name: cms_files_pages fk_rails_28864918c8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_files_pages
+    ADD CONSTRAINT fk_rails_28864918c8 FOREIGN KEY (cms_file_id) REFERENCES public.cms_files(id);
+
+
+--
+-- Name: cms_files_layouts fk_rails_2925d59485; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_files_layouts
+    ADD CONSTRAINT fk_rails_2925d59485 FOREIGN KEY (cms_file_id) REFERENCES public.cms_files(id);
+
+
+--
 -- Name: events fk_rails_2e7e36b62c; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4947,6 +4971,14 @@ ALTER TABLE ONLY public.user_activity_alerts
 
 ALTER TABLE ONLY public.form_sections
     ADD CONSTRAINT fk_rails_364c041eca FOREIGN KEY (form_id) REFERENCES public.forms(id);
+
+
+--
+-- Name: cms_layouts_partials fk_rails_3692f2130f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_layouts_partials
+    ADD CONSTRAINT fk_rails_3692f2130f FOREIGN KEY (cms_partial_id) REFERENCES public.cms_partials(id);
 
 
 --
@@ -5003,6 +5035,14 @@ ALTER TABLE ONLY public.conventions
 
 ALTER TABLE ONLY public.permissions
     ADD CONSTRAINT fk_rails_47812e3d12 FOREIGN KEY (staff_position_id) REFERENCES public.staff_positions(id);
+
+
+--
+-- Name: cms_partials_pages fk_rails_48ce1f3044; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_partials_pages
+    ADD CONSTRAINT fk_rails_48ce1f3044 FOREIGN KEY (cms_partial_id) REFERENCES public.cms_partials(id);
 
 
 --
@@ -5070,6 +5110,22 @@ ALTER TABLE ONLY public.signups
 
 
 --
+-- Name: organization_roles_users fk_rails_711b0b09bb; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_roles_users
+    ADD CONSTRAINT fk_rails_711b0b09bb FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: cms_layouts_partials fk_rails_7255733b32; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_layouts_partials
+    ADD CONSTRAINT fk_rails_7255733b32 FOREIGN KEY (cms_layout_id) REFERENCES public.cms_layouts(id);
+
+
+--
 -- Name: oauth_access_tokens fk_rails_732cb83ab7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5107,6 +5163,14 @@ ALTER TABLE ONLY public.signups
 
 ALTER TABLE ONLY public.signup_changes
     ADD CONSTRAINT fk_rails_79e46f1342 FOREIGN KEY (user_con_profile_id) REFERENCES public.user_con_profiles(id);
+
+
+--
+-- Name: cms_files_layouts fk_rails_82c2fb2f5b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_files_layouts
+    ADD CONSTRAINT fk_rails_82c2fb2f5b FOREIGN KEY (cms_layout_id) REFERENCES public.cms_layouts(id);
 
 
 --
@@ -5358,6 +5422,14 @@ ALTER TABLE ONLY public.conventions
 
 
 --
+-- Name: cms_partials_pages fk_rails_c0ad4edcf1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_partials_pages
+    ADD CONSTRAINT fk_rails_c0ad4edcf1 FOREIGN KEY (page_id) REFERENCES public.pages(id);
+
+
+--
 -- Name: event_categories fk_rails_c3b33a1b7c; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5379,6 +5451,14 @@ ALTER TABLE ONLY public.active_storage_attachments
 
 ALTER TABLE ONLY public.permissions
     ADD CONSTRAINT fk_rails_c526e10020 FOREIGN KEY (cms_content_group_id) REFERENCES public.cms_content_groups(id);
+
+
+--
+-- Name: staff_positions_user_con_profiles fk_rails_c6eecee531; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.staff_positions_user_con_profiles
+    ADD CONSTRAINT fk_rails_c6eecee531 FOREIGN KEY (staff_position_id) REFERENCES public.staff_positions(id);
 
 
 --
@@ -5470,6 +5550,14 @@ ALTER TABLE ONLY public.signup_requests
 
 
 --
+-- Name: organization_roles_users fk_rails_f00629add2; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_roles_users
+    ADD CONSTRAINT fk_rails_f00629add2 FOREIGN KEY (organization_role_id) REFERENCES public.organization_roles(id);
+
+
+--
 -- Name: tickets fk_rails_f029f4cf01; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5539,6 +5627,14 @@ ALTER TABLE ONLY public.tickets
 
 ALTER TABLE ONLY public.user_con_profiles
     ADD CONSTRAINT fk_rails_f7ac429ed7 FOREIGN KEY (convention_id) REFERENCES public.conventions(id);
+
+
+--
+-- Name: cms_files_pages fk_rails_fa2194f40d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cms_files_pages
+    ADD CONSTRAINT fk_rails_fa2194f40d FOREIGN KEY (page_id) REFERENCES public.pages(id);
 
 
 --

--- a/test/factories/cms_files.rb
+++ b/test/factories/cms_files.rb
@@ -8,7 +8,7 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  parent_id   :integer
-#  uploader_id :integer
+#  uploader_id :bigint
 #
 # Indexes
 #

--- a/test/factories/conventions.rb
+++ b/test/factories/conventions.rb
@@ -3,7 +3,7 @@
 #
 # Table name: conventions
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  accepting_proposals            :boolean
 #  canceled                       :boolean          default(FALSE), not null
 #  clickwrap_agreement            :text
@@ -36,9 +36,9 @@
 #  catch_all_staff_position_id    :bigint
 #  default_layout_id              :bigint
 #  organization_id                :bigint
-#  root_page_id                   :integer
+#  root_page_id                   :bigint
 #  stripe_account_id              :text
-#  updated_by_id                  :integer
+#  updated_by_id                  :bigint
 #  user_con_profile_form_id       :bigint
 #
 # Indexes

--- a/test/factories/events.rb
+++ b/test/factories/events.rb
@@ -3,7 +3,7 @@
 #
 # Table name: events
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  additional_info              :jsonb
 #  admin_notes                  :text
 #  age_restrictions_description :text
@@ -27,10 +27,10 @@
 #  url                          :text
 #  created_at                   :datetime
 #  updated_at                   :datetime
-#  convention_id                :integer
+#  convention_id                :bigint
 #  event_category_id            :bigint           not null
-#  owner_id                     :integer
-#  updated_by_id                :integer
+#  owner_id                     :bigint
+#  updated_by_id                :bigint
 #
 # Indexes
 #
@@ -48,7 +48,6 @@
 #  fk_rails_...  (updated_by_id => users.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :event do
     convention

--- a/test/factories/order_entries.rb
+++ b/test/factories/order_entries.rb
@@ -26,7 +26,6 @@
 #  fk_rails_...  (product_variant_id => product_variants.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :order_entry do
     association :order

--- a/test/factories/pages.rb
+++ b/test/factories/pages.rb
@@ -3,7 +3,7 @@
 #
 # Table name: pages
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  admin_notes              :text
 #  content                  :text
 #  hidden_from_search       :boolean          default(FALSE), not null
@@ -27,7 +27,6 @@
 #  fk_rails_...  (cms_layout_id => cms_layouts.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :page do
     sequence(:name) { |n| "Page #{n}" }

--- a/test/factories/rooms.rb
+++ b/test/factories/rooms.rb
@@ -3,11 +3,11 @@
 #
 # Table name: rooms
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  convention_id :integer
+#  convention_id :bigint
 #
 # Indexes
 #
@@ -18,7 +18,6 @@
 #  fk_rails_...  (convention_id => conventions.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :room do
     association(:convention)

--- a/test/factories/runs.rb
+++ b/test/factories/runs.rb
@@ -3,15 +3,15 @@
 #
 # Table name: runs
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  schedule_note    :text
 #  starts_at        :datetime
 #  timespan_tsrange :tsrange          not null
 #  title_suffix     :string
 #  created_at       :datetime
 #  updated_at       :datetime
-#  event_id         :integer
-#  updated_by_id    :integer
+#  event_id         :bigint
+#  updated_by_id    :bigint
 #
 # Indexes
 #
@@ -25,7 +25,6 @@
 #  fk_rails_...  (updated_by_id => users.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :run do
     event

--- a/test/factories/signups.rb
+++ b/test/factories/signups.rb
@@ -3,7 +3,7 @@
 #
 # Table name: signups
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  bucket_key           :string
 #  counted              :boolean
 #  expires_at           :datetime
@@ -11,9 +11,9 @@
 #  state                :string           default("confirmed"), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  run_id               :integer
-#  updated_by_id        :integer
-#  user_con_profile_id  :integer          not null
+#  run_id               :bigint
+#  updated_by_id        :bigint
+#  user_con_profile_id  :bigint           not null
 #
 # Indexes
 #

--- a/test/factories/staff_positions.rb
+++ b/test/factories/staff_positions.rb
@@ -3,7 +3,7 @@
 #
 # Table name: staff_positions
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  cc_addresses  :text             default([]), not null, is an Array
 #  email         :text
 #  email_aliases :text             default([]), not null, is an Array
@@ -11,7 +11,7 @@
 #  visible       :boolean
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  convention_id :integer
+#  convention_id :bigint
 #
 # Indexes
 #
@@ -23,7 +23,6 @@
 #  fk_rails_...  (convention_id => conventions.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :staff_position do
     convention

--- a/test/factories/team_members.rb
+++ b/test/factories/team_members.rb
@@ -10,9 +10,9 @@
 #  show_email           :boolean
 #  created_at           :datetime
 #  updated_at           :datetime
-#  event_id             :integer
+#  event_id             :bigint
 #  updated_by_id        :integer
-#  user_con_profile_id  :integer          not null
+#  user_con_profile_id  :bigint           not null
 #
 # Indexes
 #
@@ -24,7 +24,6 @@
 #  fk_rails_...  (user_con_profile_id => user_con_profiles.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :team_member do
     event

--- a/test/factories/ticket_types.rb
+++ b/test/factories/ticket_types.rb
@@ -3,7 +3,7 @@
 #
 # Table name: ticket_types
 #
-#  id                                :integer          not null, primary key
+#  id                                :bigint           not null, primary key
 #  allows_event_signups              :boolean          default(TRUE), not null
 #  counts_towards_convention_maximum :boolean          default(TRUE), not null
 #  description                       :text
@@ -11,7 +11,7 @@
 #  name                              :text             not null
 #  created_at                        :datetime         not null
 #  updated_at                        :datetime         not null
-#  convention_id                     :integer
+#  convention_id                     :bigint
 #  event_id                          :bigint
 #
 # Indexes

--- a/test/factories/tickets.rb
+++ b/test/factories/tickets.rb
@@ -8,9 +8,9 @@
 #  updated_at           :datetime         not null
 #  event_id             :bigint
 #  order_entry_id       :bigint
-#  provided_by_event_id :integer
-#  ticket_type_id       :integer
-#  user_con_profile_id  :integer
+#  provided_by_event_id :bigint
+#  ticket_type_id       :bigint
+#  user_con_profile_id  :bigint
 #
 # Indexes
 #

--- a/test/factories/user_con_profiles.rb
+++ b/test/factories/user_con_profiles.rb
@@ -3,7 +3,7 @@
 #
 # Table name: user_con_profiles
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  accepted_clickwrap_agreement :boolean          default(FALSE), not null
 #  additional_info              :jsonb
 #  address                      :text
@@ -30,8 +30,8 @@
 #  zipcode                      :string
 #  created_at                   :datetime
 #  updated_at                   :datetime
-#  convention_id                :integer          not null
-#  user_id                      :integer          not null
+#  convention_id                :bigint           not null
+#  user_id                      :bigint           not null
 #
 # Indexes
 #
@@ -43,7 +43,6 @@
 #  fk_rails_...  (user_id => users.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :user_con_profile do
     user

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -3,7 +3,7 @@
 #
 # Table name: users
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  current_sign_in_at        :datetime
 #  current_sign_in_ip        :string
 #  email                     :string           default(""), not null
@@ -29,7 +29,6 @@
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :user do
     sequence(:first_name) { |n| "Firstname#{n}" }

--- a/test/models/cms_file_test.rb
+++ b/test/models/cms_file_test.rb
@@ -8,7 +8,7 @@
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  parent_id   :integer
-#  uploader_id :integer
+#  uploader_id :bigint
 #
 # Indexes
 #

--- a/test/models/convention_test.rb
+++ b/test/models/convention_test.rb
@@ -3,7 +3,7 @@
 #
 # Table name: conventions
 #
-#  id                             :integer          not null, primary key
+#  id                             :bigint           not null, primary key
 #  accepting_proposals            :boolean
 #  canceled                       :boolean          default(FALSE), not null
 #  clickwrap_agreement            :text
@@ -36,9 +36,9 @@
 #  catch_all_staff_position_id    :bigint
 #  default_layout_id              :bigint
 #  organization_id                :bigint
-#  root_page_id                   :integer
+#  root_page_id                   :bigint
 #  stripe_account_id              :text
-#  updated_by_id                  :integer
+#  updated_by_id                  :bigint
 #  user_con_profile_form_id       :bigint
 #
 # Indexes

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -3,7 +3,7 @@
 #
 # Table name: events
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  additional_info              :jsonb
 #  admin_notes                  :text
 #  age_restrictions_description :text
@@ -27,10 +27,10 @@
 #  url                          :text
 #  created_at                   :datetime
 #  updated_at                   :datetime
-#  convention_id                :integer
+#  convention_id                :bigint
 #  event_category_id            :bigint           not null
-#  owner_id                     :integer
-#  updated_by_id                :integer
+#  owner_id                     :bigint
+#  updated_by_id                :bigint
 #
 # Indexes
 #
@@ -48,7 +48,6 @@
 #  fk_rails_...  (updated_by_id => users.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class EventTest < ActiveSupport::TestCase

--- a/test/models/order_entry_test.rb
+++ b/test/models/order_entry_test.rb
@@ -26,7 +26,6 @@
 #  fk_rails_...  (product_variant_id => product_variants.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class OrderEntryTest < ActiveSupport::TestCase

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -3,7 +3,7 @@
 #
 # Table name: pages
 #
-#  id                       :integer          not null, primary key
+#  id                       :bigint           not null, primary key
 #  admin_notes              :text
 #  content                  :text
 #  hidden_from_search       :boolean          default(FALSE), not null
@@ -27,7 +27,6 @@
 #  fk_rails_...  (cms_layout_id => cms_layouts.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class PageTest < ActiveSupport::TestCase

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -3,11 +3,11 @@
 #
 # Table name: rooms
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  convention_id :integer
+#  convention_id :bigint
 #
 # Indexes
 #
@@ -18,7 +18,6 @@
 #  fk_rails_...  (convention_id => conventions.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class RoomTest < ActiveSupport::TestCase

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -3,15 +3,15 @@
 #
 # Table name: runs
 #
-#  id               :integer          not null, primary key
+#  id               :bigint           not null, primary key
 #  schedule_note    :text
 #  starts_at        :datetime
 #  timespan_tsrange :tsrange          not null
 #  title_suffix     :string
 #  created_at       :datetime
 #  updated_at       :datetime
-#  event_id         :integer
-#  updated_by_id    :integer
+#  event_id         :bigint
+#  updated_by_id    :bigint
 #
 # Indexes
 #
@@ -25,7 +25,6 @@
 #  fk_rails_...  (updated_by_id => users.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class RunTest < ActiveSupport::TestCase

--- a/test/models/signup_test.rb
+++ b/test/models/signup_test.rb
@@ -3,7 +3,7 @@
 #
 # Table name: signups
 #
-#  id                   :integer          not null, primary key
+#  id                   :bigint           not null, primary key
 #  bucket_key           :string
 #  counted              :boolean
 #  expires_at           :datetime
@@ -11,9 +11,9 @@
 #  state                :string           default("confirmed"), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  run_id               :integer
-#  updated_by_id        :integer
-#  user_con_profile_id  :integer          not null
+#  run_id               :bigint
+#  updated_by_id        :bigint
+#  user_con_profile_id  :bigint           not null
 #
 # Indexes
 #

--- a/test/models/staff_position_test.rb
+++ b/test/models/staff_position_test.rb
@@ -3,7 +3,7 @@
 #
 # Table name: staff_positions
 #
-#  id            :integer          not null, primary key
+#  id            :bigint           not null, primary key
 #  cc_addresses  :text             default([]), not null, is an Array
 #  email         :text
 #  email_aliases :text             default([]), not null, is an Array
@@ -11,7 +11,7 @@
 #  visible       :boolean
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  convention_id :integer
+#  convention_id :bigint
 #
 # Indexes
 #
@@ -23,7 +23,6 @@
 #  fk_rails_...  (convention_id => conventions.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class StaffPositionTest < ActiveSupport::TestCase

--- a/test/models/team_member_test.rb
+++ b/test/models/team_member_test.rb
@@ -10,9 +10,9 @@
 #  show_email           :boolean
 #  created_at           :datetime
 #  updated_at           :datetime
-#  event_id             :integer
+#  event_id             :bigint
 #  updated_by_id        :integer
-#  user_con_profile_id  :integer          not null
+#  user_con_profile_id  :bigint           not null
 #
 # Indexes
 #
@@ -24,7 +24,6 @@
 #  fk_rails_...  (user_con_profile_id => user_con_profiles.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class TeamMemberTest < ActiveSupport::TestCase

--- a/test/models/ticket_test.rb
+++ b/test/models/ticket_test.rb
@@ -8,9 +8,9 @@
 #  updated_at           :datetime         not null
 #  event_id             :bigint
 #  order_entry_id       :bigint
-#  provided_by_event_id :integer
-#  ticket_type_id       :integer
-#  user_con_profile_id  :integer
+#  provided_by_event_id :bigint
+#  ticket_type_id       :bigint
+#  user_con_profile_id  :bigint
 #
 # Indexes
 #

--- a/test/models/ticket_type_test.rb
+++ b/test/models/ticket_type_test.rb
@@ -3,7 +3,7 @@
 #
 # Table name: ticket_types
 #
-#  id                                :integer          not null, primary key
+#  id                                :bigint           not null, primary key
 #  allows_event_signups              :boolean          default(TRUE), not null
 #  counts_towards_convention_maximum :boolean          default(TRUE), not null
 #  description                       :text
@@ -11,7 +11,7 @@
 #  name                              :text             not null
 #  created_at                        :datetime         not null
 #  updated_at                        :datetime         not null
-#  convention_id                     :integer
+#  convention_id                     :bigint
 #  event_id                          :bigint
 #
 # Indexes

--- a/test/models/user_con_profile_test.rb
+++ b/test/models/user_con_profile_test.rb
@@ -3,7 +3,7 @@
 #
 # Table name: user_con_profiles
 #
-#  id                           :integer          not null, primary key
+#  id                           :bigint           not null, primary key
 #  accepted_clickwrap_agreement :boolean          default(FALSE), not null
 #  additional_info              :jsonb
 #  address                      :text
@@ -30,8 +30,8 @@
 #  zipcode                      :string
 #  created_at                   :datetime
 #  updated_at                   :datetime
-#  convention_id                :integer          not null
-#  user_id                      :integer          not null
+#  convention_id                :bigint           not null
+#  user_id                      :bigint           not null
 #
 # Indexes
 #
@@ -43,7 +43,6 @@
 #  fk_rails_...  (user_id => users.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class UserConProfileTest < ActiveSupport::TestCase

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,7 +3,7 @@
 #
 # Table name: users
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  current_sign_in_at        :datetime
 #  current_sign_in_ip        :string
 #  email                     :string           default(""), not null
@@ -29,7 +29,6 @@
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase


### PR DESCRIPTION
This fixes a couple of older inconsistencies in our database schema.  Rails doesn't particularly care about these, but other ORM frameworks (in particular, I'm playing with SeaORM and Prisma) do care.  This won't bother Rails at all, so no reason not to go ahead and do it.

Changes:

* Get IDs to be bigints
* Add composite primary keys on join tables
* Add foreign keys on join tables