### PR TITLE
Small improvements to Assets Docker image

### DIFF
--- a/Dockerfile.assets
+++ b/Dockerfile.assets
@@ -9,5 +9,8 @@ RUN chown root.root -R /usr/src/intercode/public
 FROM nginx
 RUN  rm /usr/share/nginx/html/index.*
 COPY --from=code /usr/src/intercode/public /usr/share/nginx/html
-RUN chown www-data.root -R /usr/share/nginx/html
+RUN  touch /usr/share/nginx/html/index.html && \
+     chmod 644 /usr/share/nginx/html/index.html && \
+     chown www-data.root -R /usr/share/nginx/html && \
+     mkdir -p /var/run/nginx
 COPY nginx-assets.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
  - Create a default dir for /var/run/nginx, this allows the image to run without an explicit volume mount.
  - Add a root index.html - this ensures the root page fetch is not an HTTP error which makes checking the assets site with isitup.org feasible.
