### PR TITLE
JWT signing key is now an object, not a hash

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -233,7 +233,7 @@ Doorkeeper::JWT.configure do
 
   # Optionally set additional headers for the JWT. See
   # https://tools.ietf.org/html/rfc7515#section-4.1
-  token_headers { |_opts| { kid: Doorkeeper::OpenidConnect.signing_key[:kid] } }
+  token_headers { |_opts| { kid: Doorkeeper::OpenidConnect.signing_key.kid } }
 
   # Use the application secret specified in the access grant token. Defaults to
   # `false`. If you specify `use_application_secret true`, both `secret_key` and


### PR DESCRIPTION
Closes #7532.