### PR TITLE
Relax constraints on ranked_choice_decisions to allow deletions

### DIFF
--- a/app/models/ranked_choice_decision.rb
+++ b/app/models/ranked_choice_decision.rb
@@ -25,9 +25,9 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (signup_id => signups.id)
-#  fk_rails_...  (signup_ranked_choice_id => signup_ranked_choices.id)
-#  fk_rails_...  (signup_request_id => signup_requests.id)
+#  fk_rails_...  (signup_id => signups.id) ON DELETE => nullify
+#  fk_rails_...  (signup_ranked_choice_id => signup_ranked_choices.id) ON DELETE => nullify
+#  fk_rails_...  (signup_request_id => signup_requests.id) ON DELETE => nullify
 #  fk_rails_...  (signup_round_id => signup_rounds.id)
 #  fk_rails_...  (user_con_profile_id => user_con_profiles.id)
 #

--- a/app/models/signup_ranked_choice.rb
+++ b/app/models/signup_ranked_choice.rb
@@ -5,7 +5,7 @@
 #
 #  id                       :bigint           not null, primary key
 #  priority                 :integer          not null
-#  requested_bucket_key     :string           not null
+#  requested_bucket_key     :string
 #  state                    :string           not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
@@ -27,7 +27,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (result_signup_id => signups.id)
-#  fk_rails_...  (result_signup_request_id => signup_requests.id)
+#  fk_rails_...  (result_signup_request_id => signup_requests.id) ON DELETE => nullify
 #  fk_rails_...  (target_run_id => runs.id)
 #  fk_rails_...  (updated_by_id => users.id)
 #  fk_rails_...  (user_con_profile_id => user_con_profiles.id)

--- a/db/migrate/20240717150224_relax_ranked_choice_constraints.rb
+++ b/db/migrate/20240717150224_relax_ranked_choice_constraints.rb
@@ -1,0 +1,11 @@
+class RelaxRankedChoiceConstraints < ActiveRecord::Migration[7.1]
+  def change
+    remove_foreign_key :ranked_choice_decisions, :signups
+    remove_foreign_key :ranked_choice_decisions, :signup_requests
+    remove_foreign_key :ranked_choice_decisions, :signup_ranked_choices
+
+    add_foreign_key :ranked_choice_decisions, :signups, on_delete: :nullify
+    add_foreign_key :ranked_choice_decisions, :signup_requests, on_delete: :nullify
+    add_foreign_key :ranked_choice_decisions, :signup_ranked_choices, on_delete: :nullify
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2568,7 +2568,7 @@ ALTER SEQUENCE public.signup_changes_id_seq OWNED BY public.signup_changes.id;
 CREATE TABLE public.signup_ranked_choices (
     id bigint NOT NULL,
     priority integer NOT NULL,
-    requested_bucket_key character varying NOT NULL,
+    requested_bucket_key character varying,
     state character varying NOT NULL,
     result_signup_id bigint,
     target_run_id bigint NOT NULL,
@@ -5333,7 +5333,7 @@ ALTER TABLE ONLY public.user_activity_alerts
 --
 
 ALTER TABLE ONLY public.ranked_choice_decisions
-    ADD CONSTRAINT fk_rails_3163578a2d FOREIGN KEY (signup_request_id) REFERENCES public.signup_requests(id);
+    ADD CONSTRAINT fk_rails_3163578a2d FOREIGN KEY (signup_request_id) REFERENCES public.signup_requests(id) ON DELETE SET NULL;
 
 
 --
@@ -5453,7 +5453,7 @@ ALTER TABLE ONLY public.root_sites
 --
 
 ALTER TABLE ONLY public.signup_ranked_choices
-    ADD CONSTRAINT fk_rails_6129ac5277 FOREIGN KEY (result_signup_request_id) REFERENCES public.signup_requests(id);
+    ADD CONSTRAINT fk_rails_6129ac5277 FOREIGN KEY (result_signup_request_id) REFERENCES public.signup_requests(id) ON DELETE SET NULL;
 
 
 --
@@ -5565,7 +5565,7 @@ ALTER TABLE ONLY public.signup_changes
 --
 
 ALTER TABLE ONLY public.ranked_choice_decisions
-    ADD CONSTRAINT fk_rails_7a24c25ccf FOREIGN KEY (signup_id) REFERENCES public.signups(id);
+    ADD CONSTRAINT fk_rails_7a24c25ccf FOREIGN KEY (signup_id) REFERENCES public.signups(id) ON DELETE SET NULL;
 
 
 --
@@ -5845,7 +5845,7 @@ ALTER TABLE ONLY public.oauth_access_grants
 --
 
 ALTER TABLE ONLY public.ranked_choice_decisions
-    ADD CONSTRAINT fk_rails_b5dde4741e FOREIGN KEY (signup_ranked_choice_id) REFERENCES public.signup_ranked_choices(id);
+    ADD CONSTRAINT fk_rails_b5dde4741e FOREIGN KEY (signup_ranked_choice_id) REFERENCES public.signup_ranked_choices(id) ON DELETE SET NULL;
 
 
 --
@@ -6103,6 +6103,7 @@ ALTER TABLE ONLY public.cms_files_pages
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240717150224'),
 ('20240620014115'),
 ('20240608175912'),
 ('20240526181616'),

--- a/test/factories/signup_ranked_choices.rb
+++ b/test/factories/signup_ranked_choices.rb
@@ -5,7 +5,7 @@
 #
 #  id                       :bigint           not null, primary key
 #  priority                 :integer          not null
-#  requested_bucket_key     :string           not null
+#  requested_bucket_key     :string
 #  state                    :string           not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
@@ -27,7 +27,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (result_signup_id => signups.id)
-#  fk_rails_...  (result_signup_request_id => signup_requests.id)
+#  fk_rails_...  (result_signup_request_id => signup_requests.id) ON DELETE => nullify
 #  fk_rails_...  (target_run_id => runs.id)
 #  fk_rails_...  (updated_by_id => users.id)
 #  fk_rails_...  (user_con_profile_id => user_con_profiles.id)

--- a/test/models/signup_ranked_choice_test.rb
+++ b/test/models/signup_ranked_choice_test.rb
@@ -5,7 +5,7 @@
 #
 #  id                       :bigint           not null, primary key
 #  priority                 :integer          not null
-#  requested_bucket_key     :string           not null
+#  requested_bucket_key     :string
 #  state                    :string           not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
@@ -27,7 +27,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (result_signup_id => signups.id)
-#  fk_rails_...  (result_signup_request_id => signup_requests.id)
+#  fk_rails_...  (result_signup_request_id => signup_requests.id) ON DELETE => nullify
 #  fk_rails_...  (target_run_id => runs.id)
 #  fk_rails_...  (updated_by_id => users.id)
 #  fk_rails_...  (user_con_profile_id => user_con_profiles.id)


### PR DESCRIPTION
This prevents some of the issues we saw last night, and also allows users to delete things from their queue after a signup round has run.