### PR TITLE
Add foreign keys to event_ratings

### DIFF
--- a/app/models/event_rating.rb
+++ b/app/models/event_rating.rb
@@ -17,6 +17,11 @@
 #  index_event_ratings_on_user_con_profile_id               (user_con_profile_id)
 #  index_event_ratings_on_user_con_profile_id_and_event_id  (user_con_profile_id,event_id) UNIQUE
 #
+# Foreign Keys
+#
+#  fk_rails_...  (event_id => events.id)
+#  fk_rails_...  (user_con_profile_id => user_con_profiles.id)
+#
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
 
 class EventRating < ApplicationRecord

--- a/db/migrate/20221120175702_add_event_ratings_foreign_keys.rb
+++ b/db/migrate/20221120175702_add_event_ratings_foreign_keys.rb
@@ -1,0 +1,6 @@
+class AddEventRatingsForeignKeys < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :event_ratings, :user_con_profiles
+    add_foreign_key :event_ratings, :events
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5149,6 +5149,14 @@ ALTER TABLE ONLY public.oauth_access_tokens
 
 
 --
+-- Name: event_ratings fk_rails_748bde5cd4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.event_ratings
+    ADD CONSTRAINT fk_rails_748bde5cd4 FOREIGN KEY (event_id) REFERENCES public.events(id);
+
+
+--
 -- Name: oauth_openid_requests fk_rails_77114b3b09; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5314,6 +5322,14 @@ ALTER TABLE ONLY public.active_storage_variant_records
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT fk_rails_a0b385fce3 FOREIGN KEY (event_category_id) REFERENCES public.event_categories(id);
+
+
+--
+-- Name: event_ratings fk_rails_a22a77f4d9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.event_ratings
+    ADD CONSTRAINT fk_rails_a22a77f4d9 FOREIGN KEY (user_con_profile_id) REFERENCES public.user_con_profiles(id);
 
 
 --
@@ -5886,6 +5902,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220503164309'),
 ('20220609161816'),
 ('20220918173739'),
-('20220924204825');
+('20220924204825'),
+('20221120175702');
 
 

--- a/test/factories/event_ratings.rb
+++ b/test/factories/event_ratings.rb
@@ -16,8 +16,12 @@
 #  index_event_ratings_on_user_con_profile_id               (user_con_profile_id)
 #  index_event_ratings_on_user_con_profile_id_and_event_id  (user_con_profile_id,event_id) UNIQUE
 #
+# Foreign Keys
+#
+#  fk_rails_...  (event_id => events.id)
+#  fk_rails_...  (user_con_profile_id => user_con_profiles.id)
+#
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :event_rating do
     event

--- a/test/models/event_rating_test.rb
+++ b/test/models/event_rating_test.rb
@@ -16,8 +16,12 @@
 #  index_event_ratings_on_user_con_profile_id               (user_con_profile_id)
 #  index_event_ratings_on_user_con_profile_id_and_event_id  (user_con_profile_id,event_id) UNIQUE
 #
+# Foreign Keys
+#
+#  fk_rails_...  (event_id => events.id)
+#  fk_rails_...  (user_con_profile_id => user_con_profiles.id)
+#
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class EventRatingTest < ActiveSupport::TestCase


### PR DESCRIPTION
event_ratings was missing foreign keys it should have had (to events and user_con_profiles).  This adds them back in.