### PR TITLE
Don't query for the event details twice

### DIFF
--- a/app/javascript/EventsApp/EventPage/index.tsx
+++ b/app/javascript/EventsApp/EventPage/index.tsx
@@ -23,6 +23,7 @@ function useLoadEventPageQueryFromParams() {
 }
 
 export default LoadQueryWrapper(useLoadEventPageQueryFromParams, function EventPage({ data }): JSX.Element {
+  const params = useParams<{ eventId: string }>();
   const { myProfile } = useContext(AppRootContext);
   const rateEvent = useRateEvent();
   const { secretFormItems, formResponse } = useSectionizedFormItems(data.convention.event);
@@ -49,7 +50,7 @@ export default LoadQueryWrapper(useLoadEventPageQueryFromParams, function EventP
         <div className="col-md-9">
           <h1>{event.title}</h1>
 
-          <ShortFormEventDetails eventId={event.id} />
+          <ShortFormEventDetails eventId={params.eventId ?? event.id} />
         </div>
 
         <div className="col-md-3">
@@ -59,7 +60,7 @@ export default LoadQueryWrapper(useLoadEventPageQueryFromParams, function EventP
             </div>
           )}
 
-          <EventAdminMenu eventId={event.id} />
+          <EventAdminMenu eventId={params.eventId ?? event.id} />
 
           {secretFormItems.map(
             (item) =>
@@ -88,10 +89,10 @@ export default LoadQueryWrapper(useLoadEventPageQueryFromParams, function EventP
       </div>
 
       <section className="my-4">
-        <RunsSection eventId={event.id} />
+        <RunsSection eventId={params.eventId ?? event.id} />
       </section>
 
-      <LongFormEventDetails eventId={event.id} />
+      <LongFormEventDetails eventId={params.eventId ?? event.id} />
     </>
   );
 });


### PR DESCRIPTION
Subtle performance improvement for the event page: this stops the subcomponents from having to do their own separate query for the event details.  The reason they were doing it before is because we add extra stuff after the ID in the URL portion, for prettier URLs.  Rails is fine with this, but we weren't being consistent about including the extra stuff in subcomponents' query parameters.