### PR TITLE
Give searchable selectors a more useful default set of messages

### DIFF
--- a/app/javascript/BuiltInFormControls/EventSelect.tsx
+++ b/app/javascript/BuiltInFormControls/EventSelect.tsx
@@ -2,6 +2,7 @@ import type { DocumentNode } from 'graphql';
 
 import GraphQLAsyncSelect, { GraphQLAsyncSelectProps } from './GraphQLAsyncSelect';
 import { DefaultEventsQueryData, DefaultEventsQueryDocument } from './selectDefaultQueries.generated';
+import { useTranslation } from 'react-i18next';
 
 type DQ = DefaultEventsQueryData;
 type DO<QueryType extends DefaultEventsQueryData> = NonNullable<
@@ -21,6 +22,8 @@ function EventSelect<
   DataType extends DQ = DQ,
   OptionType extends DO<DataType> = DO<DQ>,
 >({ eventsQuery, ...otherProps }: EventSelectProps<DataType, OptionType, IsMulti>): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <GraphQLAsyncSelect<DataType, OptionType, IsMulti>
       isClearable
@@ -29,6 +32,14 @@ function EventSelect<
       getOptionValue={(option) => option.id}
       getOptionLabel={(option) => option.title ?? ''}
       query={eventsQuery || DefaultEventsQueryDocument}
+      placeholder={t('selectors.eventSelect.placeholder', 'Search for an event by title...')}
+      noOptionsMessage={({ inputValue }) =>
+        inputValue.trim() === ''
+          ? t('selectors.eventSelect.noInputMessage', 'Type an event title to search')
+          : t('selectors.eventSelect.noResultsMessage', `No evets found matching “{{ inputValue }}”`, {
+              inputValue,
+            })
+      }
       {...otherProps}
     />
   );

--- a/app/javascript/BuiltInFormControls/UserConProfileSelect.tsx
+++ b/app/javascript/BuiltInFormControls/UserConProfileSelect.tsx
@@ -2,6 +2,7 @@ import type { DocumentNode } from 'graphql';
 
 import GraphQLAsyncSelect, { GraphQLAsyncSelectProps } from './GraphQLAsyncSelect';
 import { DefaultUserConProfilesQueryData, DefaultUserConProfilesQueryDocument } from './selectDefaultQueries.generated';
+import { useTranslation } from 'react-i18next';
 
 type DQ = DefaultUserConProfilesQueryData;
 type DO<QueryType extends DefaultUserConProfilesQueryData> = NonNullable<
@@ -20,6 +21,8 @@ function UserConProfileSelect<
   DataType extends DQ = DQ,
   OptionType extends DO<DataType> = DO<DQ>,
 >({ userConProfilesQuery, ...otherProps }: UserConProfileSelectProps<DataType, OptionType, IsMulti>): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <GraphQLAsyncSelect<DataType, OptionType, IsMulti>
       isClearable
@@ -32,6 +35,14 @@ function UserConProfileSelect<
         </>
       )}
       query={userConProfilesQuery ?? DefaultUserConProfilesQueryDocument}
+      placeholder={t('selectors.userConProfileSelect.placeholder', 'Search for an attendee by name or email...')}
+      noOptionsMessage={({ inputValue }) =>
+        inputValue.trim() === ''
+          ? t('selectors.userConProfileSelect.noInputMessage', 'Type a name or email to search')
+          : t('selectors.userConProfileSelect.noResultsMessage', `No attendees found matching “{{ inputValue }}”`, {
+              inputValue,
+            })
+      }
       {...otherProps}
     />
   );

--- a/app/javascript/BuiltInFormControls/UserSelect.tsx
+++ b/app/javascript/BuiltInFormControls/UserSelect.tsx
@@ -4,6 +4,7 @@ import type { DocumentNode } from 'graphql';
 
 import GraphQLAsyncSelect, { GraphQLAsyncSelectProps } from './GraphQLAsyncSelect';
 import { DefaultUsersQueryData, DefaultUsersQueryDocument } from './selectDefaultQueries.generated';
+import { useTranslation } from 'react-i18next';
 
 type UserNameLabelProps<OptionType, IsMulti extends boolean> = MultiValueGenericProps<OptionType, IsMulti> & {
   data: {
@@ -35,6 +36,8 @@ function UserSelect<
   OptionType extends DO<DataType> = DO<DQ>,
   IsMulti extends boolean = false,
 >({ usersQuery, ...otherProps }: UserSelectProps<DataType, OptionType, IsMulti>): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <GraphQLAsyncSelect<DataType, OptionType, IsMulti>
       isClearable
@@ -48,6 +51,12 @@ function UserSelect<
       )}
       query={usersQuery || DefaultUsersQueryDocument}
       components={{ MultiValueLabel: UserNameLabel }}
