### PR TITLE
Multiple Liquid improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' }}
+          load: ${{ !(github.event_name == 'push' && github.event.ref == 'refs/heads/main') }}
           platforms: linux/amd64
           target: production
           tags: |

--- a/app/liquid_drops/convention_drop.rb
+++ b/app/liquid_drops/convention_drop.rb
@@ -115,6 +115,17 @@ class ConventionDrop < Liquid::Drop
     @events_created_since ||= EventsCreatedSinceDrop.new(convention)
   end
 
+  # @return [RunsCreatedSince] A structure that lets you access just the runs created since
+  #                            a certain time.  This is much more efficient than using the
+  #                            runs method and filtering by created_at.
+  # @example Retrieving the runs created since a certain date
+  #   {{ convention.runs_created_since["2018-11-03T00:00:00-05:00"] }}
+  # @example Retrieving the runs created since the last signup round opened
+  #   {{ convention.runs_created_since[convention.maximum_event_signups.current_value_change] }}
+  def runs_created_since
+    @runs_created_since ||= RunsCreatedSinceDrop.new(convention)
+  end
+
   # @return [Array<RunDrop>] Event runs at the convention
   def runs
     @events ||= convention.runs.includes(:event).to_a

--- a/app/liquid_drops/event_drop.rb
+++ b/app/liquid_drops/event_drop.rb
@@ -55,6 +55,11 @@ class EventDrop < Liquid::Drop
     event.runs.to_a
   end
 
+  # @return [ActiveSupport::TimeWithZone] The time at which the earliest run of this event starts
+  def first_run_starts_at
+    event.runs.min_by(&:starts_at).starts_at
+  end
+
   # @deprecated Please use event_category.name instead.  (Note that the name field on
   #             EventCategoryDrop is formatted as plain English rather than an underscored lowercase
   #             string.)
@@ -81,9 +86,10 @@ class EventDrop < Liquid::Drop
     define_method field do
       markdown = event.public_send(field)
       return nil unless markdown
-      MarkdownPresenter
-        .new('')
-        .render(markdown, local_images: event.images.includes(:blob).index_by { |image| image.filename.to_s })
+      MarkdownPresenter.new("").render(
+        markdown,
+        local_images: event.images.includes(:blob).index_by { |image| image.filename.to_s }
+      )
     end
   end
 
@@ -96,9 +102,9 @@ class EventDrop < Liquid::Drop
         event.event_category.event_form,
         event,
         team_member_name: event.event_category.team_member_name,
-        controller: @context.registers['controller']
+        controller: @context.registers["controller"]
       )
-      .as_json_with_rendered_markdown('event', event, '')
+      .as_json_with_rendered_markdown("event", event, "")
       .sync
   end
 end

--- a/app/liquid_drops/runs_created_since_drop.rb
+++ b/app/liquid_drops/runs_created_since_drop.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# A magical container for finding the runs that were created since a certain date.
+# @example Retrieving the runs created since a certain date
+#   {{ convention.runs_created_since["2018-11-03T00:00:00-05:00"] }}
+class RunsCreatedSinceDrop < Liquid::Drop
+  # @api
+  attr_reader :convention
+
+  # @api
+  def initialize(convention)
+    @convention = convention
+  end
+
+  # @api
+  def liquid_method_missing(date)
+    return [] unless date
+    return invoke_drop(DateTime.iso8601(date)) if date.is_a?(String)
+    convention
+      .runs
+      .where("created_at >= ?", date)
+      .includes(event: [:event_category, { team_members: :user_con_profile }])
+      .to_a
+  end
+end

--- a/app/presenters/signup_count_presenter.rb
+++ b/app/presenters/signup_count_presenter.rb
@@ -68,7 +68,7 @@ class SignupCountPresenter
     def count(**filters)
       filtered_data =
         (filters.key?(dimension) ? [@rows_by_dimension[filters.fetch(dimension)]] : @rows_by_dimension.values)
-      final? ? filtered_data.sum : filtered_data.sum { |data| data&.count(**filters) || 0 }
+      final? ? filtered_data.compact.sum : filtered_data.compact.sum { |data| data&.count(**filters) || 0 }
     end
 
     def grouped_data

