### PR TITLE
Revert "Update dependency graphql-batch to v0.5.4"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,7 +284,7 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     graphql (2.2.7)
-    graphql-batch (0.5.4)
+    graphql-batch (0.5.3)
       graphql (>= 1.12.18, < 3)
       promise.rb (~> 0.7.2)
     graphql-rails_logger (1.2.4)


### PR DESCRIPTION
Reverts neinteractiveliterature/intercode#8508

This is breaking things in prod with this error:

```
GraphQL::Batch::NoExecutorError: Cannot create loader without an Executor. Wrap the call to `for` with `GraphQL::Batch.batch` or use `GraphQL::Batch::SetupMultiplex` as a query instrumenter if using with `graphql-ruby`
```

Can't repro locally but I'm reverting it.