### PR TITLE
Be-Con round 4 fixes

### DIFF
--- a/app/javascript/SignupModeration/CreateSignup.tsx
+++ b/app/javascript/SignupModeration/CreateSignup.tsx
@@ -1,11 +1,14 @@
-import { Suspense, useState } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 import { LoadingIndicator, FormGroupWithLabel } from '@neinteractiveliterature/litform';
+import sortBy from 'lodash/sortBy';
 
 import CreateSignupRunCard from './CreateSignupRunCard';
 import EventSelect from '../BuiltInFormControls/EventSelect';
 import UserConProfileSelect from '../BuiltInFormControls/UserConProfileSelect';
 import { CreateSignupEventsQueryData, CreateSignupEventsQueryDocument } from './queries.generated';
 import { DefaultUserConProfilesQueryData } from '../BuiltInFormControls/selectDefaultQueries.generated';
+import { DateTime } from 'luxon';
+import { useTranslation } from 'react-i18next';
 
 type EventType = NonNullable<CreateSignupEventsQueryData['convention']>['events_paginated']['entries'][0];
 
@@ -14,12 +17,17 @@ type UserConProfileType = NonNullable<
 >['user_con_profiles_paginated']['entries'][0];
 
 function CreateSignup(): JSX.Element {
+  const { t } = useTranslation();
   const [event, setEvent] = useState<EventType>();
   const [userConProfile, setUserConProfile] = useState<UserConProfileType>();
+  const sortedRuns = useMemo(
+    () => sortBy(event?.runs ?? [], (run) => DateTime.fromISO(run.starts_at).toMillis()),
+    [event?.runs],
+  );
 
   return (
     <>
-      <FormGroupWithLabel label="Event">
+      <FormGroupWithLabel label={t('admin.signupModeration.createSignups.eventLabel')}>
         {(id) => (
           <EventSelect
             id={id}
@@ -30,7 +38,7 @@ function CreateSignup(): JSX.Element {
         )}
       </FormGroupWithLabel>
 
-      <FormGroupWithLabel label="Attendee">
+      <FormGroupWithLabel label={t('admin.signupModeration.createSignups.attendeeLabel')}>
         {(id) => (
           <UserConProfileSelect
             id={id}
@@ -43,7 +51,7 @@ function CreateSignup(): JSX.Element {
       {event && userConProfile && (
         <Suspense fallback={<LoadingIndicator iconSet="bootstrap-icons" />}>
           <div className="run-card-deck">
-            {event.runs.map((run) => (
+            {sortedRuns.map((run) => (
               <CreateSignupRunCard
                 key={`${run.id}-${userConProfile.id}`}
                 eventId={event.id}

--- a/app/javascript/SignupModeration/index.tsx
+++ b/app/javascript/SignupModeration/index.tsx
@@ -8,10 +8,15 @@ import AppRootContext from '../AppRootContext';
 import { SignupAutomationMode } from '../graphqlTypes.generated';
 import { useTranslation } from 'react-i18next';
 import RankedChoiceQueue from './RankedChoiceQueue';
+import useAuthorizationRequired from '../Authentication/useAuthorizationRequired';
 
 function SignupModeration(): JSX.Element {
   const { signupAutomationMode } = useContext(AppRootContext);
   const { t } = useTranslation();
+  const replacementContent = useAuthorizationRequired('can_manage_signups');
+  if (replacementContent) {
+    return replacementContent;
+  }
 
   return (
     <>

--- a/app/models/ranked_choice_decision.rb
+++ b/app/models/ranked_choice_decision.rb
@@ -3,28 +3,31 @@
 #
 # Table name: ranked_choice_decisions
 #
-#  id                      :bigint           not null, primary key
-#  decision                :text             not null
-#  extra                   :jsonb
-#  reason                  :text
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  signup_id               :bigint
-#  signup_ranked_choice_id :bigint
-#  signup_request_id       :bigint
-#  signup_round_id         :bigint           not null
-#  user_con_profile_id     :bigint
+#  id                            :bigint           not null, primary key
+#  decision                      :text             not null
+#  extra                         :jsonb
+#  reason                        :text
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null
+#  after_signup_ranked_choice_id :bigint
+#  signup_id                     :bigint
+#  signup_ranked_choice_id       :bigint
+#  signup_request_id             :bigint
+#  signup_round_id               :bigint           not null
+#  user_con_profile_id           :bigint
 #
 # Indexes
 #
-#  index_ranked_choice_decisions_on_signup_id                (signup_id)
-#  index_ranked_choice_decisions_on_signup_ranked_choice_id  (signup_ranked_choice_id)
-#  index_ranked_choice_decisions_on_signup_request_id        (signup_request_id)
-#  index_ranked_choice_decisions_on_signup_round_id          (signup_round_id)
-#  index_ranked_choice_decisions_on_user_con_profile_id      (user_con_profile_id)
+#  index_ranked_choice_decisions_on_after_signup_ranked_choice_id  (after_signup_ranked_choice_id)
+#  index_ranked_choice_decisions_on_signup_id                      (signup_id)
+#  index_ranked_choice_decisions_on_signup_ranked_choice_id        (signup_ranked_choice_id)
+#  index_ranked_choice_decisions_on_signup_request_id              (signup_request_id)
+#  index_ranked_choice_decisions_on_signup_round_id                (signup_round_id)
+#  index_ranked_choice_decisions_on_user_con_profile_id            (user_con_profile_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (after_signup_ranked_choice_id => signup_ranked_choices.id) ON DELETE => nullify
 #  fk_rails_...  (signup_id => signups.id) ON DELETE => nullify
 #  fk_rails_...  (signup_ranked_choice_id => signup_ranked_choices.id) ON DELETE => nullify
 #  fk_rails_...  (signup_request_id => signup_requests.id) ON DELETE => nullify
@@ -36,6 +39,7 @@ class RankedChoiceDecision < ApplicationRecord
   belongs_to :user_con_profile
   belongs_to :signup_round
   belongs_to :signup_ranked_choice, optional: true
+  belongs_to :after_signup_ranked_choice, class_name: "SignupRankedChoice", optional: true
   belongs_to :signup, optional: true
   belongs_to :signup_request, optional: true
   has_one :target_run, through: :signup_request

--- a/app/models/registration_policy/bucket.rb
+++ b/app/models/registration_policy/bucket.rb
@@ -65,7 +65,7 @@ class RegistrationPolicy::Bucket
 
   def signup_definitely_occupies_slot_in_bucket?(signup)
     case signup
-    when Signup
+    when Signup, SignupBucketFinder::FakeSignup
       signup.occupying_slot? && signup.bucket_key == key &&
         (
           not_counted? || signup.counted # don't count non-counted signups in a counted bucket

--- a/app/services/execute_ranked_choice_signup_service.rb
+++ b/app/services/execute_ranked_choice_signup_service.rb
@@ -90,6 +90,7 @@ class ExecuteRankedChoiceSignupService < CivilService::Service
       user_con_profile:,
       reason:,
       signup_ranked_choice:,
+      after_signup_ranked_choice:,
       extra:
     )
   end
@@ -107,6 +108,7 @@ class ExecuteRankedChoiceSignupService < CivilService::Service
       decision: :signup,
       user_con_profile:,
       signup_ranked_choice:,
+      after_signup_ranked_choice:,
       signup: result.signup,
       signup_request: result.signup_request
     )
@@ -125,8 +127,14 @@ class ExecuteRankedChoiceSignupService < CivilService::Service
       decision: :waitlist,
       user_con_profile:,
       signup_ranked_choice:,
+      after_signup_ranked_choice:,
       signup: result.signup,
       signup_request: result.signup_request
     )
+  end
+
+  def after_signup_ranked_choice
+    @after_signup_ranked_choice ||=
+      user_con_profile.signup_ranked_choices.where("priority > ?", signup_ranked_choice.priority).order(:priority).first
   end
 end

--- a/app/services/signup_bucket_finder.rb
+++ b/app/services/signup_bucket_finder.rb
@@ -51,24 +51,32 @@ class SignupBucketFinder
         movable_signup.bucket_key = destination_bucket.key
       end
 
-      @other_signups << FakeSignup.new(
-        run: signup_request.target_run,
-        state: "confirmed",
-        bucket_key: actual_bucket.key,
-        user_con_profile: signup_request.user_con_profile,
-        requested_bucket_key: signup_request.requested_bucket_key,
-        counted: actual_bucket.counted?
-      )
+      simulate_confirmed_signup(signup_request, actual_bucket)
     else
-      @other_signups << FakeSignup.new(
-        run: signup_request.target_run,
-        state: "waitlisted",
-        bucket_key: nil,
-        user_con_profile: signup_request.user_con_profile,
-        requested_bucket_key: signup_request.requested_bucket_key,
-        counted: false
-      )
+      simulate_waitlist(signup_request)
     end
+  end
+
+  def simulate_confirmed_signup(signup_request, actual_bucket)
+    @other_signups << FakeSignup.new(
+      run: signup_request.target_run,
+      state: "confirmed",
+      bucket_key: actual_bucket.key,
+      user_con_profile: signup_request.user_con_profile,
+      requested_bucket_key: signup_request.requested_bucket_key,
+      counted: actual_bucket.counted?
+    )
+  end
+
+  def simulate_waitlist(signup_request)
+    @other_signups << FakeSignup.new(
+      run: signup_request.target_run,
+      state: "waitlisted",
+      bucket_key: nil,
+      user_con_profile: signup_request.user_con_profile,
+      requested_bucket_key: signup_request.requested_bucket_key,
+      counted: false
+    )
   end
 
   def find_bucket

--- a/app/services/signup_bucket_finder.rb
+++ b/app/services/signup_bucket_finder.rb
@@ -84,6 +84,7 @@ class SignupBucketFinder
 
   def totally_full_including_signup_requests?
     return false if registration_policy.slots_unlimited?
+    return false if requested_bucket&.not_counted?
 
     slot_occupying_signups.size + pending_signup_requests.size >= registration_policy.total_slots
   end

--- a/db/migrate/20240807155222_add_after_signup_ranked_choice_id_to_ranked_choice_decisions.rb
+++ b/db/migrate/20240807155222_add_after_signup_ranked_choice_id_to_ranked_choice_decisions.rb
@@ -1,0 +1,15 @@
+class AddAfterSignupRankedChoiceIdToRankedChoiceDecisions < ActiveRecord::Migration[7.1]
+  def up
+    add_reference :ranked_choice_decisions,
+                  :after_signup_ranked_choice,
+                  null: true,
+                  foreign_key: {
+                    to_table: :signup_ranked_choices,
+                    on_delete: :nullify
+                  }
+  end
+
+  def down
+    remove_reference :ranked_choice_decisions, :after_signup_ranked_choice
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2314,7 +2314,8 @@ CREATE TABLE public.ranked_choice_decisions (
     extra jsonb,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    signup_round_id bigint NOT NULL
+    signup_round_id bigint NOT NULL,
+    after_signup_ranked_choice_id bigint
 );
 
 
@@ -4739,6 +4740,13 @@ CREATE INDEX index_products_on_provides_ticket_type_id ON public.products USING 
 
 
 --
+-- Name: index_ranked_choice_decisions_on_after_signup_ranked_choice_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ranked_choice_decisions_on_after_signup_ranked_choice_id ON public.ranked_choice_decisions USING btree (after_signup_ranked_choice_id);
+
+
+--
 -- Name: index_ranked_choice_decisions_on_signup_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5609,6 +5617,14 @@ ALTER TABLE ONLY public.event_categories
 
 
 --
+-- Name: ranked_choice_decisions fk_rails_870c17dde9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ranked_choice_decisions
+    ADD CONSTRAINT fk_rails_870c17dde9 FOREIGN KEY (after_signup_ranked_choice_id) REFERENCES public.signup_ranked_choices(id) ON DELETE SET NULL;
+
+
+--
 -- Name: maximum_event_provided_tickets_overrides fk_rails_889a5603de; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6103,6 +6119,7 @@ ALTER TABLE ONLY public.cms_files_pages
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240807155222'),
 ('20240717150224'),
 ('20240620014115'),
 ('20240608175912'),

--- a/locales/en.json
+++ b/locales/en.json
@@ -120,6 +120,10 @@
       "acceptPrompt": "Please confirm you want to accept this signup request.  This will attempt to sign {{ name }} up for {{ eventTitle }} as {{ bucketDescription }}. If there is no space in the requested bucket, the attendee will either be signed up in a flex bucket, if possible, or waitlisted.",
       "acceptPromptActions": "This will automatically email both the attendee and the event team to let them know about the signup.",
       "bucketHeader": "Bucket:",
+      "createSignups": {
+        "attendeeLabel": "Attendee",
+        "eventLabel": "Event"
+      },
       "decisionDescription": "{{ round }}: {{ decision }}",
       "headers": {
         "actions": "Actions",

--- a/test/services/event_signup_service_test.rb
+++ b/test/services/event_signup_service_test.rb
@@ -566,6 +566,17 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
         assert_equal "npc", result.signup.requested_bucket_key
       end
 
+      it "will still sign the user up if the run is otherwise full" do
+        create_other_signup("pc")
+        4.times { create_other_signup("anything") }
+        result = subject.call
+        assert result.success?
+        assert result.signup.confirmed?
+        refute result.signup.counted?
+        assert_equal "npc", result.signup.bucket_key
+        assert_equal "npc", result.signup.requested_bucket_key
+      end
+
       describe "no-preference signups" do
         let(:requested_bucket_key) { nil }
         it "will not put no-preference signups into the not-counted bucket" do

--- a/test/services/event_signup_service_test.rb
+++ b/test/services/event_signup_service_test.rb
@@ -41,7 +41,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
     let(:convention) { create(:convention, :with_notification_templates, ticket_mode: "disabled") }
 
     it "signs the user up for an event" do
-      result = subject.call
+      result = subject.call!
       assert result.success?
       assert result.signup.confirmed?
     end
@@ -51,7 +51,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
     let(:convention) { create(:convention, :with_notification_templates, ticket_mode: "ticket_per_event") }
 
     it "signs the user up for an event with a ticket purchase hold" do
-      result = subject.call
+      result = subject.call!
       assert result.success?
       assert result.signup.ticket_purchase_hold?
       assert result.signup.expires_at
@@ -64,7 +64,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
 
     it "signs the user up for an event and emails them a confirmation" do
       perform_enqueued_jobs do
-        result = subject.call
+        result = subject.call!
         assert result.success?
         assert result.signup.confirmed?
 
@@ -88,7 +88,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
             requested_bucket_key,
             user,
             suppress_confirmation: true
-          ).call
+          ).call!
         assert result.success?
 
         assert_equal 1, ActionMailer::Base.deliveries.size
@@ -121,7 +121,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
       setup { create(:team_member, event:, user_con_profile:) }
 
       it "signs up a team member as not counted" do
-        result = subject.call
+        result = subject.call!
 
         assert result.success?
         assert result.signup.confirmed?
@@ -133,7 +133,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
       it "does not care whether signups are open yet" do
         create(:signup_round, convention:, maximum_event_signups: "not_yet")
 
-        result = subject.call
+        result = subject.call!
         assert result.success?
         assert result.signup.confirmed?
       end
@@ -142,7 +142,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
     it "allows signups if the user has not yet reached the current signup limit" do
       create(:signup_round, convention:, maximum_event_signups: "1")
 
-      result = subject.call
+      result = subject.call!
       assert result.success?
       assert result.signup.confirmed?
     end
@@ -154,7 +154,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
       another_run = create(:run, event: another_event, starts_at: the_run.ends_at)
       create(:signup, counted: false, user_con_profile:, run: another_run)
 
-      result = subject.call
+      result = subject.call!
       assert result.success?
       assert result.signup.confirmed?
     end
@@ -190,7 +190,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
       another_run = create(:run, event: another_event, starts_at: the_run.ends_at)
       create(:signup, state: "withdrawn", user_con_profile:, run: another_run)
 
-      result = subject.call
+      result = subject.call!
       assert result.success?
       assert result.signup.confirmed?
     end
@@ -270,7 +270,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
         other_signup_service = EventSignupService.new(user_con_profile, other_run, requested_bucket_key, user)
         assert other_signup_service.call.success?
 
-        result = subject.call
+        result = subject.call!
         assert result.success?
       end
 
@@ -280,7 +280,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
 
         event.update!(can_play_concurrently: true)
 
-        result = subject.call
+        result = subject.call!
         assert result.success?
       end
 
@@ -314,7 +314,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
       let(:requested_bucket_key) { :cats }
 
       it "will sign the user up into that bucket" do
-        result = subject.call
+        result = subject.call!
         assert result.success?
         assert result.signup.confirmed?
         assert_equal "cats", result.signup.bucket_key
@@ -324,7 +324,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
       it "will fall back to the anything bucket if necessary" do
         2.times { create_other_signup "cats" }
 
-        result = subject.call
+        result = subject.call!
         assert result.success?
         assert result.signup.confirmed?
         assert_equal "anything", result.signup.bucket_key
@@ -459,7 +459,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
           _immovable_signup = create_other_signup "cats"
           movable_signup = create_other_signup "cats", requested_bucket_key: nil
 
-          result = subject.call
+          result = subject.call!
           assert result.success?
           assert result.signup.confirmed?
           assert_equal "cats", result.signup.requested_bucket_key
@@ -475,7 +475,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
           _immovable_signup = create_other_signup "cats"
           movable_signup = create_other_signup "cats", requested_bucket_key: nil
 
-          result = subject.call
+          result = subject.call!
           assert result.success?
           assert result.signup.confirmed?
           assert_equal "cats", result.signup.requested_bucket_key
@@ -492,7 +492,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
           _immovable_signup = create_other_signup "cats"
           movable_signup = create_other_signup "cats", requested_bucket_key: nil
 
-          result = subject.call
+          result = subject.call!
           assert result.success?
           assert result.signup.waitlisted?
           assert_equal "cats", result.signup.requested_bucket_key
@@ -509,7 +509,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
           3.times { create_other_signup "cats", counted: false }
           4.times { create_other_signup "anything" }
 
-          result = subject.call
+          result = subject.call!
 
           assert result.success?
           assert result.signup.confirmed?
@@ -549,7 +549,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
       let(:requested_bucket_key) { :npc }
 
       it "will sign the user up into that bucket" do
-        result = subject.call
+        result = subject.call!
         assert result.success?
         assert result.signup.confirmed?
         refute result.signup.counted?
@@ -559,7 +559,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
 
       it "will not use anything buckets" do
         create_other_signup("npc")
-        result = subject.call
+        result = subject.call!
         assert result.success?
         assert result.signup.waitlisted?
         assert_nil result.signup.bucket_key
@@ -569,7 +569,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
       it "will still sign the user up if the run is otherwise full" do
         create_other_signup("pc")
         4.times { create_other_signup("anything") }
-        result = subject.call
+        result = subject.call!
         assert result.success?
         assert result.signup.confirmed?
         refute result.signup.counted?
@@ -582,7 +582,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
         it "will not put no-preference signups into the not-counted bucket" do
           create_other_signup("pc")
           4.times { create_other_signup("anything") }
-          result = subject.call
+          result = subject.call!
           assert result.success?
           assert result.signup.waitlisted?
           assert_nil result.signup.bucket_key
@@ -642,7 +642,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase # rubocop:disable Metrics
     it "automatically deletes any ranked choices the user has for this run/bucket" do
       signup_ranked_choice = create(:signup_ranked_choice, user_con_profile:, target_run: the_run)
 
-      result = subject.call
+      result = subject.call!
 
       assert result.success?
       assert_equal 0, SignupRankedChoice.where(id: signup_ranked_choice.id).count


### PR DESCRIPTION
- Record the relative position of ranked choices in the decision log so that they can be properly replaced during a rerun
- Allow signing up for a non-counted bucket in an otherwise full run
- Fully simulate pending signup requests in SignupBucketFinder
- Sort runs chronologically in the Create Signup page (just like in the actual event page)
- Pop up the login dialog on moderation pages if the user isn't logged in