+      placeholder={t('selectors.userSelect.placeholder', 'Search for a user by name or email...')}
+      noOptionsMessage={({ inputValue }) =>
+        inputValue.trim() === ''
+          ? t('selectors.userSelect.noInputMessage', 'Type a name or email to search')
+          : t('selectors.userSelect.noResultsMessage', `No users found matching “{{ inputValue }}”`, { inputValue })
+      }
       {...otherProps}
     />
   );

--- a/locales/en.json
+++ b/locales/en.json
@@ -51,6 +51,7 @@
       "ticketModeDisabled": "Convention does not sell {{ ticketNamePlural }}",
       "ticketModeLabel": "{{ ticketName, capitalize }} sales",
       "ticketModeRequiredForSignup": "{{ ticketNamePlural, capitalize }} are sold and required for event signups",
+      "ticketModeTicketPerEvent": "Each event in this convention sells {{ ticketNamePlural }} separately",
       "ticketNameLabel": "Name for “ticket” at this convention"
     },
     "eventCategories": {
@@ -240,6 +241,7 @@
     "close": "Close",
     "collapse": "Collapse",
     "composeEmail": "Compose email",
+    "delete": "Delete",
     "edit": "Edit",
     "expand": "Expand",
     "help": "Help",
@@ -248,6 +250,7 @@
     "preview": "Preview",
     "proposeEventLoggedOut": "Log in to propose an event",
     "refresh": "Refresh",
+    "save": "Save",
     "selectAll": "Select all",
     "selectNone": "Select none"
   },
@@ -429,7 +432,6 @@
       "editPageHeader": "Edit signup for {{ eventTitle }}",
       "editPageTitle": "Editing signup for “{{ name }}” - {{ eventTitle }}",
       "editTitle": "Edit signup",
-      "emailsCommaTitle": "Emails (comma-separated)",
       "emailFilters": {
         "confirmedBucket": "Include {{ bucketName }} (confirmed)",
         "nobody": "Nobody",
@@ -437,9 +439,10 @@
         "waitlisted": "Include waitlisted"
       },
       "emailHeader": "Email",
-      "emailTableHeader": "Email",
+      "emailsCommaTitle": "Emails (comma-separated)",
       "emailsSemicolonTitle": "Emails (semicolon-separated)",
       "emailsSemicolonWarning": "<0>Note:</0> Most email apps use comma-separated address lists.  Only Outlook uses semicolon-separated address lists.  If you’re not using Outlook, try comma-separated first.",
+      "emailTableHeader": "Email",
       "forceConfirmSignup": {
         "bucketInputCaption": "Please choose a signup bucket for {{ name }}.",
         "header": "Force signup into run",
@@ -766,6 +769,23 @@
       "scheduleViewSelectorHeader": "View type:"
     }
   },
+  "selectors": {
+    "eventSelect": {
+      "noInputMessage": "Type an event title to search",
+      "noResultsMessage": "No evets found matching “{{ inputValue }}”",
+      "placeholder": "Search for an event by title..."
+    },
+    "userConProfileSelect": {
+      "noInputMessage": "Type a name or email to search",
+      "noResultsMessage": "No attendees found matching “{{ inputValue }}”",
+      "placeholder": "Search for an attendee by name or email..."
+    },
+    "userSelect": {
+      "noInputMessage": "Type a name or email to search",
+      "noResultsMessage": "No users found matching “{{ inputValue }}”",
+      "placeholder": "Search for a user by name or email..."
+    }
+  },
   "signups": {
     "availability": {
       "full_one": "<0>Full</0><1> ({{count}} slot)</1>",
@@ -852,7 +872,9 @@
         "acceptSignupRequest": "accepted signup request",
         "adminCreateSignup": "admin-created signup",
         "changeRegistrationPolicy": "registration policy change",
+        "holdExpired": "hold expired",
         "selfServiceSignup": "self-service signup",
+        "ticketPurchase": "ticket purchase",
         "unknown": "unknown action",
         "vacancyFill": "vacancy fill",
         "withdraw": "withdraw"


### PR DESCRIPTION
Users have often been confused by the searchable selectors, where you have to start typing to see any results to select.  This is super understandable because the working on them makes it seem like there will be things to select before you start typing.  This fixes that wording to hopefully make what's happening clearer.