### PR TITLE
shouldn't signupAdmin and signupsAdmin be combined?

### DIFF
--- a/app/javascript/EventsApp/SignupAdmin/RunEmailList.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/RunEmailList.tsx
@@ -77,8 +77,8 @@ export default LoadQueryWrapper<
 
   const mainTitle = useMemo(() => {
     separator === '; '
-      ? t('events.signupsAdmin.emailsSemicolonTitle', 'Emails (semicolon-separated)')
-      : t('events.signupsAdmin.emailsCommaTitle', 'Emails (comma-separated)');
+      ? t('events.signupAdmin.emailsSemicolonTitle', 'Emails (semicolon-separated)')
+      : t('events.signupAdmin.emailsCommaTitle', 'Emails (comma-separated)');
   }, [separator, t]);
 
   usePageTitle(`${mainTitle} - ${data.convention.event.title}`);

--- a/app/javascript/EventsApp/SignupAdmin/SignupsIndex.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/SignupsIndex.tsx
@@ -16,16 +16,16 @@ function SignupsIndex({ runPath }: SignupsIndexProps): JSX.Element {
       <RunHeader />
       <ul className="nav nav-tabs mb-2">
         <BootstrapNavLink path={`${runPath}/admin_signups/?filters.state=confirmed%2Cwaitlisted&sort.id=asc`}>
-          {t('events.signupsAdmin.title', 'Signups')}
+          {t('events.signupAdmin.title', 'Signups')}
         </BootstrapNavLink>
         <BootstrapNavLink path={`${runPath}/admin_signups/signup_changes?sort.created_at=asc`}>
-          {t('events.signupsAdmin.historyTitle', 'Change history')}
+          {t('events.signupAdmin.historyTitle', 'Change history')}
         </BootstrapNavLink>
         <BootstrapNavLink path={`${runPath}/admin_signups/emails/comma`}>
-          {t('events.signupsAdmin.emailsCommaTitle', 'Emails (comma-separated)')}
+          {t('events.signupAdmin.emailsCommaTitle', 'Emails (comma-separated)')}
         </BootstrapNavLink>
         <BootstrapNavLink path={`${runPath}/admin_signups/emails/semicolon`}>
-          {t('events.signupsAdmin.emailsSemicolonTitle', 'Emails (semicolon-separated)')}
+          {t('events.signupAdmin.emailsSemicolonTitle', 'Emails (semicolon-separated)')}
         </BootstrapNavLink>
       </ul>
       <Outlet />

--- a/app/javascript/EventsApp/SignupAdmin/index.tsx
+++ b/app/javascript/EventsApp/SignupAdmin/index.tsx
@@ -51,7 +51,7 @@ export default LoadQueryWrapper(useSignupAdminEventQueryFromParams, function Sig
             element={
               <>
                 <div className="alert alert-warning mb-2">
-                  <Trans i18nKey="events.signupsAdmin.emailsSemicolonWarning">
+                  <Trans i18nKey="events.signupAdmin.emailsSemicolonWarning">
                     <strong>Note:</strong> Most email apps use comma-separated address lists. Only Outlook uses
                     semicolon-separated address lists. If you’re not using Outlook, try comma-separated first.
                   </Trans>

--- a/locales/en.json
+++ b/locales/en.json
@@ -419,6 +419,7 @@
       "editPageHeader": "Edit signup for {{ eventTitle }}",
       "editPageTitle": "Editing signup for “{{ name }}” - {{ eventTitle }}",
       "editTitle": "Edit signup",
+      "emailsCommaTitle": "Emails (comma-separated)",
       "emailFilters": {
         "confirmedBucket": "Include {{ bucketName }} (confirmed)",
         "nobody": "Nobody",
@@ -427,6 +428,8 @@
       },
       "emailHeader": "Email",
       "emailTableHeader": "Email",
+      "emailsSemicolonTitle": "Emails (semicolon-separated)",
+      "emailsSemicolonWarning": "<0>Note:</0> Most email apps use comma-separated address lists.  Only Outlook uses semicolon-separated address lists.  If you’re not using Outlook, try comma-separated first.",
       "forceConfirmSignup": {
         "bucketInputCaption": "Please choose a signup bucket for {{ name }}.",
         "header": "Force signup into run",
@@ -439,6 +442,7 @@
         "timestampHeader": "Timestamp"
       },
       "historyPageTitle": "Signup change history - {{ eventTitle }}",
+      "historyTitle": "Change history",
       "indexPageTitle": "Signups - {{ eventTitle }}",
       "makeCountedConfirmPrompt": "<0>Are you sure? This will make {{ name }}’s signup count towards attendee totals for {{ eventTitle }}. {{ eventTitle }} will also count towards {{ name }}’s signup limit if there is a signup cap in place.</0><1>Caution: this operation does not check whether the signup buckets are already full, and therefore may result in overfilling a bucket.</1>",
       "makeNotCountedConfirmPrompt": "<0>Are you sure? This will make {{ name }}’s signup not count towards attendee totals for {{ eventTitle }}. It will also allow {{ name }} to sign up for an additional event if there is a signup cap in place.</0><1>Caution: this operation will pull additional attendees into the space freed up by making this signup not count.</1>",
@@ -447,13 +451,6 @@
       "phoneHeader": "Phone:",
       "sequenceHeader": "Seq",
       "stateHeader": "State",
-      "title": "Signups"
-    },
-    "signupsAdmin": {
-      "emailsCommaTitle": "Emails (comma-separated)",
-      "emailsSemicolonTitle": "Emails (semicolon-separated)",
-      "emailsSemicolonWarning": "<0>Note:</0> Most email apps use comma-separated address lists.  Only Outlook uses semicolon-separated address lists.  If you’re not using Outlook, try comma-separated first.",
-      "historyTitle": "Change history",
       "title": "Signups"
     },
     "signupSummary": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -432,6 +432,7 @@
       "editPageHeader": "",
       "editPageTitle": "",
       "editTitle": "",
+      "emailsCommaTitle": "",
       "emailFilters": {
         "confirmedBucket": "Include {{ bucketName }} (confirmed)",
         "nobody": "",
@@ -440,6 +441,8 @@
       },
       "emailHeader": "",
       "emailTableHeader": "",
+      "emailsSemicolonTitle": "",
+      "emailsSemicolonWarning": "",
       "forceConfirmSignup": {
         "bucketInputCaption": "",
         "header": "",
@@ -452,6 +455,7 @@
         "timestampHeader": ""
       },
       "historyPageTitle": "",
+      "historyTitle": "",
       "indexPageTitle": "",
       "makeCountedConfirmPrompt": "",
       "makeNotCountedConfirmPrompt": "",
@@ -460,13 +464,6 @@
       "phoneHeader": "",
       "sequenceHeader": "",
       "stateHeader": "",
-      "title": ""
-    },
-    "signupsAdmin": {
-      "emailsCommaTitle": "",
-      "emailsSemicolonTitle": "",
-      "emailsSemicolonWarning": "",
-      "historyTitle": "",
       "title": ""
     },
     "signupSummary": {


### PR DESCRIPTION
I had some difficulty building this to check locally, but I think this is a safe change that should simplify the locales organization (and make mis-selecting sections less likely).

Possibly this helps with #7203 since this seems to be touching the relevant parts? I wonder if there's an issue loading in from signupsAdmin?