--- a/db/migrate/20231130162442_update_all_cms_references.rb
+++ b/db/migrate/20231130162442_update_all_cms_references.rb
@@ -1,0 +1,14 @@
+class UpdateAllCmsReferences < ActiveRecord::Migration[7.1]
+  def up
+    [Page, CmsLayout, CmsPartial].each do |klass|
+      klass.find_each do |model|
+        say "Updating references for #{klass.name} #{model.id}"
+        model.send(:set_performance_metadata)
+        model.save!
+      end
+    end
+  end
+
+  def down
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5698,6 +5698,7 @@ ALTER TABLE ONLY public.cms_files_pages
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20231130162442'),
 ('20231126190837'),
 ('20231126173532'),
 ('20231126173531'),

--- a/liquid_doc.json
+++ b/liquid_doc.json
@@ -571,6 +571,20 @@
           ]
         },
         {
+          "name": "first_run_starts_at",
+          "docstring": "",
+          "tags": [
+            {
+              "tag_name": "return",
+              "name": null,
+              "text": "The time at which the earliest run of this event starts",
+              "types": [
+                "ActiveSupport::TimeWithZone"
+              ]
+            }
+          ]
+        },
+        {
           "name": "category",
           "docstring": "",
           "tags": [

--- a/liquid_doc.json
+++ b/liquid_doc.json
@@ -1867,6 +1867,32 @@
           ]
         },
         {
+          "name": "runs_created_since",
+          "docstring": "",
+          "tags": [
+            {
+              "tag_name": "example",
+              "name": "Retrieving the runs created since a certain date",
+              "text": "{{ convention.runs_created_since[\"2018-11-03T00:00:00-05:00\"] }}",
+              "types": null
+            },
+            {
+              "tag_name": "example",
+              "name": "Retrieving the runs created since the last signup round opened",
+              "text": "{{ convention.runs_created_since[convention.maximum_event_signups.current_value_change] }}",
+              "types": null
+            },
+            {
+              "tag_name": "return",
+              "name": null,
+              "text": "A structure that lets you access just the runs created since\na certain time.  This is much more efficient than using the\nruns method and filtering by created_at.",
+              "types": [
+                "RunsCreatedSince"
+              ]
+            }
+          ]
+        },
+        {
           "name": "runs",
           "docstring": "",
           "tags": [
@@ -4367,6 +4393,68 @@
               "types": [
                 "PayWhatYouWantValueDrop"
               ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "RunsCreatedSinceDrop",
+      "superclasses": [
+        "RunsCreatedSinceDrop",
+        "Liquid::Drop"
+      ],
+      "docstring": "A magical container for finding the runs that were created since a certain date.",
+      "tags": [
+        {
+          "tag_name": "example",
+          "name": "Retrieving the runs created since a certain date",
+          "text": "{{ convention.runs_created_since[\"2018-11-03T00:00:00-05:00\"] }}",
+          "types": null
+        }
+      ],
+      "methods": [
+        {
+          "name": "convention",
+          "docstring": "",
+          "tags": [
+            {
+              "tag_name": "api",
+              "name": null,
+              "text": "",
+              "types": null
+            }
+          ]
+        },
+        {
+          "name": "initialize",
+          "docstring": "",
+          "tags": [
+            {
+              "tag_name": "api",
+              "name": null,
+              "text": "",
+              "types": null
+            },
+            {
+              "tag_name": "return",
+              "name": null,
+              "text": "a new instance of RunsCreatedSinceDrop",
+              "types": [
+                "RunsCreatedSinceDrop"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "liquid_method_missing",
+          "docstring": "",
+          "tags": [
+            {
+              "tag_name": "api",
+              "name": null,
+              "text": "",
+              "types": null
             }
           ]
         }


### PR DESCRIPTION
* Treat `render` tags as references for the purpose of eager loading and the admin dropdown
* Don't break with signup count rows that are null
* Add `EventDrop#first_run_starts_at`
* Add `ConventionDrop#runs_created_since`