### PR TITLE
Precompile bootsnap cache for faster startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ ENV NODE_ENV production
 ENV AWS_ACCESS_KEY_ID dummy
 ENV AWS_SECRET_ACCESS_KEY dummy
 
+RUN bundle exec bootsnap precompile --gemfile app/ lib/
 RUN DATABASE_URL=postgresql://fakehost/not_a_real_database AWS_S3_BUCKET=fakebucket bundle exec rails assets:precompile
 RUN rm -r doc-site
 


### PR DESCRIPTION
This is part of the default Dockerfile for Rails 7.1 apps, and I think it's a generally good idea so I'm adding it to our custom one.