### PR TITLE
Clairvoyant autoscaling for signup openings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,3 +66,7 @@ Metrics/MethodLength:
 # prettier and rubocop are fighting about this one, let prettier win
 Style/StringLiteralsInInterpolation:
   Enabled: false
+
+# Not sure why Prettier isn't disabling this but apparently we have to
+Style/StringLiterals:
+  Enabled: false

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,9 @@ packageExtensions:
   autoprefixer@*:
     dependencies:
       colorette: "*"
+  '@n1ru4l/graphql-live-query@*':
+    dependencies:
+      tslib: "*"
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs

--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,10 @@ group :development do
   gem 'rubocop-rails'
   gem 'rubocop-sequel'
   gem 'prettier', '2.1.0'
+  gem 'prettier_print'
+  gem 'syntax_tree'
+  gem 'syntax_tree-haml'
+  gem 'syntax_tree-rbs'
 
   # Find missing `end` statements
   gem 'dead_end'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,9 @@ GEM
       activesupport (> 5.0)
       railties (> 5.0)
       rouge (~> 3.0)
+    haml (5.2.2)
+      temple (>= 0.8.0)
+      tilt
     heapy (0.2.0)
       thor
     i18n (1.11.0)
@@ -293,14 +296,14 @@ GEM
     jaro_winkler (1.5.4)
     jaro_winkler (1.5.4-java)
     jmespath (1.6.1)
-    json (2.5.1)
-    json (2.5.1-java)
+    json (2.6.2)
+    json (2.6.2-java)
     json-jwt (1.11.0)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
     jwt (2.4.1)
-    kramdown (2.3.1)
+    kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -374,16 +377,16 @@ GEM
       timeout
     nio4r (2.5.8)
     nio4r (2.5.8-java)
-    nokogiri (1.13.7)
+    nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.7-java)
+    nokogiri (1.13.8-java)
       racc (~> 1.4)
     oj (3.13.4)
     orm_adapter (0.5.0)
     ox (2.14.4)
     parallel (1.22.1)
-    parser (3.1.2.0)
+    parser (3.1.2.1)
       ast (~> 2.4.1)
     pg (1.2.3)
     pg_search (2.3.5)
@@ -391,6 +394,7 @@ GEM
       activesupport (>= 5.2)
     phonelib (0.6.53)
     prettier (2.1.0)
+    prettier_print (0.1.0)
     promise.rb (0.7.4)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -486,7 +490,7 @@ GEM
       rubocop-ast (>= 1.18.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.19.1)
+    rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
     rubocop-performance (1.11.5)
       rubocop (>= 1.7.0, < 2.0)
@@ -523,7 +527,7 @@ GEM
     skylight (5.3.2)
       activesupport (>= 5.2.0)
     slop (3.6.0)
-    solargraph (0.44.3)
+    solargraph (0.46.0)
       backport (~> 1.2)
       benchmark
       bundler (>= 1.17.2)
@@ -562,11 +566,22 @@ GEM
       stripe (> 5, < 6)
     strscan (3.0.3)
     strscan (3.0.3-java)
+    syntax_tree (3.3.0)
+      prettier_print
+    syntax_tree-haml (1.3.1)
+      haml (>= 5.2)
+      prettier_print
+      syntax_tree (>= 2.0.1)
+    syntax_tree-rbs (0.5.0)
+      prettier_print
+      rbs
+      syntax_tree (>= 2.0.1)
     systemu (2.6.5)
+    temple (0.8.2)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.2.1)
-    tilt (2.0.10)
+    tilt (2.0.11)
     timeout (0.3.0)
     tins (1.20.2)
     twilio-ruby (5.69.0)
@@ -597,7 +612,7 @@ GEM
     will_paginate (3.3.1)
     with_advisory_lock (4.6.0)
       activerecord (>= 4.2)
-    yard (0.9.27)
+    yard (0.9.28)
       webrick (~> 1.7.0)
     zeitwerk (2.6.0)
 
@@ -660,6 +675,7 @@ DEPENDENCIES
   pg_search
   phonelib
   prettier (= 2.1.0)
+  prettier_print
   pry-rails
   pry-remote
   puma
@@ -688,6 +704,9 @@ DEPENDENCIES
   stackprof
   stripe
   stripe-ruby-mock (>= 3.1.0.rc3)
+  syntax_tree
+  syntax_tree-haml
+  syntax_tree-rbs
   term-ansicolor
   twilio-ruby (~> 5.69.0)
   typeprof

