### PR TITLE
Don't require Sentry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
           sudo apt-get update
-          sudo apt-get install postgresql-client -y
+          sudo apt-get install postgresql-client-16 -y
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -71,9 +71,13 @@ end
 
 class SentryReporter
   def call(_worker_instance, queue, _sqs_msg, body)
-    Sentry.with_scope do |scope|
-      scope.set_tags(job: body["job_class"], queue: queue)
-      scope.set_extras(message: body)
+    if Sentry.initialized?
+      Sentry.with_scope do |scope|
+        scope.set_tags(job: body["job_class"], queue: queue)
+        scope.set_extras(message: body)
+        yield
+      end
+    else
       yield
     end
   end


### PR DESCRIPTION
This will hopefully make Shoryuken jobs run again if Sentry isn't configured.