### PR TITLE
Stop logging logs

### DIFF
--- a/config/initializers/cloudwatchlogger.rb
+++ b/config/initializers/cloudwatchlogger.rb
@@ -122,12 +122,16 @@ if ENV["CLOUDWATCH_LOG_GROUP"]
       end
   end
 
+  # Don't log about every log message attempt
+  logger_logger = Logger.new($stderr)
+  logger_logger.level = Logger::WARN
+
   cloudwatch_logger =
     CloudWatchLogger.new(
       {},
       ENV["CLOUDWATCH_LOG_GROUP"],
       dyno_type || ENV["CLOUDWATCH_LOG_STREAM_NAME"] || "intercode",
-      { format: :json, logger: nil }
+      { format: :json, logger: logger_logger }
     )
   Rails.application.config.logger.extend(ActiveSupport::Logger.broadcast(cloudwatch_logger))
 end


### PR DESCRIPTION
I thought passing `logger: nil` would make the logger not log about itself, but apparently it just makes it use the Rails default logger instead.  Let's give it a bespoke logger that just logs to STDERR and only logs warning and error messages.