### PR TITLE
Use the right region for confirming subscriptions

### DIFF
--- a/app/controllers/sns_notifications_controller.rb
+++ b/app/controllers/sns_notifications_controller.rb
@@ -4,7 +4,7 @@ class SnsNotificationsController < ApplicationController
   before_action :verify_request_authenticity
 
   def self.sns_client
-    @sns_client ||= Aws::SNS::Client.new
+    @sns_client ||= Aws::SNS::Client.new(region: ReceiveSnsEmailDeliveryService.aws_region)
   end
 
   def create


### PR DESCRIPTION
This should let orgs that use a separate AWS region for SNS/SES receiving to have automatic subscription confirmation work correctly.