### PR TITLE
Disable invariant checks when rendering CMS pages

### DIFF
--- a/app/graphql/cms_page_content_loader.rb
+++ b/app/graphql/cms_page_content_loader.rb
@@ -7,23 +7,12 @@ class CmsPageContentLoader < GraphQL::Batch::Loader
   end
 
   def perform(keys)
-    invariant_pages, variant_pages = keys.partition(&:invariant?)
-    invariant_pages_by_cache_key = invariant_pages.index_by { |page| cache_key_for_page(page) }
+    cms_rendering_context.preload_page_content(*keys)
 
     rendered_content =
-      Rails
-        .cache
-        .fetch_multi(*invariant_pages_by_cache_key.keys) do |key|
-          cms_rendering_context.render_page_content(invariant_pages_by_cache_key[key])
-        end
-
-    cms_rendering_context.preload_page_content(*variant_pages)
-
-    rendered_content.update(
-      variant_pages
+      keys
         .index_by { |page| cache_key_for_page(page) }
         .transform_values { |page| cms_rendering_context.render_page_content(page) }
-    )
 
     keys.each { |page| fulfill(page, rendered_content[cache_key_for_page(page)]) }
   end


### PR DESCRIPTION
Our check for whether or not a template is invariant doesn't seem to be fully working.  If a template is incorrectly marked as invariant, the page it's on will effectively stop being updated as the underlying data changes.  I'm not super convinced this optimization was doing a lot for us anyway, so I'm simply going to disable it.