### PR TITLE
Fix JWT generation

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -218,7 +218,7 @@ Doorkeeper::JWT.configure do
 
     {
       iat: Time.current.utc.to_i,
-      exp: (Time.current + opts[:expires_in].seconds).utc.to_i,
+      exp: (Time.current + (opts[:expires_in]&.seconds || 24.hours)).utc.to_i,
       # @see JWT reserved claims - https://tools.ietf.org/html/draft-jones-json-web-token-07#page-7
       jti: SecureRandom.uuid,
       user: {


### PR DESCRIPTION
I accidentally broke JWT generation by removing the default expiration time from OAuth access tokens.  JWT needs an expiration time, so let's give it a reasonable default one.