### PR TITLE
Recycle the S3 and KMS client for each received email

### DIFF
--- a/.toys.rb
+++ b/.toys.rb
@@ -294,7 +294,8 @@ tool "download_email" do
 
     ENV["AWS_PROFILE"] = "neil"
     ENV["AWS_REGION"] = "us-east-1"
-    message = ReceiveSnsEmailDeliveryService.s3_client.get_object(bucket: "intercode-inbox", key: message_id).body.read
+    message =
+      ReceiveSnsEmailDeliveryService.new.s3_client.get_object(bucket: "intercode-inbox", key: message_id).body.read
     File.write("#{message_id}.eml", message)
   end
 end


### PR DESCRIPTION
I think hanging onto the client objects is causing memory leaks.  Let's just have them GCed on every message.