### PR TITLE
Be-Con round 3 fixes

### DIFF
--- a/app/javascript/DevModeGraphiql.tsx
+++ b/app/javascript/DevModeGraphiql.tsx
@@ -17,13 +17,13 @@ export type DevModeGraphiqlProps = {
 };
 
 function DevModeGraphiql({ authenticityTokens: { graphql: authenticityToken } }: DevModeGraphiqlProps): JSX.Element {
-  const link = useIntercodeApolloLink(authenticityToken);
+  const link = useIntercodeApolloLink(authenticityToken, '/graphql');
 
   // @ts-expect-error This might be really broken but I need to ship a patch release ASAP and this is less important
   const fetcher: Fetcher = useCallback(
     (operation) => {
       const operationAsGraphQLRequest = operation as unknown as GraphQLRequest;
-       
+
       operationAsGraphQLRequest.query = parse(operation.query);
       return execute(link, operationAsGraphQLRequest);
     },

--- a/app/javascript/SignupModeration/SignupModerationQueue.tsx
+++ b/app/javascript/SignupModeration/SignupModerationQueue.tsx
@@ -195,7 +195,9 @@ function SignupRankedChoiceCell({ value }: { value: SignupModerationSignupReques
   const finalDecision = useMemo(() => {
     if (value.signup_ranked_choice?.ranked_choice_decisions) {
       return sortBy(
-        value.signup_ranked_choice.ranked_choice_decisions ?? [],
+        value.signup_ranked_choice.ranked_choice_decisions.filter(
+          (decision) => decision.decision !== RankedChoiceDecisionValue.SkipChoice,
+        ) ?? [],
         (decision) => new Date(decision.created_at).getTime() * -1,
       )[0];
     } else {

--- a/app/javascript/useIntercodeApolloClient.ts
+++ b/app/javascript/useIntercodeApolloClient.ts
@@ -49,6 +49,7 @@ export function getIntercodeUserTimezoneHeader() {
 
 export function useIntercodeApolloLink(
   authenticityToken: string,
+  uri: string,
   onUnauthenticatedRef?: RefObject<() => void>,
 ): ApolloLink {
   const AuthLink = useAuthHeadersLink(authenticityToken);
@@ -73,13 +74,17 @@ export function useIntercodeApolloLink(
   const ErrorHandlerLink = useErrorHandlerLink(onUnauthenticatedRef);
 
   // adapted from https://github.com/jaydenseric/apollo-upload-client/issues/63#issuecomment-392501449
-  const TerminatingLink = split(
-    isUpload,
-    createUploadLink({ uri: '/graphql', fetch }),
-    new BatchHttpLink({
-      uri: '/graphql',
-      fetch,
-    }),
+  const TerminatingLink = useMemo(
+    () =>
+      split(
+        isUpload,
+        createUploadLink({ uri, fetch }),
+        new BatchHttpLink({
+          uri,
+          fetch,
+        }),
+      ),
+    [uri],
   );
 
   const link = useMemo(
@@ -95,7 +100,7 @@ function useIntercodeApolloClient(
   onUnauthenticatedRef: RefObject<() => void>,
   queryData?: DataProxy.WriteQueryOptions<unknown, unknown>[],
 ): ApolloClient<NormalizedCacheObject> {
-  const link = useIntercodeApolloLink(authenticityToken, onUnauthenticatedRef);
+  const link = useIntercodeApolloLink(authenticityToken, '/graphql', onUnauthenticatedRef);
 
   const client = useMemo(() => {
     const client = new ApolloClient({

--- a/app/models/registration_policy.rb
+++ b/app/models/registration_policy.rb
@@ -12,9 +12,9 @@ class RegistrationPolicy
     new(
       buckets: [
         RegistrationPolicy::Bucket.new(
-          key: 'unlimited',
-          name: 'Signups',
-          description: 'Signups for this event',
+          key: "unlimited",
+          name: "Signups",
+          description: "Signups for this event",
           slots_limited: false
         )
       ]
@@ -24,7 +24,7 @@ class RegistrationPolicy
   attr_reader :buckets
 
   def initialize(attributes = {})
-    super(attributes)
+    super
     @buckets ||= []
   end
 
@@ -69,7 +69,7 @@ class RegistrationPolicy
   end
 
   def attributes
-    { buckets: buckets, prevent_no_preference_signups: prevent_no_preference_signups? }
+    { buckets:, prevent_no_preference_signups: prevent_no_preference_signups? }
   end
 
   def buckets=(buckets)
@@ -125,8 +125,8 @@ class RegistrationPolicy
     buckets.all? { |bucket| bucket == other.bucket_with_key(bucket.key) }
   end
 
-  def as_json(*args)
-    super.merge(buckets: buckets.as_json(*args))
+  def as_json(*)
+    super.merge(buckets: buckets.as_json(*))
   end
 
   def blank?

--- a/app/models/registration_policy/bucket.rb
+++ b/app/models/registration_policy/bucket.rb
@@ -59,22 +59,23 @@ class RegistrationPolicy::Bucket
 
   def available_slots(signups)
     return nil if slots_unlimited?
-    my_signups_count =
-      signups.count do |signup|
-        case signup
-        when Signup
-          signup.occupying_slot? && signup.bucket_key == key &&
-            (
-              not_counted? || signup.counted # don't count non-counted signups in a counted bucket
-            )
-        when SignupRequest
-          signup.requested_bucket_key == key
-        else
-          raise ArgumentError,
-                "RegistrationPolicy::Bucket doesn't know how to count #{signup.class.name} objects as signups"
-        end
-      end
+    my_signups_count = signups.count { |signup| signup_definitely_occupies_slot_in_bucket?(signup) }
     [total_slots - my_signups_count, 0].max
+  end
+
+  def signup_definitely_occupies_slot_in_bucket?(signup)
+    case signup
+    when Signup
+      signup.occupying_slot? && signup.bucket_key == key &&
+        (
+          not_counted? || signup.counted # don't count non-counted signups in a counted bucket
+        )
+    when SignupRequest
+      signup.state == "pending" && signup.requested_bucket_key == key
+    else
+      raise ArgumentError,
+            "RegistrationPolicy::Bucket doesn't know how to count #{signup.class.name} objects as signups"
+    end
   end
 
   def errors_for_signup(_signup, _other_signups)
@@ -83,21 +84,21 @@ class RegistrationPolicy::Bucket
 
   def attributes
     {
-      key: key,
-      name: name,
-      description: description,
-      total_slots: total_slots,
-      minimum_slots: minimum_slots,
-      preferred_slots: preferred_slots,
-      slots_limited: slots_limited,
-      anything: anything,
-      not_counted: not_counted,
-      expose_attendees: expose_attendees
+      key:,
+      name:,
+      description:,
+      total_slots:,
+      minimum_slots:,
+      preferred_slots:,
+      slots_limited:,
+      anything:,
+      not_counted:,
+      expose_attendees:
     }
   end
 
   def metadata
-    { key: key, name: name, description: description }
+    { key:, name:, description: }
   end
 
   def ==(other)

--- a/app/models/signup_ranked_choice.rb
+++ b/app/models/signup_ranked_choice.rb
@@ -40,7 +40,7 @@ class SignupRankedChoice < ApplicationRecord
   belongs_to :result_signup_request, class_name: "SignupRequest", optional: true
   belongs_to :updated_by, class_name: "User"
   has_one :convention, through: :user_con_profile
-  has_many :ranked_choice_decisions, dependent: :destroy
+  has_many :ranked_choice_decisions, dependent: :nullify
 
   validates :state, presence: true, inclusion: { in: Types::SignupRankedChoiceStateType.values.keys }
   validate :ensure_all_fields_point_at_the_same_convention

--- a/app/models/signup_request.rb
+++ b/app/models/signup_request.rb
@@ -43,6 +43,7 @@ class SignupRequest < ApplicationRecord
   has_one :convention, through: :user_con_profile
   has_one :event, through: :target_run
   has_one :signup_ranked_choice, inverse_of: :result_signup_request, dependent: :nullify
+  has_many :ranked_choice_decisions, dependent: :nullify
 
   validates :state, presence: true, inclusion: { in: Types::SignupRequestStateType.values.keys }
   validate :ensure_all_fields_point_at_the_same_convention

--- a/app/services/accept_signup_ranked_choice_service.rb
+++ b/app/services/accept_signup_ranked_choice_service.rb
@@ -59,7 +59,8 @@ class AcceptSignupRankedChoiceService < CivilService::Service
       target_run: signup_ranked_choice.target_run,
       requested_bucket_key: signup_ranked_choice.requested_bucket_key,
       whodunit:,
-      suppress_notifications:,
+      # Never send notifications when creating SignupRequests from ranked choices
+      suppress_notifications: true,
       action: "accept_signup_ranked_choice",
       keep_pending_ranked_choices: true
     ).call!

--- a/app/services/rerun_moderated_ranked_choice_signup_round_service.rb
+++ b/app/services/rerun_moderated_ranked_choice_signup_round_service.rb
@@ -43,6 +43,5 @@ class RerunModeratedRankedChoiceSignupRoundService < CivilService::Service
 
     signup_ranked_choice.update!(state: "pending", priority:)
     signup_request.destroy!
-    decision.destroy!
   end
 end

--- a/test/factories/signup_requests.rb
+++ b/test/factories/signup_requests.rb
@@ -34,8 +34,8 @@
 # rubocop:enable Layout/LineLength, Lint/RedundantCopDisableDirective
 FactoryBot.define do
   factory :signup_request do
-    association :target_run, factory: :run
-    state { 'pending' }
+    target_run factory: :run
+    state { "pending" }
 
     after(:build) do |signup_request|
       signup_request.user_con_profile ||=


### PR DESCRIPTION
- Treat no-preference pending signup requests as occupying a slot
- Suppress notification emails during moderated rounds
- Don't delete prior ranked choice decisions during rerun
- Don't show "skip choice" as the final decision