### PR TITLE
Make "email" and "profile" scopes available (just aliases for public and read_profile)

### DIFF
--- a/app/javascript/OAuth/AuthorizationPrompt.tsx
+++ b/app/javascript/OAuth/AuthorizationPrompt.tsx
@@ -135,7 +135,7 @@ function AuthorizationPrompt() {
 
           <p>
             This will allow {preAuth?.client_name} to access{' '}
-            {scopes?.includes('read_profile')
+            {scopes?.includes('read_profile') || scopes?.includes('profile')
               ? 'all information in your convention profiles'
               : 'the public information in your convention profiles'}{' '}
             as well as information about events you can access.

--- a/app/javascript/OAuth/PermissionsPrompt.tsx
+++ b/app/javascript/OAuth/PermissionsPrompt.tsx
@@ -37,38 +37,7 @@ function getScopeGroupDescription(scopeGroup: string, t: TFunction) {
 }
 
 function getScopeDescription(scopeName: string, t: TFunction) {
-  switch (scopeName) {
-    case 'public':
-      return t('oauth.permissions.public');
-    case 'openid':
-      return t('oauth.permissions.openid');
-    case 'read_profile':
-      return t('oauth.permissions.read_profile');
-    case 'read_signups':
-      return t('oauth.permissions.read_signups');
-    case 'read_events':
-      return t('oauth.permissions.read_events');
-    case 'read_conventions':
-      return t('oauth.permissions.read_conventions');
-    case 'read_organizations':
-      return t('oauth.permissions.read_organizations');
-    case 'read_email_routing':
-      return t('oauth.permissions.read_email_routing');
-    case 'manage_profile':
-      return t('oauth.permissions.manage_profile');
-    case 'manage_signups':
-      return t('oauth.permissions.manage_signups');
-    case 'manage_events':
-      return t('oauth.permissions.manage_events');
-    case 'manage_conventions':
-      return t('oauth.permissions.manage_conventions');
-    case 'manage_organizations':
-      return t('oauth.permissions.manage_organizations');
-    case 'manage_email_routing':
-      return t('oauth.permissions.manage_email_routing');
-    default:
-      return scopeName;
-  }
+  return t(`oauth.permissions.${scopeName}`, scopeName);
 }
 
 export type PermissionsPromptProps = {

--- a/app/policies/authorization_info.rb
+++ b/app/policies/authorization_info.rb
@@ -52,7 +52,7 @@ class AuthorizationInfo
   end
 
   def oauth_scope?(scope)
-    resolved_scope = SCOPE_ALIASES[scope.to_sym] if SCOPE_ALIASES.key?(scope.to_sym)
+    resolved_scope = SCOPE_ALIASES[scope.to_sym] || scope.to_sym
 
     unless Doorkeeper.configuration.scopes.include?(resolved_scope.to_s)
       raise ArgumentError, "Invalid scope: #{resolved_scope}"

--- a/app/policies/authorization_info.rb
+++ b/app/policies/authorization_info.rb
@@ -8,6 +8,8 @@ class AuthorizationInfo
     Queries::UserConProfileQueryManager
   ].freeze
 
+  SCOPE_ALIASES = { email: :public, profile: :read_profile }.freeze
+
   module QueryMethods
     METHODS = AuthorizationInfo::QUERY_MANAGER_CLASSES.flat_map(&:query_methods)
     delegate(*METHODS, to: :authorization_info)
@@ -34,11 +36,7 @@ class AuthorizationInfo
     @user = user
     @assumed_identity_from_profile = assumed_identity_from_profile
     @doorkeeper_token = doorkeeper_token
-    possible_query_manager_params = {
-      user: user,
-      known_user_con_profiles: known_user_con_profiles,
-      authorization_info: self
-    }
+    possible_query_manager_params = { user:, known_user_con_profiles:, authorization_info: self }
 
     QUERY_MANAGER_CLASSES.each do |query_manager_class|
       instance_variable_name = query_manager_class.name.demodulize.underscore.to_sym
@@ -54,13 +52,17 @@ class AuthorizationInfo
   end
 
   def oauth_scope?(scope)
-    raise ArgumentError, "Invalid scope: #{scope}" unless Doorkeeper.configuration.scopes.include?(scope.to_s)
+    resolved_scope = SCOPE_ALIASES[scope.to_sym] if SCOPE_ALIASES.key?(scope.to_sym)
 
-    doorkeeper_token.nil? || doorkeeper_token.scopes.exists?(scope)
+    unless Doorkeeper.configuration.scopes.include?(resolved_scope.to_s)
+      raise ArgumentError, "Invalid scope: #{resolved_scope}"
+    end
+
+    doorkeeper_token.nil? || doorkeeper_token.scopes.exists?(resolved_scope)
   end
 
-  def oauth_scoped_disjunction(&block)
-    Queries::OAuthScopedDisjunction.evaluate(self, &block)
+  def oauth_scoped_disjunction(&)
+    Queries::OAuthScopedDisjunction.evaluate(self, &)
   end
 
   def actual_user

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -96,6 +96,8 @@ Doorkeeper.configure do
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
   default_scopes :public
   optional_scopes :openid,
+                  :email,
+                  :profile,
                   :read_profile,
                   :read_signups,
                   :read_events,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,8 @@ en:
         title: Authorized applications
     scopes:
       public: 'Access your public data, and public data about conventions you are signed up for'
+      email: 'Access your public data, and public data about conventions you are signed up for'
+      profile: 'Access your personal profile data'
       read_profile: 'Access your personal profile data'
       read_signups: 'Access data about your signups'
       read_events: 'Access data about the events and event proposals you manage'

--- a/locales/en.json
+++ b/locales/en.json
@@ -985,6 +985,7 @@
       "readPublic": "Read-only access to public data"
     },
     "permissions": {
+      "email": "Access your public data, and public data about conventions you are signed up for",
       "manage_conventions": "Update conventions you manage",
       "manage_email_routing": "Update sitewide email routing rules",
       "manage_events": "Update events and event proposals you manage",
@@ -992,6 +993,7 @@
       "manage_profile": "Update your personal profile data",
       "manage_signups": "Sign you up and withdraw you from events",
       "openid": "Authenticate you using your account",
+      "profile": "Access your personal profile data",
       "public": "Access your public data, and public data about conventions you are signed up for",
       "read_conventions": "Access privileged data about the conventions you manage (e.g. user profiles)",
       "read_email_routing": "Read sitewide email routing rules",


### PR DESCRIPTION
This should make Listmonk's OpenID Connect support work, hopefully.