### PR TITLE
Several nullability fixes and a deprecation from liquid-syntax-conformance branch

### DIFF
--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -42,7 +42,10 @@ class Types::EventType < Types::BaseObject
   field :runs, [Types::RunType], null: false do
     argument :start, Types::DateType, required: false
     argument :finish, Types::DateType, required: false
-    argument :exclude_conflicts, Boolean, required: false
+    argument :exclude_conflicts,
+             Boolean,
+             required: false,
+             deprecation_reason: "This parameter hasn't actually worked for a long time"
   end
 
   def runs(**args)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,7 +28,7 @@
 #  url                          :text
 #  created_at                   :datetime
 #  updated_at                   :datetime
-#  convention_id                :bigint
+#  convention_id                :bigint           not null
 #  event_category_id            :bigint           not null
 #  owner_id                     :bigint
 #  updated_by_id                :bigint

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -11,7 +11,7 @@
 #  title_suffix     :string
 #  created_at       :datetime
 #  updated_at       :datetime
-#  event_id         :bigint
+#  event_id         :bigint           not null
 #  updated_by_id    :bigint
 #
 # Indexes

--- a/app/models/signup.rb
+++ b/app/models/signup.rb
@@ -12,7 +12,7 @@
 #  state                :string           default("confirmed"), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  run_id               :bigint
+#  run_id               :bigint           not null
 #  updated_by_id        :bigint
 #  user_con_profile_id  :bigint           not null
 #

--- a/app/models/signup_request.rb
+++ b/app/models/signup_request.rb
@@ -5,6 +5,7 @@
 # Table name: signup_requests
 #
 #  id                   :bigint           not null, primary key
+#  priority             :integer
 #  requested_bucket_key :string
 #  state                :string           default("pending"), not null
 #  created_at           :datetime         not null

--- a/db/migrate/20230109012113_make_run_event_id_not_nullable.rb
+++ b/db/migrate/20230109012113_make_run_event_id_not_nullable.rb
@@ -1,0 +1,5 @@
+class MakeRunEventIdNotNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :runs, :event_id, false
+  end
+end

--- a/db/migrate/20230113184026_make_signup_run_id_not_nullable.rb
+++ b/db/migrate/20230113184026_make_signup_run_id_not_nullable.rb
@@ -1,0 +1,5 @@
+class MakeSignupRunIdNotNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :signups, :run_id, false
+  end
+end