--- a/app/javascript/graphqlTypes.generated.ts
+++ b/app/javascript/graphqlTypes.generated.ts
@@ -1118,6 +1118,7 @@ export type CreateCmsContentGroupPayload = {
 export type CreateCmsFileInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars['String']>;
+  /** @deprecated Migrating to ActiveStorage direct uploads; please use signed_blob_id instead */
   file?: InputMaybe<Scalars['Upload']>;
   signedBlobId?: InputMaybe<Scalars['ID']>;
 };

--- a/app/services/autoscale_servers_service.rb
+++ b/app/services/autoscale_servers_service.rb
@@ -1,0 +1,76 @@
+class AutoscaleServersService < CivilService::Service
+  USERS_PER_INSTANCE = 30
+  MIN_INSTANCES = 1
+  MIN_INSTANCES_FOR_SIGNUP_OPENING = 2
+  MAX_INSTANCES = 8
+  SIGNUP_OPENING_LOOKAHEAD_TIME = 1.hour
+  SIGNUP_OPENING_DECAY_TIME = 1.hour
+
+  def self.scaling_target_for_signup_opening(convention)
+    user_count =
+      if convention.ticket_mode == "required_for_signup"
+        convention.user_con_profiles.joins(:ticket).count
+      else
+        convention.user_con_profiles.count
+      end
+
+    (
+      # log2 term: bias the low end of the formula to use more servers, because redundancy = good
+      # linear term: the log2 term accounts for ~half of the needed servers
+      # constant term: never go below a certain minimum for a signup opening
+      (0.5 * Math.log2(user_count)) + (0.5 * (1 / USERS_PER_INSTANCE) * user_count) + MIN_INSTANCES_FOR_SIGNUP_OPENING
+    )
+  end
+
+  def self.smooth_decay(decay_amount, start, finish)
+    smoothed_decay_factor = (Math.cos((decay_amount + 1) * Math::PI) + 1) / 2.0
+    max_decay = start - finish
+    start - (max_decay * smoothed_decay_factor)
+  end
+
+  def self.scaling_target_for(time)
+    nearby_increases = Convention.connection.select_rows <<~SQL
+      select id, timespans.*
+      from conventions,
+        jsonb_to_recordset(maximum_event_signups->'timespans') timespans(start timestamp, value text)
+      where start between #{Convention.connection.quote time - SIGNUP_OPENING_LOOKAHEAD_TIME}
+      and #{Convention.connection.quote time + SIGNUP_OPENING_DECAY_TIME}
+      and value not in ('not_now', 'not_yet')
+      and signup_mode = 'self_service';
+    SQL
+
+    return MIN_INSTANCES if nearby_increases.empty?
+
+    conventions_by_id = Convention.where(id: nearby_increases.map(&:first)).index_by(&:id)
+    scaling_targets =
+      nearby_increases.map do |convention_id, start_time, _value|
+        target = scaling_target_for_signup_opening(conventions_by_id.fetch(convention_id))
+        if start_time >= time
+          target
+        else
+          decay_amount = (time - start_time) / SIGNUP_OPENING_DECAY_TIME
+          smooth_decay(decay_amount, target, MIN_INSTANCES)
+        end
+      end
+
+    [[MIN_INSTANCES, *scaling_targets].max, MAX_INSTANCES].min.ceil
+  end
+
+  private
+
+  def inner_call
+    adapter = HostingServiceAdapters::Base.find_adapter
+    return unless adapter
+
+    scaling_target = self.class.scaling_target_for(Time.now)
+    current_instance_count = adapter.fetch_instance_count
+
+    if current_instance_count == scaling_target
+      Rails.logger.info "Currently running #{current_instance_count} #{"instance".pluralize(current_instance_count)}; \
+no autoscaling needed"
+    else
+      Rails.logger.info "Autoscaling to #{scaling_target} instances"
+      adapter.update_instance_count(scaling_target)
+    end
+  end
+end

--- a/app/services/hosting_service_adapters/base.rb
+++ b/app/services/hosting_service_adapters/base.rb
@@ -1,0 +1,17 @@
+class HostingServiceAdapters::Base
+  def self.find_adapter
+    [HostingServiceAdapters::Render].map(&:new).find(&:applicable?)
+  end
+
+  def applicable?
+    raise NotImplementedError, "HostingServiceAdapters::Base subclasses must implement #applicable?"
+  end
+
+  def fetch_instance_count
+    raise NotImplementedError, "HostingServiceAdapters::Base subclasses must implement #fetch_instance_count"
+  end
+
+  def update_instance_count(instance_count)
+    raise NotImplementedError, "HostingServiceAdapters::Base subclasses must implement #update_instance_count"
+  end
+end