--- a/db/migrate/20230113220828_make_event_convention_id_not_nullable.rb
+++ b/db/migrate/20230113220828_make_event_convention_id_not_nullable.rb
@@ -1,0 +1,5 @@
+class MakeEventConventionIdNotNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :events, :convention_id, false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1538,7 +1538,7 @@ CREATE TABLE public.events (
     updated_by_id bigint,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    convention_id bigint,
+    convention_id bigint NOT NULL,
     owner_id bigint,
     status character varying DEFAULT 'active'::character varying NOT NULL,
     registration_policy jsonb,
@@ -2375,7 +2375,7 @@ ALTER SEQUENCE public.root_sites_id_seq OWNED BY public.root_sites.id;
 
 CREATE TABLE public.runs (
     id bigint NOT NULL,
-    event_id bigint,
+    event_id bigint NOT NULL,
     starts_at timestamp without time zone,
     title_suffix character varying,
     schedule_note text,
@@ -2500,7 +2500,8 @@ CREATE TABLE public.signup_requests (
     result_signup_id bigint,
     updated_by_id bigint,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    priority integer
 );
 
 
@@ -2529,7 +2530,7 @@ ALTER SEQUENCE public.signup_requests_id_seq OWNED BY public.signup_requests.id;
 
 CREATE TABLE public.signups (
     id bigint NOT NULL,
-    run_id bigint,
+    run_id bigint NOT NULL,
     bucket_key character varying,
     updated_by_id bigint,
     created_at timestamp without time zone NOT NULL,
@@ -5901,8 +5902,18 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220502182655'),
 ('20220503164309'),
 ('20220609161816'),
+('20220807163855'),
+('20220807165227'),
+('20220807170349'),
+('20220807170912'),
+('20220807172511'),
 ('20220918173739'),
 ('20220924204825'),
-('20221120175702');
+('20221120175702'),
+('20230109012113'),
+('20230112164622'),
+('20230113184026'),
+('20230113220828'),
+('20230627000846');
 
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -2840,7 +2840,7 @@ type Event {
   provided_tickets: [Ticket!]!
   registration_policy: RegistrationPolicy
   run(id: ID): Run!
-  runs(excludeConflicts: Boolean, finish: Date, start: Date): [Run!]!
+  runs(excludeConflicts: Boolean @deprecated(reason: "This parameter hasn't actually worked for a long time"), finish: Date, start: Date): [Run!]!
   short_blurb: String
   short_blurb_html: String
   slots_limited: Boolean

--- a/schema.json
+++ b/schema.json
@@ -14032,8 +14032,8 @@
                     "ofType": null
                   },
                   "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
+                  "isDeprecated": true,
+                  "deprecationReason": "This parameter hasn't actually worked for a long time"
                 }
               ],
               "type": {

--- a/test/factories/events.rb
+++ b/test/factories/events.rb
@@ -27,7 +27,7 @@
 #  url                          :text
 #  created_at                   :datetime
 #  updated_at                   :datetime
-#  convention_id                :bigint
+#  convention_id                :bigint           not null
 #  event_category_id            :bigint           not null
 #  owner_id                     :bigint
 #  updated_by_id                :bigint

--- a/test/factories/runs.rb
+++ b/test/factories/runs.rb
@@ -10,7 +10,7 @@
 #  title_suffix     :string
 #  created_at       :datetime
 #  updated_at       :datetime
-#  event_id         :bigint
+#  event_id         :bigint           not null
 #  updated_by_id    :bigint
 #
 # Indexes

--- a/test/factories/signup_requests.rb
+++ b/test/factories/signup_requests.rb
@@ -4,6 +4,7 @@
 # Table name: signup_requests
 #
 #  id                   :bigint           not null, primary key
+#  priority             :integer
 #  requested_bucket_key :string
 #  state                :string           default("pending"), not null
 #  created_at           :datetime         not null
@@ -32,7 +33,6 @@
 #  fk_rails_...  (user_con_profile_id => user_con_profiles.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :signup_request do
     association :target_run, factory: :run

--- a/test/factories/signups.rb
+++ b/test/factories/signups.rb
@@ -11,7 +11,7 @@
 #  state                :string           default("confirmed"), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  run_id               :bigint
+#  run_id               :bigint           not null
 #  updated_by_id        :bigint
 #  user_con_profile_id  :bigint           not null
 #

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -27,7 +27,7 @@
 #  url                          :text
 #  created_at                   :datetime
 #  updated_at                   :datetime
-#  convention_id                :bigint
+#  convention_id                :bigint           not null
 #  event_category_id            :bigint           not null
 #  owner_id                     :bigint
 #  updated_by_id                :bigint

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -10,7 +10,7 @@
 #  title_suffix     :string
 #  created_at       :datetime
 #  updated_at       :datetime
-#  event_id         :bigint
+#  event_id         :bigint           not null
 #  updated_by_id    :bigint
 #
 # Indexes

--- a/test/models/signup_request_test.rb
+++ b/test/models/signup_request_test.rb
@@ -4,6 +4,7 @@
 # Table name: signup_requests
 #
 #  id                   :bigint           not null, primary key
+#  priority             :integer
 #  requested_bucket_key :string
 #  state                :string           default("pending"), not null
 #  created_at           :datetime         not null
@@ -32,7 +33,6 @@
 #  fk_rails_...  (user_con_profile_id => user_con_profiles.id)
 #
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
-# rubocop:disable Metrics/LineLength, Lint/RedundantCopDisableDirective
 require 'test_helper'
 
 class SignupRequestTest < ActiveSupport::TestCase

--- a/test/models/signup_test.rb
+++ b/test/models/signup_test.rb
@@ -11,7 +11,7 @@
 #  state                :string           default("confirmed"), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  run_id               :bigint
+#  run_id               :bigint           not null
 #  updated_by_id        :bigint
 #  user_con_profile_id  :bigint           not null
 #


### PR DESCRIPTION
This enforces a few non-nullability constraints at the database level (previously they were enforced at the ActiveRecord level).  It also deprecates an argument that hasn't worked in a long time.