--- a/app/services/hosting_service_adapters/render.rb
+++ b/app/services/hosting_service_adapters/render.rb
@@ -1,0 +1,54 @@
+class HostingServiceAdapters::Render < HostingServiceAdapters::Base
+  def applicable?
+    ENV["RENDER_API_KEY"].present? && ENV["RENDER_SERVICE_ID"].present?
+  end
+
+  def fetch_instance_count
+    url = URI("https://api.render.com/v1/services/#{ENV.fetch("RENDER_SERVICE_ID")}")
+    http = Net::HTTP.new(url.host, url.port)
+    http.use_ssl = true
+
+    request = Net::HTTP::Get.new(url)
+    request["Accept"] = "application/json"
+    request["Authorization"] = "Bearer #{ENV.fetch("RENDER_API_KEY")}"
+
+    response = http.request(request)
+    raise response.body unless response.is_a?(Net::HTTPSuccess)
+
+    body = JSON.parse(response.body)
+    body["serviceDetails"]["numInstances"]
+  end
+
+  def update_instance_count(instance_count)
+    url = URI("https://api.render.com/v1/services/#{ENV.fetch("RENDER_SERVICE_ID")}/scale")
+
+    http = Net::HTTP.new(url.host, url.port)
+    http.use_ssl = true
+
+    request = Net::HTTP::Post.new(url)
+    request["Accept"] = "application/json"
+    request["Content-Type"] = "application/json"
+    request["Authorization"] = "Bearer #{ENV.fetch("RENDER_API_KEY")}"
+    request.body = JSON.dump({ numInstances: instance_count })
+
+    response = http.request(request)
+    raise response.body unless response.is_a?(Net::HTTPSuccess)
+
+    deploy_service
+  end
+
+  private
+
+  def deploy_service
+    url = URI("https://api.render.com/v1/services/#{ENV.fetch("RENDER_SERVICE_ID")}/deploys")
+    http = Net::HTTP.new(url.host, url.port)
+    http.use_ssl = true
+
+    request = Net::HTTP::Post.new(url)
+    request["Accept"] = "application/json"
+    request["Authorization"] = "Bearer #{ENV.fetch("RENDER_API_KEY")}"
+
+    response = http.request(request)
+    raise response.body unless response.is_a?(Net::HTTPSuccess)
+  end
+end

--- a/config/cloudwatch_schedule.rb
+++ b/config/cloudwatch_schedule.rb
@@ -1,13 +1,17 @@
-require 'cloudwatch_scheduler'
+require "cloudwatch_scheduler"
 
 CloudwatchScheduler() do |_config|
   # every hour at 10 minutes past the hour
-  task 'run_notifications', cron: '10 * * * ? *' do
+  task "run_notifications", cron: "10 * * * ? *" do
     RunNotificationsService.new.call!
   end
 
   # every day at 5:00am
-  task 'cleanup', cron: '0 5 * * ? *' do
+  task "cleanup", cron: "0 5 * * ? *" do
     CleanupDbService.new.call!
+  end
+
+  task "autoscale", cron: "0/15 * * * ? *" do
+    AutoscaleServersService.new.call!
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -19338,17 +19338,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"tslib@npm:*, tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:~2.4.0":
+  version: 2.4.0
+  resolution: "tslib@npm:2.4.0"
+  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:~2.4.0":
-  version: 2.4.0
-  resolution: "tslib@npm:2.4.0"
-  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds a cron job that runs every 15 minutes.  For each convention, it looks for signup opening times, and if we're close to one, it scales servers to accommodate the predicted need.

The formula for predicting needed servers at a signup opening time is:

$(0.5 * \log_2 (userCount)) + (0.5 * \frac{1}{usersPerInstance} * userCount) + 2$

I arrived at this after some trial and error in Grapher.  The basic ideas here are:

* We never want fewer than 2 servers at a signup opening time
* At the low end, we want to bias towards more redundancy for smaller conventions
* Aside from that, the scale should be roughly linear

The constant `usersPerInstance` is currently set to 30, but can be adjusted in code.  I arrived at 30 again via trial and error, trying to align the results of this formula with what we've been doing for NEIL Hosting.

The scaling algorithm roughly looks like this:

* 1 hour before signup opening, scale up to the maximum predicted level needed
* Starting at signup opening time, begin a smooth decay of the number of servers using a cosine function
* 1 hour after signup opening, return to the minimum number of instances (currently 1).

If there are two conventions with overlapping signup opening times, this algorithm will choose whichever one needs the larger number of instances at the current time.