### PR TITLE
Intercon W post round 1 fixes

### DIFF
--- a/app/javascript/EventsApp/EventPage/RunCard.tsx
+++ b/app/javascript/EventsApp/EventPage/RunCard.tsx
@@ -54,7 +54,7 @@ export type RunCardProps = {
   createSignup: (
     signupOption: SignupOption,
   ) => Promise<undefined | null | Pick<Signup, '__typename' | 'id' | 'state' | 'expires_at' | 'counted'>>;
-  withdrawSignup: () => Promise<unknown>;
+  withdrawSignup: () => unknown;
   withdrawPendingSignupRequest: () => Promise<unknown>;
 };
 

--- a/app/javascript/EventsApp/EventPage/WithdrawMySignupButton.tsx
+++ b/app/javascript/EventsApp/EventPage/WithdrawMySignupButton.tsx
@@ -1,45 +1,31 @@
-import { useTranslation } from 'react-i18next';
-import { useConfirm, ErrorDisplay } from '@neinteractiveliterature/litform';
-
 import WithdrawSignupButton, { WithdrawSignupButtonProps } from './WithdrawSignupButton';
-import { EventPageQueryData } from './queries.generated';
-import { client } from '../../useIntercodeApolloClient';
-import { WithdrawMySignupDocument } from './mutations.generated';
+import { useWithdrawMySignupModal, WithdrawMySignupModalProps } from './WithdrawMySignupModal';
 
-export type WithdrawMySignupButtonProps = Omit<WithdrawSignupButtonProps, 'withdrawSignup'> & {
-  run: EventPageQueryData['convention']['event']['runs'][0];
-  event: EventPageQueryData['convention']['event'];
-  reloadOnSuccess?: boolean;
-};
+export type WithdrawMySignupButtonProps = Omit<WithdrawSignupButtonProps, 'withdrawSignup'> &
+  Omit<WithdrawMySignupModalProps, 'close'> & {
+    reloadOnSuccess?: boolean;
+  };
 
 function WithdrawMySignupButton({
   run,
   event,
   reloadOnSuccess,
+  signup,
+  signupRounds,
   ...otherProps
 }: WithdrawMySignupButtonProps): JSX.Element {
-  const { t } = useTranslation();
-  const confirm = useConfirm();
-  const withdrawSignup = () =>
-    confirm({
-      prompt: t('events.withdrawPrompt.selfServiceSignup', {
-        eventTitle: event.title,
-      }),
-      action: async () => {
-        await client.mutate({ mutation: WithdrawMySignupDocument, variables: { runId: run.id } });
-        if (reloadOnSuccess) {
-          window.location.reload();
-        }
-      },
-      renderError: (error) => <ErrorDisplay graphQLError={error} />,
-    });
+  const withdrawMySignupModal = useWithdrawMySignupModal();
 
   return (
-    <WithdrawSignupButton
-      withdrawSignup={withdrawSignup}
-      buttonClass="withdraw-user-signup-button btn-outline-danger"
-      {...otherProps}
-    />
+    <>
+      <WithdrawSignupButton
+        withdrawSignup={() => withdrawMySignupModal.openModal({ event, run, signup, signupRounds })}
+        buttonClass="withdraw-user-signup-button btn-outline-danger"
+        {...otherProps}
+      />
+
+      <withdrawMySignupModal.Component />
+    </>
   );
 }
 

--- a/app/javascript/EventsApp/EventPage/WithdrawMySignupModal.tsx
+++ b/app/javascript/EventsApp/EventPage/WithdrawMySignupModal.tsx
@@ -1,0 +1,129 @@
+import AppRootContext from 'AppRootContext';
+import { Signup, Event, SignupState, SignupAutomationMode, Run } from 'graphqlTypes.generated';
+import { useCallback, useContext, useMemo, useState } from 'react';
+import Modal from 'react-bootstrap4-modal';
+import { Trans, useTranslation } from 'react-i18next';
+import { parseSignupRounds } from 'SignupRoundUtils';
+import { DateTime } from 'luxon';
+import { BootstrapFormCheckbox, ErrorDisplay } from '@neinteractiveliterature/litform';
+import { WithdrawMySignupDocument } from './mutations.generated';
+import { ApolloError, useApolloClient } from '@apollo/client';
+import { useRevalidator } from 'react-router';
+
+export type WithdrawMySignupModalProps = {
+  close: () => void;
+  event: Pick<Event, 'title'>;
+  signup: Pick<Signup, 'id' | 'state' | 'counted'>;
+  run: Pick<Run, 'id'>;
+  signupRounds: Parameters<typeof parseSignupRounds>[0];
+};
+
+export function WithdrawMySignupModal({ close, event, run, signup, signupRounds }: WithdrawMySignupModalProps) {
+  const { signupMode, signupAutomationMode } = useContext(AppRootContext);
+  const { t } = useTranslation();
+  const [checked, setChecked] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<ApolloError>();
+  const client = useApolloClient();
+  const revalidator = useRevalidator();
+
+  const currentRound = useMemo(() => {
+    const parsedRounds = parseSignupRounds(signupRounds);
+    const now = DateTime.local();
+    return parsedRounds.find((round) => round.timespan.includesTime(now));
+  }, [signupRounds]);
+
+  const requiresCheckbox = useMemo(() => signup.state === SignupState.Confirmed, [signup.state]);
+
+  const withdraw = async () => {
+    setBusy(true);
+    try {
+      await client.mutate({ mutation: WithdrawMySignupDocument, variables: { runId: run.id } });
+      await client.resetStore();
+      revalidator.revalidate();
+      close();
+    } catch (error) {
+      setError(error);
+    }
+  };
+
+  const withdrawPrompt = useMemo(() => {
+    if (signup && signup.state === SignupState.Confirmed && !signup.counted) {
+      return t('events.withdrawPrompt.notCounted', { eventTitle: event.title });
+    } else if (
+      signupAutomationMode === SignupAutomationMode.RankedChoice &&
+      typeof currentRound?.maximum_event_signups === 'number'
+    ) {
+      return t('events.withdrawPrompt.duringLimitedRankedChoiceSignupRoundCounted', { eventTitle: event.title });
+    } else if (signupMode === 'moderated') {
+      return (
+        <Trans i18nKey="events.withdrawPrompt.moderatedSignup" values={{ eventTitle: event.title }}>
+          <p>
+            <strong>
+              If you’re thinking of signing up for a different event instead, please go to that event’s page and request
+              to sign up for it.
+            </strong>{' '}
+            If the request is accepted, you’ll automatically be withdrawn from this event.
+          </p>
+          <p className="mb-0">Are you sure you want to withdraw from {{ eventTitle: event.title }}?</p>
+        </Trans>
+      );
+    } else {
+      return t('events.withdrawPrompt.selfServiceSignup', { eventTitle: event.title });
+    }
+  }, [event.title, signup, signupMode, signupAutomationMode, t, currentRound?.maximum_event_signups]);
+
+  return (
+    <Modal visible>
+      <div className="modal-header">
+        <div className="lead">{t('events.withdrawPrompt.title')}</div>
+      </div>
+      <div className="modal-body">
+        <div>{withdrawPrompt}</div>
+        {requiresCheckbox && (
+          <div className="mt-2">
+            <BootstrapFormCheckbox
+              type="checkbox"
+              label={<Trans i18nKey="events.withdrawPrompt.checkboxLabel" values={{ eventTitle: event.title }} />}
+              checked={checked}
+              onChange={(event) => setChecked(event.target.checked)}
+            />
+          </div>
+        )}
+        <ErrorDisplay graphQLError={error} />
+      </div>
+      <div className="modal-footer">
+        <button className="btn btn-secondary" disabled={busy} onClick={close}>
+          {t('buttons.cancel')}
+        </button>
+        <button className="btn btn-primary" disabled={busy || (requiresCheckbox && !checked)} onClick={withdraw}>
+          {t('buttons.confirm')}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+export function useWithdrawMySignupModal() {
+  const [props, setProps] = useState<WithdrawMySignupModalProps>();
+
+  const openModal = useCallback((newProps: Omit<WithdrawMySignupModalProps, 'close'>) => {
+    setProps((prevProps) => {
+      if (prevProps != null) {
+        throw new Error('Modal is already open');
+      }
+
+      return { ...newProps, close: () => setProps(undefined) };
+    });
+  }, []);
+
+  const Component = () => {
+    if (props == null) {
+      return <></>;
+    } else {
+      return <WithdrawMySignupModal {...props} />;
+    }
+  };
+
+  return { openModal, Component };
+}

--- a/app/javascript/EventsApp/ScheduleGrid/RunDetails.tsx
+++ b/app/javascript/EventsApp/ScheduleGrid/RunDetails.tsx
@@ -1,7 +1,6 @@
 import { useContext, useMemo } from 'react';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { useApolloClient } from '@apollo/client';
 import { Placement } from '@popperjs/core';
 import { usePopper } from 'react-popper';
 import { useTranslation } from 'react-i18next';
@@ -40,7 +39,6 @@ const RunDetails = React.forwardRef<HTMLDivElement, RunDetailsProps>(function Ru
   const { t } = useTranslation();
   const { myProfile, conventionTimespan, siteMode, convention } = useContext(AppRootContext);
   const rateEvent = useRateEvent();
-  const apolloClient = useApolloClient();
   const formatRunTimespan = useFormatRunTimespan();
   const format = useAppDateTimeFormat();
 

--- a/app/javascript/setupI18Next.ts
+++ b/app/javascript/setupI18Next.ts
@@ -42,16 +42,20 @@ const localesVersion = import.meta.env.COMMIT_HASH;
 
 const initOptions: InitOptions<ChainedBackendOptions> = {
   backend: {
-    backends: [LocalStorageBackend, CodeSplitLoaderBackend],
+    backends: [...(import.meta.env.PROD ? [LocalStorageBackend] : []), CodeSplitLoaderBackend],
     backendOptions: [
-      {
-        // 1 day
-        expirationTime: 24 * 60 * 60 * 1000,
-        versions: {
-          en: localesVersion,
-          es: localesVersion,
-        },
-      },
+      ...(import.meta.env.PROD
+        ? [
+            {
+              // 1 day
+              expirationTime: 24 * 60 * 60 * 1000,
+              versions: {
+                en: localesVersion,
+                es: localesVersion,
+              },
+            },
+          ]
+        : []),
       {},
     ],
   },

--- a/app/services/cms_content_loaders/base.rb
+++ b/app/services/cms_content_loaders/base.rb
@@ -38,8 +38,6 @@ class CmsContentLoaders::Base < CivilService::Service
     if existing_content_identifiers.include?(item.identifier)
       conflict_action = conflict_action_for(item, attrs)
 
-      puts "#{item.identifier}: #{conflict_action}"
-
       case conflict_action
       when :skip
         return :skip
@@ -52,8 +50,6 @@ class CmsContentLoaders::Base < CivilService::Service
         ensure_no_conflict_for(item.identifier)
         raise ActiveModel::ValidationError, self
       end
-    else
-      puts "#{item.identifier}: no conflict"
     end
 
     create_item(item, attrs)

--- a/app/services/cms_content_loaders/base.rb
+++ b/app/services/cms_content_loaders/base.rb
@@ -36,12 +36,36 @@ class CmsContentLoaders::Base < CivilService::Service
 
   def load_item(item, attrs)
     if existing_content_identifiers.include?(item.identifier)
-      return :skip if conflict_policy == :skip
+      conflict_action = conflict_action_for(item, attrs)
 
-      cms_parent_association.where(identifier_attribute => item.identifier).destroy_all if conflict_policy == :overwrite
+      puts "#{item.identifier}: #{conflict_action}"
+
+      case conflict_action
+      when :skip
+        return :skip
+      when :overwrite
+        storage_adapter
+          .cms_parent_association
+          .where(storage_adapter.identifier_attribute => item.identifier)
+          .destroy_all
+      when :error
+        ensure_no_conflict_for(item.identifier)
+        raise ActiveModel::ValidationError, self
+      end
+    else
+      puts "#{item.identifier}: no conflict"
     end
 
     create_item(item, attrs)
+  end
+
+  def conflict_action_for(item, attrs)
+    case conflict_policy
+    when CmsContentLoaders::ConflictPolicy
+      conflict_policy.action_for(storage_adapter.item_from_database(item.identifier), item, attrs)
+    else
+      conflict_policy
+    end
   end
 
   def create_item(item, attrs)
@@ -60,21 +84,20 @@ class CmsContentLoaders::Base < CivilService::Service
   def ensure_no_conflicting_content
     return unless conflict_policy == :error
 
-    storage_adapter
-      .all_items_from_disk
-      .map(&:identifier)
-      .each do |identifier|
-        next if content_identifiers.present? && content_identifiers.exclude?(identifier)
+    storage_adapter.all_items_from_disk.map(&:identifier).each { |identifier| ensure_no_conflict_for(identifier) }
+  end
 
-        if taken_special_identifiers[identifier]
-          errors.add(:base, "#{cms_parent.name} already has a #{taken_special_identifiers[identifier]}")
-        end
+  def ensure_no_conflict_for(identifier)
+    return if content_identifiers.present? && content_identifiers.exclude?(identifier)
 
-        next unless existing_content_identifiers.include?(identifier)
-        errors.add(
-          :base,
-          "A #{storage_adapter.subdir.singularize} named #{identifier} already exists in #{cms_parent.name}"
-        )
-      end
+    if taken_special_identifiers[identifier]
+      errors.add(:base, "#{cms_parent.name} already has a #{taken_special_identifiers[identifier]}")
+    end
+
+    return unless existing_content_identifiers.include?(identifier)
+    errors.add(
+      :base,
+      "A #{storage_adapter.subdir.singularize} named #{identifier} already exists in #{cms_parent.name}"
+    )
   end
 end

--- a/app/services/cms_content_loaders/conflict_policies/update.rb
+++ b/app/services/cms_content_loaders/conflict_policies/update.rb
@@ -1,0 +1,61 @@
+class CmsContentLoaders::ConflictPolicies::Update < CmsContentLoaders::ConflictPolicy
+  class SkippedItem
+    attr_reader :existing_item, :new_item, :attrs, :reason
+    delegate :identifier, to: :existing_item
+
+    def initialize(existing_item:, new_item:, attrs:, reason:)
+      @existing_item = existing_item
+      @new_item = new_item
+      @attrs = attrs
+      @reason = reason
+    end
+
+    def message
+      "skipped #{existing_item.model&.class&.name} #{identifier} because #{reason}"
+    end
+  end
+
+  attr_reader :previous_content_by_identifier, :skipped_items
+
+  def initialize(previous_content_by_identifier)
+    @previous_content_by_identifier = previous_content_by_identifier
+    @skipped_items = []
+  end
+
+  def all_previous_content_keys
+    @all_previous_content_keys ||= Set.new(previous_content_by_identifier.flat_map(&:keys))
+  end
+
+  def previous_content_for(identifier)
+    if previous_content_by_identifier.key?(identifier)
+      previous_content_by_identifier[identifier]
+    else
+      all_previous_content_keys.index_with(nil)
+    end
+  end
+
+  def action_for(existing_item, new_item, attrs)
+    previous_content = previous_content_for(existing_item.identifier)
+
+    modified_keys = []
+    previous_content.each do |key, value|
+      existing_value = existing_item.model&.public_send(key)
+
+      if existing_value != value && existing_value != attrs[key]
+        modified_keys << key
+      end
+    end
+
+    if modified_keys.any?
+      skipped_items << SkippedItem.new(
+        existing_item:,
+        new_item:,
+        attrs:,
+        reason: "#{modified_keys.to_sentence} #{modified_keys.size == 1 ? 'has' : 'have'} been modified"
+      )
+      :skip
+    else
+      :overwrite
+    end
+  end
+end

--- a/app/services/cms_content_loaders/conflict_policies/update.rb
+++ b/app/services/cms_content_loaders/conflict_policies/update.rb
@@ -38,12 +38,11 @@ class CmsContentLoaders::ConflictPolicies::Update < CmsContentLoaders::ConflictP
     previous_content = previous_content_for(existing_item.identifier)
 
     modified_keys = []
-    previous_content.each do |key, value|
-      existing_value = existing_item.model&.public_send(key)
+    previous_content.stringify_keys.each do |key, previous_value|
+      existing_value = existing_item.model&.public_send(key)&.strip
+      new_value = attrs.stringify_keys[key]&.strip
 
-      if existing_value != value && existing_value != attrs[key]
-        modified_keys << key
-      end
+      modified_keys << key if existing_value != previous_value&.strip && existing_value != new_value
     end
 
     if modified_keys.any?
@@ -51,7 +50,7 @@ class CmsContentLoaders::ConflictPolicies::Update < CmsContentLoaders::ConflictP
         existing_item:,
         new_item:,
         attrs:,
-        reason: "#{modified_keys.to_sentence} #{modified_keys.size == 1 ? 'has' : 'have'} been modified"
+        reason: "#{modified_keys.to_sentence} #{modified_keys.size == 1 ? "has" : "have"} been modified"
       )
       :skip
     else

--- a/app/services/cms_content_loaders/conflict_policy.rb
+++ b/app/services/cms_content_loaders/conflict_policy.rb
@@ -1,0 +1,5 @@
+class CmsContentLoaders::ConflictPolicy
+  def action_for(_existing_item, _new_item, _attrs)
+    raise "CmsContentLoader::ConflictPolicy subclasses must implement #action_for(existing_item, new_item, attrs)"
+  end
+end

--- a/app/services/cms_content_storage_adapters/base.rb
+++ b/app/services/cms_content_storage_adapters/base.rb
@@ -18,23 +18,23 @@ class CmsContentStorageAdapters::Base
   end
 
   def subdir
-    raise NotImplementedError, 'CmsContentStorageAdapters::Base subclasses must implement #subdir'
+    raise NotImplementedError, "CmsContentStorageAdapters::Base subclasses must implement #subdir"
   end
 
   def identifier_attribute
-    raise NotImplementedError, 'CmsContentStorageAdapters::Base subclasses must implement #identifier_attribute'
+    raise NotImplementedError, "CmsContentStorageAdapters::Base subclasses must implement #identifier_attribute"
   end
 
   def cms_parent_association
-    raise NotImplementedError, 'CmsContentStorageAdapters::Base subclasses must implement #cms_parent_association'
+    raise NotImplementedError, "CmsContentStorageAdapters::Base subclasses must implement #cms_parent_association"
   end
 
   def identifier_for_path(_content_set, _path)
-    raise NotImplementedError, 'CmsContentStorageAdapters::Base subclasses must implement #identifier_for_path'
+    raise NotImplementedError, "CmsContentStorageAdapters::Base subclasses must implement #identifier_for_path"
   end
 
   def path_for_identifier(_content_set, _path)
-    raise NotImplementedError, 'CmsContentStorageAdapters::Base subclasses must implement #path_for_identifier'
+    raise NotImplementedError, "CmsContentStorageAdapters::Base subclasses must implement #path_for_identifier"
   end
 
   def identifier_for_model(model)
@@ -42,19 +42,19 @@ class CmsContentStorageAdapters::Base
   end
 
   def read_item_attrs(_item)
-    raise NotImplementedError, 'CmsContentStorageAdapters::Base subclasses must implement #read_item_attrs'
+    raise NotImplementedError, "CmsContentStorageAdapters::Base subclasses must implement #read_item_attrs"
   end
 
   def serialize_item(_item, _io)
-    raise NotImplementedError, 'CmsContentStorageAdapters::Base subclasses must implement #serialize_item'
+    raise NotImplementedError, "CmsContentStorageAdapters::Base subclasses must implement #serialize_item"
   end
 
   def filename_pattern
-    '*'
+    "*"
   end
 
   def own_paths_from_disk_for_cms_content_set(content_set)
-    Dir[content_set.content_path(subdir, '**', filename_pattern)]
+    Dir[content_set.content_path(subdir, "**", filename_pattern)]
   end
 
   def own_items_from_disk_for_cms_content_set(content_set)
@@ -93,6 +93,16 @@ class CmsContentStorageAdapters::Base
     end
   end
 
+  def item_from_database(identifier)
+    model = cms_parent_association.find_by(identifier_attribute => identifier)
+    ItemInfo.new(
+      content_set: cms_content_set,
+      path: path_for_identifier(cms_content_set, identifier),
+      identifier:,
+      model:
+    )
+  end
+
   def merge_items(item_lists)
     item_lists_by_identifier = item_lists.map { |item_list| item_list.index_by(&:identifier) }
     item_lists_by_identifier.inject(&:merge).values
@@ -101,7 +111,7 @@ class CmsContentStorageAdapters::Base
   def basename_without_extension(path, extension)
     root_relative_path = Pathname.new(path).relative_path_from(CmsContentSet.root_path)
     base_path = File.join(root_relative_path.each_filename.to_a.slice(2..-1))
-    base_path.gsub(/#{Regexp.escape extension}\z/, '')
+    base_path.gsub(/#{Regexp.escape extension}\z/, "")
   end
 
   def parse_content_with_yaml_frontmatter(raw)

--- a/app/services/cms_content_storage_adapters/cms_graphql_queries.rb
+++ b/app/services/cms_content_storage_adapters/cms_graphql_queries.rb
@@ -1,6 +1,6 @@
 class CmsContentStorageAdapters::CmsGraphqlQueries < CmsContentStorageAdapters::Base
   def subdir
-    'graphql_queries'
+    "graphql_queries"
   end
 
   def cms_parent_association
@@ -8,19 +8,19 @@ class CmsContentStorageAdapters::CmsGraphqlQueries < CmsContentStorageAdapters::
   end
 
   def identifier_attribute
-    'identifier'
+    "identifier"
   end
 
   def filename_pattern
-    '*.graphql'
+    "*.graphql"
   end
 
   def identifier_for_path(_content_set, path)
-    basename_without_extension(path, '.graphql')
+    basename_without_extension(path, ".graphql")
   end
 
   def path_for_identifier(content_set, identifier)
-    content_set.content_path(File.join('graphql_queries', "#{identifier}.graphql"))
+    content_set.content_path(File.join("graphql_queries", "#{identifier}.graphql"))
   end
 
   def read_item_attrs(item)
@@ -30,7 +30,11 @@ class CmsContentStorageAdapters::CmsGraphqlQueries < CmsContentStorageAdapters::
   def serialize_item(item, io)
     write_content_with_yaml_frontmatter(
       item.model.query,
-      item.model.attributes.except('query', 'id', 'parent_id', 'parent_type', 'created_at', 'updated_at').compact,
+      item
+        .model
+        .attributes
+        .except("query", "id", "parent_id", "parent_type", "created_at", "updated_at", "identifier")
+        .compact,
       io
     )
   end

--- a/app/services/cms_content_storage_adapters/cms_layouts.rb
+++ b/app/services/cms_content_storage_adapters/cms_layouts.rb
@@ -1,6 +1,6 @@
 class CmsContentStorageAdapters::CmsLayouts < CmsContentStorageAdapters::Base
   def subdir
-    'layouts'
+    "layouts"
   end
 
   def cms_parent_association
@@ -8,19 +8,19 @@ class CmsContentStorageAdapters::CmsLayouts < CmsContentStorageAdapters::Base
   end
 
   def identifier_attribute
-    'name'
+    "name"
   end
 
   def filename_pattern
-    '*.liquid'
+    "*.liquid"
   end
 
   def identifier_for_path(_content_set, path)
-    basename_without_extension(path, '.liquid')
+    basename_without_extension(path, ".liquid")
   end
 
   def path_for_identifier(content_set, identifier)
-    content_set.content_path(File.join('layouts', "#{identifier}.liquid"))
+    content_set.content_path(File.join("layouts", "#{identifier}.liquid"))
   end
 
   def read_item_attrs(item)
@@ -30,7 +30,11 @@ class CmsContentStorageAdapters::CmsLayouts < CmsContentStorageAdapters::Base
   def serialize_item(item, io)
     write_content_with_yaml_frontmatter(
       item.model.content.gsub("\r\n", "\n"),
-      item.model.attributes.except('content', 'id', 'parent_id', 'parent_type', 'created_at', 'updated_at').compact,
+      item
+        .model
+        .attributes
+        .except("content", "id", "parent_id", "parent_type", "created_at", "updated_at", "name")
+        .compact,
       io
     )
   end

--- a/app/services/cms_content_storage_adapters/cms_partials.rb
+++ b/app/services/cms_content_storage_adapters/cms_partials.rb
@@ -1,6 +1,6 @@
 class CmsContentStorageAdapters::CmsPartials < CmsContentStorageAdapters::Base
   def subdir
-    'partials'
+    "partials"
   end
 
   def cms_parent_association
@@ -8,19 +8,19 @@ class CmsContentStorageAdapters::CmsPartials < CmsContentStorageAdapters::Base
   end
 
   def identifier_attribute
-    'name'
+    "name"
   end
 
   def filename_pattern
-    '*.liquid'
+    "*.liquid"
   end
 
   def identifier_for_path(_content_set, path)
-    basename_without_extension(path, '.liquid')
+    basename_without_extension(path, ".liquid")
   end
 
   def path_for_identifier(content_set, identifier)
-    content_set.content_path(File.join('partials', "#{identifier}.liquid"))
+    content_set.content_path(File.join("partials", "#{identifier}.liquid"))
   end
 
   def read_item_attrs(item)
@@ -30,7 +30,11 @@ class CmsContentStorageAdapters::CmsPartials < CmsContentStorageAdapters::Base
   def serialize_item(item, io)
     write_content_with_yaml_frontmatter(
       item.model.content.gsub("\r\n", "\n"),
-      item.model.attributes.except('content', 'id', 'parent_id', 'parent_type', 'created_at', 'updated_at').compact,
+      item
+        .model
+        .attributes
+        .except("content", "id", "parent_id", "parent_type", "created_at", "updated_at", "name")
+        .compact,
       io
     )
   end

--- a/app/services/cms_content_storage_adapters/notification_templates.rb
+++ b/app/services/cms_content_storage_adapters/notification_templates.rb
@@ -1,6 +1,6 @@
 class CmsContentStorageAdapters::NotificationTemplates < CmsContentStorageAdapters::Base
   def subdir
-    'notification_templates'
+    "notification_templates"
   end
 
   def cms_parent_association
@@ -8,19 +8,19 @@ class CmsContentStorageAdapters::NotificationTemplates < CmsContentStorageAdapte
   end
 
   def identifier_attribute
-    'event_key'
+    "event_key"
   end
 
   def filename_pattern
-    '*.liquid'
+    "*.liquid"
   end
 
   def identifier_for_path(_content_set, path)
-    basename_without_extension(path, '.liquid')
+    basename_without_extension(path, ".liquid")
   end
 
   def path_for_identifier(content_set, identifier)
-    content_set.content_path(File.join('notification_templates', "#{identifier}.liquid"))
+    content_set.content_path(File.join("notification_templates", "#{identifier}.liquid"))
   end
 
   def read_item_attrs(item)
@@ -30,7 +30,7 @@ class CmsContentStorageAdapters::NotificationTemplates < CmsContentStorageAdapte
   def serialize_item(item, io)
     write_content_with_yaml_frontmatter(
       item.model.body_html.gsub("\r\n", "\n"),
-      item.model.attributes.except('body_html', 'id', 'convention_id', 'created_at', 'updated_at').compact,
+      item.model.attributes.except("body_html", "id", "convention_id", "created_at", "updated_at", "event_key").compact,
       io
     )
   end

--- a/app/services/cms_content_storage_adapters/pages.rb
+++ b/app/services/cms_content_storage_adapters/pages.rb
@@ -1,6 +1,6 @@
 class CmsContentStorageAdapters::Pages < CmsContentStorageAdapters::Base
   def subdir
-    'pages'
+    "pages"
   end
 
   def cms_parent_association
@@ -8,19 +8,19 @@ class CmsContentStorageAdapters::Pages < CmsContentStorageAdapters::Base
   end
 
   def identifier_attribute
-    'slug'
+    "slug"
   end
 
   def filename_pattern
-    '*.liquid'
+    "*.liquid"
   end
 
   def identifier_for_path(_content_set, path)
-    basename_without_extension(path, '.liquid')
+    basename_without_extension(path, ".liquid")
   end
 
   def path_for_identifier(content_set, identifier)
-    content_set.content_path(File.join('pages', "#{identifier}.liquid"))
+    content_set.content_path(File.join("pages", "#{identifier}.liquid"))
   end
 
   def read_item_attrs(item)
@@ -33,8 +33,18 @@ class CmsContentStorageAdapters::Pages < CmsContentStorageAdapters::Base
       item
         .model
         .attributes
-        .except('content', 'id', 'parent_id', 'cms_layout_id', 'parent_type', 'created_at', 'updated_at')
-        .merge('layout_name' => item.model.cms_layout&.name)
+        .except(
+          "content",
+          "id",
+          "parent_id",
+          "cms_layout_id",
+          "parent_type",
+          "created_at",
+          "updated_at",
+          "slug",
+          "invariant"
+        )
+        .merge("layout_name" => item.model.cms_layout&.name)
         .compact,
       io
     )

--- a/app/services/export_cms_content_set_service.rb
+++ b/app/services/export_cms_content_set_service.rb
@@ -32,7 +32,7 @@ class ExportCmsContentSetService < CivilService::Service
     success
   end
 
-  def export_content_from_adapter(storage_adapter)
+  def export_content_from_adapter(storage_adapter) # rubocop:disable Metrics/MethodLength
     inherited_items =
       storage_adapter.merge_items(
         inherited_content_sets.map do |inherited_content_set|

--- a/cms_content_sets/base/notification_templates/events/event_updated.liquid
+++ b/cms_content_sets/base/notification_templates/events/event_updated.liquid
@@ -6,7 +6,7 @@ body_text: >
 
   A change log is available at: {{ event.history_url | absolute_url }}
 ---
-<h1>Proposal updated</h1>
+<h1>Event updated</h1>
 
 <p>
   “{{ event.title }}” has been updated. To view the event, go

--- a/cms_content_sets/base/notification_templates/signups/signup_confirmation.liquid
+++ b/cms_content_sets/base/notification_templates/signups/signup_confirmation.liquid
@@ -21,14 +21,7 @@ body_text: |-
 
   Your new signup:
   {{ signup.starts_at | date: "%a %l:%M%P" }} - {{ signup.ends_at | date: "%l:%M%P" }}: {{ signup.run.room_names | join: ', ' }}
-  {{ signup.event.event_category.name | replace: "_", " " | humanize}}: {{ signup.event.title }}
-  {%- if signup.state != 'confirmed' %} [{{ signup.state | capitalize }}]{% endif -%}
-  {%- if signup.team_member? %} [{{ signup.event.team_member_name }}]
-  {%- elsif signup.bucket.name -%}
-    {%- if signup.bucket.name != 'Signups' -%}
-      {%- if signup.bucket.name != 'Interested' %} [{{ signup.bucket.name }}]{% endif -%}
-    {%- endif -%}
-  {%- endif %}
+  {{ signup.event.event_category.name | replace: "_", " " | humanize}}: {{ signup.event.title }}{% render "signup_bucket_description" signup:signup %}
   {{ signup.event_url | absolute_url }}
 ---
 {% assign run = signup.run %}
@@ -56,17 +49,6 @@ body_text: |-
     <strong>
       <a href="{{ signup.event_url | absolute_url }}">{{ signup.event.title }}</a>
     </strong>
-    {% if signup.state != 'confirmed' %}
-      &nbsp;[{{ signup.state | capitalize }}]
-    {% endif %}
-    {% if signup.team_member? %}
-      &nbsp;[{{ signup.event.team_member_name }}]
-    {% elsif signup.bucket.name %}
-      {% if signup.bucket.name != 'Signups' %}
-        {% if signup.bucket.name != 'Interested' %}
-          &nbsp;[{{ signup.bucket.name }}]
-        {% endif %}
-      {% endif %}
-    {% endif %}
+    {% render "signup_bucket_description" signup:signup %}
   </div>
 </li>

--- a/cms_content_sets/base/partials/signup_bucket_description.liquid
+++ b/cms_content_sets/base/partials/signup_bucket_description.liquid
@@ -1,0 +1,13 @@
+---
+admin_notes: Given a signup, describes its state to the user who owns it
+---
+{%- if signup.state != 'confirmed' %} [{{ signup.state | capitalize }}]{% endif -%}
+{%- if signup.team_member? %} [{{ signup.event.team_member_name }}]
+{%- elsif signup.bucket.name -%}
+  {%- if signup.bucket.name != 'Signups' -%}
+    {%- if signup.bucket.name != 'Interested' %} [{{ signup.bucket.name }}
+      {%- if signup.bucket.name != signup.requested_bucket.name %} (requested {{ signup.requested_bucket.name}}){% endif -%}
+    ]
+    {%- endif -%}
+  {%- endif -%}
+{%- endif -%}

--- a/cms_content_sets/smoke_and_mirrors/partials/user_signups.liquid
+++ b/cms_content_sets/smoke_and_mirrors/partials/user_signups.liquid
@@ -62,18 +62,7 @@ invariant: false
               <strong>
                 <a href="{{ signup.event_url }}">{{ signup.event.title }} </a>
               </strong>
-              {% if signup.state != 'confirmed' %}
-                &nbsp;[{{ signup.state | capitalize }}]
-              {% endif %}
-              {% if signup.team_member? %}
-                &nbsp;[{{ signup.event.team_member_name }}]
-              {% elsif signup.bucket.name %}
-                {% if signup.bucket.name != 'Signups' %}
-                  {% if signup.bucket.name != 'Interested' %}
-                    &nbsp;[{{ signup.bucket.name }}]
-                  {% endif %}
-                {% endif %}
-              {% endif %}
+              {% render "signup_bucket_description" signup:signup %}
             </div>
           </div>
 

--- a/cms_content_sets/standard/partials/user_signups.liquid
+++ b/cms_content_sets/standard/partials/user_signups.liquid
@@ -12,12 +12,7 @@
           </div>
           <div class="col">
             <a href="{{ signup.event_url }}">{{ signup.event.title }}</a>
-            {% if signup.state != 'confirmed' %}
-              [{{ signup.state | capitalize }}]
-            {% endif %}
-            {% if signup.team_member? %}
-              [{{ signup.event.team_member_name }}]
-            {% endif %}
+            {% render "signup_bucket_description" signup:signup %}
           </div>
 
           <div>

--- a/cms_content_sets/wanderlust/forms/Brainstorming session proposal form.json
+++ b/cms_content_sets/wanderlust/forms/Brainstorming session proposal form.json
@@ -1,0 +1,258 @@
+{
+  "title": "Brainstorming session proposal form",
+  "form_type": "event_proposal",
+  "sections": [
+    {
+      "title": "Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Session Title",
+          "required": true
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "public_description": "Event length",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the event. The description should be at least a couple of paragraphs, but can be as long as you like. This description is used to promote your session and attract attendees who will enjoy it.<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the event to be used for the List of Events page and the\nconvention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        }
+      ]
+    },
+    {
+      "title": "Participant Counts",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "{% include \"forum_registration_policy_instructions\" %}"
+        },
+        {
+          "item_type": "registration_policy",
+          "identifier": "registration_policy",
+          "admin_description": "Participant Slots",
+          "visibility": "normal",
+          "writeability": "normal",
+          "presets": [
+            {
+              "name": "Unlimited Interested Attendees",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "interested",
+                    "name": "Interested",
+                    "description": "I'm interested in attending! This will add this event to your con schedule. It will not count against the maximum signups allowed at this time, and will not prevent you from signing up for other events happening at the same time.",
+                    "not_counted": true,
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited Participants",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "participant",
+                    "name": "Participant",
+                    "description": "Sign up to participate in this session. This will add this event to your con schedule. It will not count against the maximum signups allowed at this time, and will not prevent you from signing up for other events happening at the same time.",
+                    "not_counted": true,
+                    "slots_limited": true
+                  }
+                ]
+              }
+            }
+          ],
+          "required": true,
+          "allow_custom": true
+        }
+      ]
+    },
+    {
+      "title": "Other Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Forum@Intercon staff."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "central_question",
+          "admin_description": "What is the question you're hoping to answer in this brainstorming session?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "What is the question you're hoping to answer in this brainstorming session?  (This should hopefully be also included in the public description of the session; if it's not, please go back and add it.)",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "how_answer",
+          "admin_description": "What kind of information would help you answer this question?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "What kind of information would help you answer this question?\n\n(For example, if you were holding a brainstorming session on ideas for a new campaign larp, you might want to know what sorts of things people would like to see but aren't available, and you might also want to know what's likely to influence them to sign up for a larp or not to.)",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "other_staff_info",
+          "admin_description": "Other Info for the Staff",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Please enter any additional information you wish to tell the Forum@Intercon staff.<br>This information will be shown only to the staff and will not be available publicly."
+        }
+      ]
+    },
+    {
+      "title": "Scheduling Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Forum@Intercon staff."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "<div class=\"alert alert-success mt-4\"><strong>New for Intercon T:</strong> we'll be offering Forum session slots throughout the weekend in addition to Thursday and Friday.  We'll prioritize filling Thursday and Friday, but also hope to have Forum content available during afternoon and evening weekend slots.</div>"
+        },
+        {
+          "item_type": "timeblock_preference",
+          "identifier": "timeblock_preferences",
+          "admin_description": "Timeblock Preferences",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Please pick your top three preferences for when you'd like to run your event. Please also mark all times when you will not be available to run your event.",
+          "timeblocks": [
+            {
+              "label": "Morning",
+              "start": {
+                "hour": 9
+              },
+              "finish": {
+                "hour": 13
+              }
+            },
+            {
+              "label": "Afternoon",
+              "start": {
+                "hour": 14
+              },
+              "finish": {
+                "hour": 18
+              }
+            },
+            {
+              "label": "Evening",
+              "start": {
+                "hour": 20
+              },
+              "finish": {
+                "hour": 24
+              }
+            }
+          ],
+          "omit_timeblocks": [
+            {
+              "date": "2025-02-27",
+              "label": "Morning"
+            },
+            {
+              "date": "2025-02-27",
+              "label": "Afternoon"
+            }
+          ]
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "scheduling_constraints",
+          "admin_description": "Scheduling Constraints",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "If there are scheduling constraints on your event (for example, if are you proposing another event), or there are times your event cannot be scheduled, please discuss them here."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "space_requirements",
+          "admin_description": "Space Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Space Requirements** for your event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "sound_requirements",
+          "admin_description": "Sound Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Sound Requirements** for your event.  If your event is going to be loud, or is going to run better in a quieter area, please let us know.  We run in shared space, with rooms near by each other, so perfect sound isolation is impossible, but we want to arrange events to not interfere with each other."
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Con Services Event Form.json
+++ b/cms_content_sets/wanderlust/forms/Con Services Event Form.json
@@ -1,0 +1,66 @@
+{
+  "title": "Con Services Event Form",
+  "form_type": "event",
+  "sections": [
+    {
+      "title": "Event Properties",
+      "section_items": [
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "public_description": "Title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Title",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "mask_policy",
+          "public_description": "Mask Policy",
+          "default_value": "required",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_vertical",
+          "caption": "**Mask policy**",
+          "choices": [
+            {
+              "value": "required",
+              "caption": "Masks are required for all attendees"
+            },
+            {
+              "value": "required_unless_eating",
+              "caption": "Masks are required for all attendees unless actively eating"
+            },
+            {
+              "value": "optional",
+              "caption": "Masks are optional, but attendees are still welcome to mask"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "public_description": "Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the game. The description should be at least a couple of paragraphs, but can be as long as you like.<br>The game description is used to promote your game and attract players who will enjoy it. Be reasonably clear on where and when the game is set, and what the game is about. Let your players know what can they expect to be doing during the LARP, and make them excited to play your game! (We can offer suggestions if you would like advice on this.)<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Filler event form.json
+++ b/cms_content_sets/wanderlust/forms/Filler event form.json
@@ -1,0 +1,286 @@
+{
+  "title": "Filler event form",
+  "form_type": "event",
+  "sections": [
+    {
+      "title": "Event Properties",
+      "section_items": [
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "public_description": "Title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Title",
+          "required": true
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "public_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "public_description": "Event length",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "mask_policy",
+          "public_description": "Mask policy",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_vertical",
+          "caption": "**Mask policy**",
+          "choices": [
+            {
+              "value": "required",
+              "caption": "Masks are required for all attendees"
+            },
+            {
+              "value": "required_unless_eating",
+              "caption": "Masks are required for all attendees unless actively eating"
+            },
+            {
+              "value": "optional",
+              "caption": "Masks are optional, but attendees are still welcome to mask"
+            },
+            {
+              "value": "tbd",
+              "caption": "To Be Determined - Will be resolved before schedule goes live"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "public_description": "Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the game. The description should be at least a couple of paragraphs, but can be as long as you like.<br>The game description is used to promote your game and attract players who will enjoy it. Be reasonably clear on where and when the game is set, and what the game is about. Let your players know what can they expect to be doing during the LARP, and make them excited to play your game! (We can offer suggestions if you would like advice on this.)<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "public_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the game to be used for the List of Events page and the\nconvention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "content_warnings",
+          "admin_description": "Player Visible Content Warnings",
+          "public_description": "Content Warnings",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "**Content Warnings**<br>Per NEIL policy, game descriptions must include either a content warning or an explicit statement that no content warnings are applicable. For more information, see the [NEIL policies <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](http://interactiveliterature.org/NEIL/communityPolicies.html#contentWarningsPolicy) page.<br>Please provide a content warning for your game.",
+          "required": false
+        },
+        {
+          "item_type": "age_restrictions",
+          "identifier": "age_restrictions",
+          "admin_description": "Player Visible Age Restrictions",
+          "public_description": "Age Restrictions",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "**Age Restrictions**<br>Please include the preferred ages of players for your larp. Examples are \"Players must be 18 or older\", or \"players under 16 must check with the GMs before playing\", to \"children at least [age] years old are welcome in this game\".",
+          "required": false
+        },
+        {
+          "item_type": "registration_policy",
+          "identifier": "registration_policy",
+          "visibility": "normal",
+          "writeability": "normal",
+          "presets": [
+            {
+              "name": "Unlimited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "unlimited",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Interested Indicator Slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "interested",
+                    "name": "Interested",
+                    "description": "I'm interested in attending! This will add this event to your con schedule. It will not count against the maximum signups allowed at this time, and will not prevent you from signing up for other events happening at the same time.",
+                    "not_counted": true,
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited Session Participants (for Forum@Intercon events)",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "participant",
+                    "name": "Participant",
+                    "description": "Sign up to participate in this session. This will add this event to your con schedule. It will not count against the maximum signups allowed at this time, and will not prevent you from signing up for other events happening at the same time.",
+                    "not_counted": true,
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "signups",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots for larps with NPCs",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "pcs",
+                    "name": "PC",
+                    "description": "Player characters",
+                    "slots_limited": true,
+                    "expose_attendees": true
+                  },
+                  {
+                    "key": "npcs",
+                    "name": "NPC",
+                    "description": "Non-player characters",
+                    "not_counted": true,
+                    "slots_limited": true,
+                    "expose_attendees": true
+                  }
+                ],
+                "prevent_no_preference_signups": true
+              }
+            },
+            {
+              "name": "Limited slots for horde larps",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "cast",
+                    "name": "Cast",
+                    "description": "Players who will have one character for the entire game",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "horde",
+                    "name": "Horde",
+                    "description": "Players who will be playing multiple characters over the course of the game",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots by gender (classic Intercon-style)",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "female",
+                    "name": "Female role",
+                    "description": "Female characters",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "male",
+                    "name": "Male role",
+                    "description": "Male characters",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "flex",
+                    "name": "Flex",
+                    "anything": true,
+                    "description": "Characters that are not strictly defined as male or female",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            }
+          ],
+          "required": false,
+          "allow_custom": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "can_play_concurrently",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_horizontal",
+          "caption": "Can this event be played concurrently with other events?",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Yes"
+            },
+            {
+              "value": "false",
+              "caption": "No"
+            }
+          ],
+          "required": false
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "Is this event run by the convention?",
+          "public_description": "Convention-run event",
+          "default_value": "no",
+          "visibility": "normal",
+          "writeability": "admin",
+          "other": false,
+          "style": "radio_vertical",
+          "caption": "Is this an official event run by {{convention.name}}?",
+          "choices": [
+            {
+              "value": "yes",
+              "caption": "Yes"
+            },
+            {
+              "value": "no",
+              "caption": "No"
+            }
+          ],
+          "required": false
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Forum event form.json
+++ b/cms_content_sets/wanderlust/forms/Forum event form.json
@@ -1,0 +1,253 @@
+{
+  "title": "Forum event form",
+  "form_type": "event",
+  "sections": [
+    {
+      "title": "Event Properties",
+      "section_items": [
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "public_description": "Title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Title",
+          "required": true
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "public_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "public_description": "Event length",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "public_description": "Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the game. The description should be at least a couple of paragraphs, but can be as long as you like.<br>The game description is used to promote your game and attract players who will enjoy it. Be reasonably clear on where and when the game is set, and what the game is about. Let your players know what can they expect to be doing during the LARP, and make them excited to play your game! (We can offer suggestions if you would like advice on this.)<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "public_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the game to be used for the List of Events page and the\nconvention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "mask_policy",
+          "public_description": "Mask policy",
+          "default_value": "required",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_vertical",
+          "caption": "**Mask policy** (Note: Forum@Intercon events are required to be masked.  This question is included on the form only so that this information will appear on events in the search feature.)",
+          "choices": [
+            {
+              "value": "required",
+              "caption": "Masks are required for all attendees"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "content_warnings",
+          "admin_description": "Player Visible Content Warnings",
+          "public_description": "Content Warnings",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "**Content Warnings**<br>Per NEIL policy, game descriptions must include either a content warning or an explicit statement that no content warnings are applicable. For more information, see the [NEIL policies <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](http://interactiveliterature.org/NEIL/communityPolicies.html#contentWarningsPolicy) page.<br>Please provide a content warning for your game.",
+          "required": false
+        },
+        {
+          "item_type": "age_restrictions",
+          "identifier": "age_restrictions",
+          "admin_description": "Player Visible Age Restrictions",
+          "public_description": "Age Restrictions",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "**Age Restrictions**<br>Please include the preferred ages of players for your larp. Examples are \"Players must be 18 or older\", or \"players under 16 must check with the GMs before playing\", to \"children at least [age] years old are welcome in this game\".",
+          "required": false
+        },
+        {
+          "item_type": "registration_policy",
+          "identifier": "registration_policy",
+          "visibility": "normal",
+          "writeability": "normal",
+          "presets": [
+            {
+              "name": "Unlimited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "unlimited",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Interested Indicator Slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "interested",
+                    "name": "Interested",
+                    "description": "I'm interested in attending! This will add this event to your con schedule. It will not count against the maximum signups allowed at this time, and will not prevent you from signing up for other events happening at the same time.",
+                    "not_counted": true,
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited Session Participants (for Forum@Intercon events)",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "participant",
+                    "name": "Participant",
+                    "description": "Sign up to participate in this session. This will add this event to your con schedule. It will not count against the maximum signups allowed at this time, and will not prevent you from signing up for other events happening at the same time.",
+                    "not_counted": true,
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "signups",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots for larps with NPCs",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "pcs",
+                    "name": "PC",
+                    "description": "Player characters",
+                    "slots_limited": true,
+                    "expose_attendees": true
+                  },
+                  {
+                    "key": "npcs",
+                    "name": "NPC",
+                    "description": "Non-player characters",
+                    "not_counted": true,
+                    "slots_limited": true,
+                    "expose_attendees": true
+                  }
+                ],
+                "prevent_no_preference_signups": true
+              }
+            },
+            {
+              "name": "Limited slots for horde larps",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "cast",
+                    "name": "Cast",
+                    "description": "Players who will have one character for the entire game",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "horde",
+                    "name": "Horde",
+                    "description": "Players who will be playing multiple characters over the course of the game",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots by gender (classic Intercon-style)",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "female",
+                    "name": "Female role",
+                    "description": "Female characters",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "male",
+                    "name": "Male role",
+                    "description": "Male characters",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "flex",
+                    "name": "Flex",
+                    "anything": true,
+                    "description": "Characters that are not strictly defined as male or female",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            }
+          ],
+          "required": false,
+          "allow_custom": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "can_play_concurrently",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_horizontal",
+          "caption": "Can this event be played concurrently with other events?",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Yes"
+            },
+            {
+              "value": "false",
+              "caption": "No"
+            }
+          ],
+          "required": false
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Larp event form.json
+++ b/cms_content_sets/wanderlust/forms/Larp event form.json
@@ -1,0 +1,380 @@
+{
+  "title": "Larp event form",
+  "form_type": "event",
+  "sections": [
+    {
+      "title": "Event Properties",
+      "section_items": [
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "public_description": "Title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Title",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "author",
+          "public_description": "Author(s)",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Author(s)",
+          "required": true
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "public_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "organization",
+          "public_description": "Organization",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Organization"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "url",
+          "public_description": "Homepage",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "format": "text",
+          "caption": "Event or Organization Homepage URL",
+          "free_text_type": "url"
+        },
+        {
+          "item_type": "registration_policy",
+          "identifier": "registration_policy",
+          "visibility": "normal",
+          "writeability": "normal",
+          "presets": [
+            {
+              "name": "Unlimited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "unlimited",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "signups",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots for larps with NPCs",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "pcs",
+                    "name": "PC",
+                    "description": "Player characters",
+                    "slots_limited": true,
+                    "expose_attendees": true
+                  },
+                  {
+                    "key": "npcs",
+                    "name": "NPC",
+                    "description": "Non-player characters",
+                    "not_counted": true,
+                    "slots_limited": true,
+                    "expose_attendees": true
+                  }
+                ],
+                "prevent_no_preference_signups": true
+              }
+            },
+            {
+              "name": "Limited slots for horde larps",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "cast",
+                    "name": "Cast",
+                    "description": "Players who will have one character for the entire game",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "horde",
+                    "name": "Horde",
+                    "description": "Players who will be playing multiple characters over the course of the game",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots by gender (classic Intercon-style)",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "female",
+                    "name": "Female role",
+                    "description": "Female characters",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "male",
+                    "name": "Male role",
+                    "description": "Male characters",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "flex",
+                    "name": "Flex",
+                    "anything": true,
+                    "description": "Characters that are not strictly defined as male or female",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            }
+          ],
+          "required": true,
+          "allow_custom": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "can_play_concurrently",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_horizontal",
+          "caption": "Can this event be played concurrently with other events?",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Yes"
+            },
+            {
+              "value": "false",
+              "caption": "No"
+            }
+          ]
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "replayable",
+          "public_description": "Can be replayed?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_horizontal",
+          "caption": "Can this event be replayed, if you've already played it before?",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Yes"
+            },
+            {
+              "value": "false",
+              "caption": "No"
+            }
+          ]
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "public_description": "Event length",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "mask_policy",
+          "public_description": "Mask policy",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_vertical",
+          "caption": "**Mask policy**",
+          "choices": [
+            {
+              "value": "required",
+              "caption": "Masks are required for all attendees"
+            },
+            {
+              "value": "required_unless_eating",
+              "caption": "Masks are required for all attendees unless actively eating"
+            },
+            {
+              "value": "request",
+              "caption": "Mask policy will be the strictest requested on casting surveys"
+            },
+            {
+              "value": "optional",
+              "caption": "Masks are optional, but attendees are still welcome to mask"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "public_description": "Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the game. The description should be at least a couple of paragraphs, but can be as long as you like.<br>The game description is used to promote your game and attract players who will enjoy it. Be reasonably clear on where and when the game is set, and what the game is about. Let your players know what can they expect to be doing during the LARP, and make them excited to play your game! (We can offer suggestions if you would like advice on this.)<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "public_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the game to be used for the List of Events page and the\nconvention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "**Content Warnings**<br>Per NEIL policy, game descriptions must include either a content warning or an explicit statement that no content warnings are applicable. For more information, see the [NEIL policies <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](http://interactiveliterature.org/NEIL/communityPolicies.html#contentWarningsPolicy) page."
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "content_warnings_selector",
+          "admin_description": "Content Warning Picklist",
+          "public_description": "Common Content Flags",
+          "visibility": "normal",
+          "writeability": "normal",
+          "other": false,
+          "style": "checkbox_vertical",
+          "caption": "<b>Specific Content Advisories</b>\n<br>Please indicate which of these common categories of content are contained in your game",
+          "choices": [
+            {
+              "value": "content_bigotry",
+              "caption": "Depictions of bigotry"
+            },
+            {
+              "value": "content_abuse",
+              "caption": "Depictions of abuse"
+            },
+            {
+              "value": "content_violence",
+              "caption": "Realistic simulations or descriptions of violence"
+            },
+            {
+              "value": "content_rape",
+              "caption": "Content involving rape"
+            },
+            {
+              "value": "content_minorities_targeted",
+              "caption": "Humor targeting minorities and other marginalized groups"
+            },
+            {
+              "value": "content_religion",
+              "caption": "Disrespect of real-world religions"
+            },
+            {
+              "value": "content_sex",
+              "caption": "Depictions of sexual acts"
+            },
+            {
+              "value": "content_noise",
+              "caption": "Use of loud noises"
+            },
+            {
+              "value": "content_light",
+              "caption": "Use of flashing lights, or absence of light"
+            },
+            {
+              "value": "content_accessability",
+              "caption": "Physical requirements that might affect accessibility"
+            },
+            {
+              "value": "content_gender",
+              "caption": "Casting without regard to gender preferences"
+            },
+            {
+              "value": "content_none",
+              "caption": "No specific content advisory"
+            },
+            {
+              "value": "content_no_response",
+              "caption": "GMs chose not to respond"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "content_warnings",
+          "admin_description": "Player Visible Content Warnings",
+          "public_description": "Custom Content Advisories",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "**Custom Content Advisories or Warnings**<br>\nPlease expand upon any of the above selections, and/or any other content advisories or warnings you wish to mention or provide the above opt-out text.",
+          "required": true
+        },
+        {
+          "item_type": "age_restrictions",
+          "identifier": "age_restrictions",
+          "admin_description": "Player Visible Age Restrictions",
+          "public_description": "Age Restrictions",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "**Age Restrictions**<br>Please include the preferred ages of players for your larp. Examples are \"Players must be 18 or older\", or \"players under 16 must check with the GMs before playing\", to \"children at least [age] years old are welcome in this game\".",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "participant_communications",
+          "admin_description": "Participant Communications",
+          "public_description": "Participant Communications",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "**Player Communications**<br>How will you distribute game information to your players? Will you be using a casting form? Will\ncharacter roles be cast and distributed before the convention or on site, or will characters be\ndeveloped as part of the game?<br>Please use this space to let your players know what to expect.\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "physical_restrictions",
+          "admin_description": "Physical Restrictions",
+          "public_description": "Physical Restrictions",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "**Physical and Accessibility Restrictions**<br>\nAre there any physical restrictions or accessability concerns imposed by your larp? For example, live boffer combat, confined sets, lound souds, standing for long periods, etc. If so, please explain and consider if this needs to be mentioned in the event descriptions."
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Larp proposal form.json
+++ b/cms_content_sets/wanderlust/forms/Larp proposal form.json
@@ -1,0 +1,623 @@
+{
+  "title": "Larp proposal form",
+  "form_type": "event_proposal",
+  "sections": [
+    {
+      "title": "Larp Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Event Title",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "authors",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Author(s)",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "organization",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Organization"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "url",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Event or Organization Homepage URL"
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "**Event Length**\n<br>Please note that events longer than 6 hours will be harder to schedule, except on Sunday.",
+          "required": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "mask_policy",
+          "public_description": "Mask policy",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_vertical",
+          "caption": "**Mask policy**",
+          "choices": [
+            {
+              "value": "required",
+              "caption": "Masks are required for all attendees"
+            },
+            {
+              "value": "required_unless_eating",
+              "caption": "Masks are required for all attendees unless actively eating"
+            },
+            {
+              "value": "request",
+              "caption": "Mask policy will be the strictest requested on casting surveys"
+            },
+            {
+              "value": "optional",
+              "caption": "Masks are optional, but attendees are still welcome to mask"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the event. The description should be at least a couple of paragraphs, but can be as long as you like.<br>This description is used to promote your larp and attract players who will enjoy it. Be reasonably clear on where and when the larp is set, and what the larp is about. Let your players know what they can expect to be doing during the larp, and make them excited to play your larp! (We can offer suggestions if you would like advice on this.)<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the event to be used for the List of Events page and the\nconvention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "replayable",
+          "admin_description": "Is this event replayable?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_horizontal",
+          "caption": "**Replayability**<br>Is this event playable by people who have played it before?  Please note that this is advisory, and Intercon will not enforce this by removing players who have already played this larp.  This should only be set to \"No\" if the experience of playing this larp would be notibly degraded upon replay, i.e. for larps deeply based around secrets.",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Yes"
+            },
+            {
+              "value": "false",
+              "caption": "No"
+            },
+            {
+              "value": "ask",
+              "caption": "Ask First"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Character Counts",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "{% include \"proposal_form_registration_policy_instructions\" %}"
+        },
+        {
+          "item_type": "registration_policy",
+          "identifier": "registration_policy",
+          "admin_description": "Character Slots",
+          "visibility": "normal",
+          "writeability": "normal",
+          "presets": [
+            {
+              "name": "Unlimited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "unlimited",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "signups",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots for larps with NPCs",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "pcs",
+                    "name": "PC",
+                    "description": "Player characters",
+                    "slots_limited": true,
+                    "expose_attendees": true
+                  },
+                  {
+                    "key": "npcs",
+                    "name": "NPC",
+                    "description": "Non-player characters",
+                    "not_counted": true,
+                    "slots_limited": true,
+                    "expose_attendees": true
+                  }
+                ],
+                "prevent_no_preference_signups": true
+              }
+            },
+            {
+              "name": "Limited slots for horde larps",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "cast",
+                    "name": "Cast",
+                    "description": "Players who will have one character for the entire game",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "horde",
+                    "name": "Horde",
+                    "description": "Players who will be playing multiple characters over the course of the game",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots by gender (classic Intercon-style)",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "female",
+                    "name": "Female role",
+                    "description": "Female characters",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "male",
+                    "name": "Male role",
+                    "description": "Male characters",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "flex",
+                    "name": "Flex",
+                    "anything": true,
+                    "description": "Characters that are not strictly defined as male or female",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            }
+          ],
+          "required": true,
+          "allow_custom": true
+        }
+      ]
+    },
+    {
+      "title": "Player Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "{{convention.name}} appeals to a diverse group of players of all ages, ethnicities, belief systems, sexual orientations, physical capabilities, experience, etc. Authors can write interesting larps that might not be suitable for all audiences. In order for the con staff to balance these potentially opposing requirements, please answer the following questions:<br><br>"
+        },
+        {
+          "item_type": "age_restrictions",
+          "identifier": "age_restrictions",
+          "admin_description": "Player Visible Age Restrictions",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "**Age Restrictions**<br>Please include the acceptable ages of players for your larp. Examples are \"Players must be 18 or older\", or \"players under 16 must check with the GMs before playing\", to \"children at least [age] years old are welcome in this larp\".",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "player_communications",
+          "admin_description": "Player Communications",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "**Player Communications**<br>How will you distribute larp information to your players? Will you be using a casting form? Will character roles be cast and distributed before the convention or on site, or will characters be developed as part of the larp? Approximately how much reading can a player expect to do for this larp?<br>Please use this space to let your players know what to expect.",
+          "required": true
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "<span class=\"lead\">Content Advisories or Warnings</span><br>Per NEIL policy, larp descriptions must either include content warnings about potentially difficult or upsetting content that players can expect to interact with OR the explicit statement that \"The GMs of this LARP have chosen not to include a content warning. If you have any questions about the content in this LARP, please contact the email provided. Otherwise, player discretion is advised.\" <p>For more information, see the [NEIL policies <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](http://interactiveliterature.org/NEIL/communityPolicies.html#contentWarningsPolicy) page"
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "content_warnings_selector",
+          "admin_description": "Content Warning Picklist",
+          "public_description": "Common Content Flags",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "checkbox_vertical",
+          "caption": "<b>Specific Content Advisories</b>\n<br>Please indicate which of these common categories of content are contained in your game",
+          "choices": [
+            {
+              "value": "content_bigotry",
+              "caption": "Depictions of bigotry"
+            },
+            {
+              "value": "content_abuse",
+              "caption": "Depictions of abuse"
+            },
+            {
+              "value": "content_violence",
+              "caption": "Realistic simulations or descriptions of violence"
+            },
+            {
+              "value": "content_rape",
+              "caption": "Content involving rape"
+            },
+            {
+              "value": "content_minorities_targeted",
+              "caption": "Humor targeting minorities and other marginalized groups"
+            },
+            {
+              "value": "content_religion",
+              "caption": "Disrespect of real-world religions"
+            },
+            {
+              "value": "content_sex",
+              "caption": "Depictions of sexual acts"
+            },
+            {
+              "value": "content_noise",
+              "caption": "Use of loud noises"
+            },
+            {
+              "value": "content_light",
+              "caption": "Use of flashing lights, or absence of light"
+            },
+            {
+              "value": "content_accessability",
+              "caption": "Physical requirements that might affect accessibility"
+            },
+            {
+              "value": "content_gender",
+              "caption": "Casting without regard to gender preferences"
+            },
+            {
+              "value": "content_none",
+              "caption": "None of the above"
+            },
+            {
+              "value": "content_no_response",
+              "caption": "GMs chose not to respond"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "content_warnings",
+          "admin_description": "Player Visible Content Warnings",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "**Custom Content Advisories or Warnings**<br>\nPlease expand upon any of the above selections, and/or any other content advisories or warnings you wish to mention or provide the above opt-out text.",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "physical_restrictions",
+          "admin_description": "Physical Restrictions",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "**Physical and Accessibility Restrictions**<br>\nAre there any physical restrictions or accessibility concerns imposed by your larp? For example, live boffer combat, confined sets, loud sounds, standing for long periods, etc. If so, please explain and consider if this needs to be mentioned in the event descriptions."
+        }
+      ]
+    },
+    {
+      "title": "GM/Author Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Proposals Committee."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "gms",
+          "admin_description": "GMs for the larp",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "**GMs for your larp.**<br>Note that the GMs listed here are only for the purpose of evaluating your proposal. If your proposal is accepted, you'll be able to select GMs from the users registered for  {{ convention.name }}."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "other_games",
+          "admin_description": "Other larps from the team",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "What other larps have you written or run? Where and when were they run?"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "run_before",
+          "admin_description": "Has this larp run before?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "{{ convention.name }} is looking for larps that are new and larps that have run before, either at a\nconvention, or elsewhere.<br>If this larp has run before, where was that?\n"
+        }
+      ]
+    },
+    {
+      "title": "Scheduling Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Proposals Committee."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "The con can schedule your event into one (or more) of the time slots available over the weekend. In an effort to optimize the space available and to provide the greatest number of player slots in prime time periods, minimum size requirements will be in effect on Saturday afternoon, Saturday evening, and Friday evening for most rooms. Smaller larps (fewer than 10 players) and boffer-style larps (or other larps) which require large space needs may be accepted on a conditional basis during these time periods until after initial scheduling takes place. The more flexibility you can provide in your scheduling options, the greater the ability to have the game accepted and scheduled. Sunday, morning, midnight, and Thursday slots are encouraged. "
+        },
+        {
+          "item_type": "timeblock_preference",
+          "identifier": "timeblock_preferences",
+          "admin_description": "Timeblock Preferences",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Please pick your top preferences for when you'd like to run your larp. Please also mark all times when you will not be available to run your larp",
+          "timeblocks": [
+            {
+              "label": "Morning",
+              "start": {
+                "hour": 9
+              },
+              "finish": {
+                "hour": 13
+              }
+            },
+            {
+              "label": "Afternoon",
+              "start": {
+                "hour": 14
+              },
+              "finish": {
+                "hour": 18
+              }
+            },
+            {
+              "label": "Evening",
+              "start": {
+                "hour": 20
+              },
+              "finish": {
+                "hour": 24
+              }
+            },
+            {
+              "label": "After Midnight",
+              "start": {
+                "hour": 24
+              },
+              "finish": {
+                "hour": 26,
+                "minute": 0
+              }
+            }
+          ],
+          "omit_timeblocks": [
+            {
+              "date": "2025-02-27",
+              "label": "Morning"
+            },
+            {
+              "date": "2025-02-27",
+              "label": "Afternoon"
+            },
+            {
+              "date": "2025-03-02",
+              "label": "Evening"
+            }
+          ]
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "can_play_concurrently",
+          "admin_description": "Can Play Concurrently?",
+          "default_value": "false",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_horizontal",
+          "caption": "Can players play in your larp and another event at the same time?",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Yes"
+            },
+            {
+              "value": "false",
+              "caption": "No"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "multiple_runs",
+          "admin_description": "Can Do Multiple Runs?",
+          "default_value": "false",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_horizontal",
+          "caption": "Are you willing to hold this event more than once at this convention?",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Yes"
+            },
+            {
+              "value": "false",
+              "caption": "No"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "scheduling_constraints",
+          "admin_description": "Scheduling Constraints",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "If you are willing to hold the larp more than once, please discuss your preferences below.<br>In addition, if there are scheduling constraints on your larp (for example, if are you proposing another event), or there are times your larp cannot be scheduled, please discuss them as well."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "space_requirements",
+          "admin_description": "Space Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Space Requirements** for your event.\n<br>We can typically guarantee one function space room per game. If you need more than that, we may be able to make it work, depending on the size of your game, and when during the convention it is scheduled.  Running on Sunday is more likely to be able to provide multiple rooms.  If you need other physical features of your space (high ceilings, a sink, etc) please list them here."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "sound_requirements",
+          "admin_description": "Sound Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Sound Requirements** for your event.  If your event is going to be loud, or is going to run better in a quieter area, please let us know.  We run in shared space, with rooms near by each other, so perfect sound isolation is impossible, but we want to arrange games to not interfere with each other."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "setup_teardown",
+          "admin_description": "Setup/Teardown requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Are there any special <b>Setup or Teardown Requirements</b> for this event? For example, do you need extra time to set up or tear down a complex set? (Requests for standard furniture will be handled separately closer to the convention. Intercon can not provide unusual setup materials for your event. Please reference [the GM Policies <i class='bi-box-arrow-up-right' aria-hidden='true'></i>]({% page_url gmpolicies %}#FurnitureService) for available items )"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "setup_time",
+          "admin_description": "Setup Time",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "format": "text",
+          "caption": "How much time do you need to **set up** your larp before the event can begin?",
+          "free_text_type": "text"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "cleanup_time",
+          "admin_description": "Cleanup Time",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "format": "plain",
+          "caption": "How much time do you need to **clean up** your larp after the event is over?"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "other_committee_info",
+          "admin_description": "Other Info for the Committee",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "<b>Any other information you wish to tell the Proposals Committee that would help them evaluate and provide feedback for your larp?</b> <br>This may include information that is not player-facing. This information will be shown only to the Proposals Committee."
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Moderated discussion proposal form.json
+++ b/cms_content_sets/wanderlust/forms/Moderated discussion proposal form.json
@@ -1,0 +1,199 @@
+{
+  "title": "Moderated discussion proposal form",
+  "form_type": "event_proposal",
+  "sections": [
+    {
+      "title": "Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Discussion Title",
+          "required": true
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the event. The description should be at least a couple of paragraphs, but can be as long as you like. This description is used to promote your presentation and attract attendees who will enjoy it.<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the event to be used for the List of Events page and the\nconvention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        }
+      ]
+    },
+    {
+      "title": "Other Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Forum@Intercon staff."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "whats_important",
+          "admin_description": "What do you think is important for a great moderated discussion?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "What do you think is important for a great moderated discussion?",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "special_considerations",
+          "admin_description": "Are there any special considerations you feel are important for moderating a discussion on this topic?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Are there any special considerations you feel are important for moderating a discussion on this topic?",
+          "required": false
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "other_staff_info",
+          "admin_description": "Other Info for the Staff",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Please enter any additional information you wish to tell the Forum@Intercon staff.<br>This information will be shown only to the staff and will not be available publicly."
+        }
+      ]
+    },
+    {
+      "title": "Scheduling Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Forum@Intercon staff."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "<div class=\"alert alert-success mt-4\"><strong>New for Intercon T:</strong> we'll be offering Forum session slots throughout the weekend in addition to Thursday and Friday.  We'll prioritize filling Thursday and Friday, but also hope to have Forum content available during afternoon and evening weekend slots.</div>"
+        },
+        {
+          "item_type": "timeblock_preference",
+          "identifier": "timeblock_preferences",
+          "admin_description": "Timeblock Preferences",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Please pick your top three preferences for when you'd like to run your event. Please also mark all times when you will not be available to run your event.",
+          "timeblocks": [
+            {
+              "label": "Morning",
+              "start": {
+                "hour": 9
+              },
+              "finish": {
+                "hour": 13
+              }
+            },
+            {
+              "label": "Afternoon",
+              "start": {
+                "hour": 14
+              },
+              "finish": {
+                "hour": 18
+              }
+            },
+            {
+              "label": "Evening",
+              "start": {
+                "hour": 20
+              },
+              "finish": {
+                "hour": 24
+              }
+            }
+          ],
+          "omit_timeblocks": [
+            {
+              "date": "2025-02-27",
+              "label": "Morning"
+            },
+            {
+              "date": "2025-02-27",
+              "label": "Afternoon"
+            }
+          ]
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "scheduling_constraints",
+          "admin_description": "Scheduling Constraints",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "If there are scheduling constraints on your event (for example, if are you proposing another event), or there are times your event cannot be scheduled, please discuss them here."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "space_requirements",
+          "admin_description": "Space Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Space Requirements** for your event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "sound_requirements",
+          "admin_description": "Sound Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Sound Requirements** for your event.  If your event is going to be loud, or is going to run better in a quieter area, please let us know.  We run in shared space, with rooms near by each other, so perfect sound isolation is impossible, but we want to arrange events to not interfere with each other."
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Panel proposal form.json
+++ b/cms_content_sets/wanderlust/forms/Panel proposal form.json
@@ -1,0 +1,206 @@
+{
+  "title": "Panel proposal form",
+  "form_type": "event_proposal",
+  "sections": [
+    {
+      "title": "Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Panel Title",
+          "required": true
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "<div class=\"alert alert-warning mt-4 mb-2\">FYI: In the past, Intercon has reached out to potential panelists after selecting topics and assembled the panels itself.  Forum@Intercon will allow the moderator to select their panel from people they know to be passionate and informed about the topic.  The next page will prompt you to enter the panelists for your proposed event.</div>"
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the event. The description should be at least a couple of paragraphs, but can be as long as you like. This description is used to promote your presentation and attract attendees who will enjoy it.<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the event to be used for the List of Events page and the\nconvention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        }
+      ]
+    },
+    {
+      "title": "Other Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Forum@Intercon staff."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "panelists",
+          "admin_description": "Panelists",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Who will be the panelists?",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "why_panelists",
+          "admin_description": "Why have you selected these panelists?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Why have you selected these panelists?",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "other_staff_info",
+          "admin_description": "Other Info for the Staff",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Please enter any additional information you wish to tell the Forum@Intercon staff.<br>This information will be shown only to the staff and will not be available publicly."
+        }
+      ]
+    },
+    {
+      "title": "Scheduling Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Forum@Intercon staff."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "<div class=\"alert alert-success\"><strong>New for Intercon T:</strong> we'll be offering Forum session slots throughout the weekend in addition to Thursday and Friday.  We'll prioritize filling Thursday and Friday, but also hope to have Forum content available during afternoon and evening weekend slots.</div>"
+        },
+        {
+          "item_type": "timeblock_preference",
+          "identifier": "timeblock_preferences",
+          "admin_description": "Timeblock Preferences",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Please pick your top three preferences for when you'd like to run your event. Please also mark all times when you will not be available to run your event.",
+          "timeblocks": [
+            {
+              "label": "Morning",
+              "start": {
+                "hour": 9
+              },
+              "finish": {
+                "hour": 13
+              }
+            },
+            {
+              "label": "Afternoon",
+              "start": {
+                "hour": 14
+              },
+              "finish": {
+                "hour": 18
+              }
+            },
+            {
+              "label": "Evening",
+              "start": {
+                "hour": 20
+              },
+              "finish": {
+                "hour": 24
+              }
+            }
+          ],
+          "omit_timeblocks": [
+            {
+              "date": "2025-02-27",
+              "label": "Afternoon"
+            },
+            {
+              "date": "2025-02-27",
+              "label": "Morning"
+            }
+          ]
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "scheduling_constraints",
+          "admin_description": "Scheduling Constraints",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "If there are scheduling constraints on your event (for example, if are you proposing another event), or there are times your event cannot be scheduled, please discuss them here."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "space_requirements",
+          "admin_description": "Space Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Space Requirements** for your event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "sound_requirements",
+          "admin_description": "Sound Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Sound Requirements** for your event.  If your event is going to be loud, or is going to run better in a quieter area, please let us know.  We run in shared space, with rooms near by each other, so perfect sound isolation is impossible, but we want to arrange events to not interfere with each other."
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Presentation proposal form.json
+++ b/cms_content_sets/wanderlust/forms/Presentation proposal form.json
@@ -1,0 +1,209 @@
+{
+  "title": "Presentation proposal form",
+  "form_type": "event_proposal",
+  "sections": [
+    {
+      "title": "Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Presentation Title",
+          "required": true
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the event. The description should be at least a couple of paragraphs, but can be as long as you like. This description is used to promote your presentation and attract attendees who will enjoy it.<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the event to be used for the List of Events page and the\nconvention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        }
+      ]
+    },
+    {
+      "title": "Other Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Forum@Intercon staff."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "major_points",
+          "admin_description": "Major points",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "What are the major points you hope to cover in this presentation?",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "what_interests_you",
+          "admin_description": "What interests you about this topic?  What made you want to learn more about it?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "What interests you about this topic?  What made you want to learn more about it?",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "equipment",
+          "admin_description": "Equipment",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "What kind of equipment, if any, will you need for this presentation?  (e.g. projector/screen, easel, etc.)",
+          "required": false
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "other_staff_info",
+          "admin_description": "Other Info for the Staff",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Please enter any additional information you wish to tell the Forum@Intercon staff.<br>This information will be shown only to the staff and will not be available publicly."
+        }
+      ]
+    },
+    {
+      "title": "Scheduling Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Forum@Intercon staff."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "<div class=\"alert alert-success\"><strong>New for Intercon T:</strong> we'll be offering Forum session slots throughout the weekend in addition to Thursday and Friday.  We'll prioritize filling Thursday and Friday, but also hope to have Forum content available during afternoon and evening weekend slots.</div>"
+        },
+        {
+          "item_type": "timeblock_preference",
+          "identifier": "timeblock_preferences",
+          "admin_description": "Timeblock Preferences",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Please pick your top three preferences for when you'd like to run your event. Please also mark all times when you will not be available to run your event.",
+          "timeblocks": [
+            {
+              "label": "Morning",
+              "start": {
+                "hour": 9
+              },
+              "finish": {
+                "hour": 13
+              }
+            },
+            {
+              "label": "Afternoon",
+              "start": {
+                "hour": 14
+              },
+              "finish": {
+                "hour": 18
+              }
+            },
+            {
+              "label": "Evening",
+              "start": {
+                "hour": 20
+              },
+              "finish": {
+                "hour": 24
+              }
+            }
+          ],
+          "omit_timeblocks": [
+            {
+              "date": "2025-02-27",
+              "label": "Morning"
+            },
+            {
+              "date": "2025-02-27",
+              "label": "Afternoon"
+            }
+          ]
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "scheduling_constraints",
+          "admin_description": "Scheduling Constraints",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "If there are scheduling constraints on your event (for example, if are you proposing another event), or there are times your event cannot be scheduled, please discuss them here."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "space_requirements",
+          "admin_description": "Space Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Space Requirements** for your event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "sound_requirements",
+          "admin_description": "Sound Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Sound Requirements** for your event.  If your event is going to be loud, or is going to run better in a quieter area, please let us know.  We run in shared space, with rooms near by each other, so perfect sound isolation is impossible, but we want to arrange events to not interfere with each other."
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Social Event Form.json
+++ b/cms_content_sets/wanderlust/forms/Social Event Form.json
@@ -1,0 +1,197 @@
+{
+  "title": "Social Event Form",
+  "form_type": "event",
+  "sections": [
+    {
+      "title": "Event Properties",
+      "section_items": [
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "public_description": "Title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Title",
+          "required": true
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "public_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "public_description": "Event length",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "mask_policy",
+          "public_description": "Mask policy",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_vertical",
+          "caption": "**Mask policy**",
+          "choices": [
+            {
+              "value": "required",
+              "caption": "Masks are required for all attendees"
+            },
+            {
+              "value": "required_unless_eating",
+              "caption": "Masks are required for all attendees unless actively eating"
+            },
+            {
+              "value": "optional",
+              "caption": "Masks are optional, but attendees are still welcome to mask"
+            },
+            {
+              "value": "tbd",
+              "caption": "To Be Determined - Will be resolved before schedule goes live"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "public_description": "Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the event. The description should be at least a couple of paragraphs, but can be as long as you like.<br>The description is used to promote your event and attract attendees who will enjoy it. <br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "public_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the event to be used for the List of Events page. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "content_warnings",
+          "admin_description": "Player Visible Content Warnings",
+          "public_description": "Content Warnings",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "**Content Warnings**<br>Per NEIL policy, game descriptions must include either a content warning or an explicit statement that no content warnings are applicable. For more information, see the [NEIL policies <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](http://interactiveliterature.org/NEIL/communityPolicies.html#contentWarningsPolicy) page.<br>Please provide a content warning for your game.",
+          "required": false
+        },
+        {
+          "item_type": "age_restrictions",
+          "identifier": "age_restrictions",
+          "admin_description": "Player Visible Age Restrictions",
+          "public_description": "Age Restrictions",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "**Age Restrictions**<br>Please include the required age of attendees for your event. Examples are \"Attendees must be 18 or older\".",
+          "required": false
+        },
+        {
+          "item_type": "registration_policy",
+          "identifier": "registration_policy",
+          "admin_description": "Character Slots",
+          "visibility": "normal",
+          "writeability": "normal",
+          "presets": [
+            {
+              "name": "Unlimited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "unlimited",
+                    "name": "Interested",
+                    "description": "I'm interested in attending! This will add this event to your con schedule. It will not count against the maximum signups allowed at this time, and will not prevent you from signing up for other events happening at the same time.",
+                    "not_counted": true,
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited Slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "custom_1",
+                    "name": "Interested",
+                    "anything": false,
+                    "description": "I'm interested in attending! This will add this event to your con schedule. It will count against the maximum signups allowed at this time, and will prevent you from signing up for other events happening at the same time.",
+                    "not_counted": false,
+                    "slots_limited": true,
+                    "expose_attendees": false
+                  }
+                ],
+                "__typename": "RegistrationPolicy",
+                "prevent_no_preference_signups": false
+              }
+            }
+          ],
+          "required": false,
+          "allow_custom": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "can_play_concurrently",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_horizontal",
+          "caption": "Can this event be played concurrently with other events?",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Yes"
+            },
+            {
+              "value": "false",
+              "caption": "No"
+            }
+          ],
+          "required": false
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "Is this event run by the convention?",
+          "public_description": "Convention-run event",
+          "default_value": "no",
+          "visibility": "normal",
+          "writeability": "admin",
+          "other": false,
+          "style": "radio_vertical",
+          "caption": "Is this an official event run by {{convention.name}}?",
+          "choices": [
+            {
+              "value": "yes",
+              "caption": "Yes"
+            },
+            {
+              "value": "no",
+              "caption": "No"
+            }
+          ],
+          "required": false
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Social Event proposal form.json
+++ b/cms_content_sets/wanderlust/forms/Social Event proposal form.json
@@ -1,0 +1,256 @@
+{
+  "title": "Social Event proposal form",
+  "form_type": "event_proposal",
+  "sections": [
+    {
+      "title": "Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Event Title",
+          "required": true
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "mask_policy",
+          "public_description": "Mask policy",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_vertical",
+          "caption": "**Mask policy**",
+          "choices": [
+            {
+              "value": "required",
+              "caption": "Masks are required for all attendees"
+            },
+            {
+              "value": "required_unless_eating",
+              "caption": "Masks are required for all attendees unless actively eating"
+            },
+            {
+              "value": "optional",
+              "caption": "Masks are optional, but attendees are still welcome to mask"
+            },
+            {
+              "value": "tbd",
+              "caption": "To Be Determined - Will be resolved before schedule goes live"
+            }
+          ],
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the event. The description should be at least a couple of paragraphs, but can be as long as you like. This description is used to promote your social event and attract attendees who will enjoy it.<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the event to be used for the List of Events page and the convention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "content_warnings",
+          "admin_description": "Attendee Visible Content Warnings",
+          "public_description": "Content Warnings",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "**Content Warnings**<br>Not every social event will require a content warning, but if yours does, please provide it here."
+        }
+      ]
+    },
+    {
+      "title": "Attendee Counts",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "{% include \"social_event_registration_policy_instructions\" %}"
+        },
+        {
+          "item_type": "registration_policy",
+          "identifier": "registration_policy",
+          "admin_description": "Character Slots",
+          "visibility": "normal",
+          "writeability": "normal",
+          "presets": [
+            {
+              "name": "Unlimited capacity",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "interested",
+                    "name": "Interested",
+                    "description": "I'm interested in attending! This will add this event to your con schedule. It will not count against the maximum signups allowed at this time, and will not prevent you from signing up for other events happening at the same time.",
+                    "not_counted": true,
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited capacity",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "signups",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            }
+          ],
+          "required": true,
+          "allow_custom": true
+        }
+      ]
+    },
+    {
+      "title": "Scheduling Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Hospitality staff."
+        },
+        {
+          "item_type": "timeblock_preference",
+          "identifier": "timeblock_preferences",
+          "admin_description": "Timeblock Preferences",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Please pick your top three preferences for when you'd like to run your event. Please also mark all times when you will not be available to run your event.",
+          "timeblocks": [
+            {
+              "label": "Morning",
+              "start": {
+                "hour": 9
+              },
+              "finish": {
+                "hour": 13
+              }
+            },
+            {
+              "label": "Afternoon",
+              "start": {
+                "hour": 14
+              },
+              "finish": {
+                "hour": 18
+              }
+            },
+            {
+              "label": "Evening",
+              "start": {
+                "hour": 20
+              },
+              "finish": {
+                "hour": 24
+              }
+            },
+            {
+              "label": "After Midnight",
+              "start": {
+                "hour": 24
+              },
+              "finish": {
+                "hour": 28
+              }
+            }
+          ],
+          "omit_timeblocks": []
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "scheduling_constraints",
+          "admin_description": "Scheduling Constraints",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "If there are scheduling constraints on your event (for example, if are you proposing another event), or there are times your event cannot be scheduled, please discuss them here."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "space_requirements",
+          "admin_description": "Space Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Space Requirements** for your event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "sound_requirements",
+          "admin_description": "Sound Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Sound Requirements** for your event.  If your event is going to be loud, or is going to run better in a quieter area, please let us know.  We run in shared space, with rooms near by each other, so perfect sound isolation is impossible, but we want to arrange events to not interfere with each other."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "anything_else",
+          "admin_description": "Anything else?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Is there anything else you'd like to tell the Hospitality staff about your event?  If so, please do so here."
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/User con profile form.json
+++ b/cms_content_sets/wanderlust/forms/User con profile form.json
@@ -1,0 +1,237 @@
+{
+  "title": "User con profile form",
+  "form_type": "user_con_profile",
+  "sections": [
+    {
+      "title": "Your {{ convention.name }} profile",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "<div class=\"mb-4\">Your contact information will be made available to {{ convention.name }} staff and the organizers of the events you sign up for. Supplying the contact information is optional. If you have concerns about sharing this information, <strong>please do not enter it</strong>. But if you do not provide it, organizers may not be able to send you event-related materials.</div>"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "first_name",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "First name"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "last_name",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Last name"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "nickname",
+          "admin_description": "Badge Name",
+          "public_description": "Badge Name",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Badge Name\n<br><small>This will be printed on your badge instead of your name, if provided</small>"
+        },
+        {
+          "item_type": "date",
+          "identifier": "birth_date",
+          "admin_description": "Birth date",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "<p class=\"m-0\">Birth date<br>\n<small>Note: Specifying your birth date is optional. But if you choose not to, you may not be able to sign up for age-restricted games.</small></p>"
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "pronouns",
+          "visibility": "normal",
+          "writeability": "normal",
+          "other": true,
+          "style": "radio_vertical",
+          "caption": "Pronouns",
+          "choices": [
+            {
+              "value": "She/Her/Hers",
+              "caption": "She/Her/Hers"
+            },
+            {
+              "value": "He/Him/His",
+              "caption": "He/Him/His"
+            },
+            {
+              "value": "They/Them/Theirs",
+              "caption": "They/Them/Theirs"
+            },
+            {
+              "value": "Don't use pronouns, use my name",
+              "caption": "Don't use pronouns, use my name"
+            }
+          ]
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "<div class=\"card bg-light my-4\"><div class=\"card-body\"><ul class=\"list-unstyled\"><li>Email: {{ user.email }}</li><li>Password: <em>not shown</em></li></ul><p class=\"m-0\"><strong>To change your account email address or password, <a href=\"/users/edit\">edit your site account</a>.</strong></p></div></div>"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "discord_id",
+          "admin_description": "Discord ID",
+          "public_description": "Discord ID",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "format": "plain",
+          "caption": "Discord ID/Username"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "mobile_phone",
+          "admin_description": "Phone",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "format": "plain",
+          "caption": "Phone<br/>\n<small class=\"text-muted\">Include country code for phone numbers outside US or Canada</small>",
+          "free_text_type": "tel"
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "allow_sms",
+          "admin_description": "Receive site texts?",
+          "default_value": "true",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_vertical",
+          "caption": "Receive text message notifications close to or during the convention when you get into events off a waitlist, or when signups in events you’re running change?",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Receive texts"
+            },
+            {
+              "value": "false",
+              "caption": "Don't receive texts"
+            }
+          ]
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "receive_whos_free_emails",
+          "admin_description": "Receive emails about openings when I'm free?",
+          "default_value": "true",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_vertical",
+          "caption": "Closer to the convention, {{ convention.name }} may notify attendees who are free in particular time slots, to promote events that need signups in order to run.  These notifications are to help avoid having to cancel events, and we encourage attendees to receive them, but you may choose to opt out if you wish.",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Receive notifications about events that need signups"
+            },
+            {
+              "value": "false",
+              "caption": "Opt out of these notifications"
+            }
+          ]
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "address",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Street address"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "city",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "City"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "state",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "State/province"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "zipcode",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "ZIP/postal code"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "country",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Country"
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "how_heard",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "How did you hear about {{ convention.name }}?"
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "mailing_lists",
+          "default_value": [
+            "intercon"
+          ],
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "checkbox_vertical",
+          "caption": "I would like to receive email about:",
+          "choices": [
+            {
+              "value": "intercon",
+              "caption": "Intercon"
+            },
+            {
+              "value": "nelco",
+              "caption": "NELCO"
+            },
+            {
+              "value": "neil_other",
+              "caption": "Other NEIL initiatives"
+            }
+          ]
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "vaccination_status",
+          "admin_description": "Vaccination Status",
+          "public_description": "Vaccination Status",
+          "visibility": "normal",
+          "writeability": "admin",
+          "style": "checkbox_vertical",
+          "caption": "COVID-19 Vaccination Status (Read-only)\n",
+          "choices": [
+            {
+              "value": "Verified",
+              "caption": "Verified"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Volunteer event form.json
+++ b/cms_content_sets/wanderlust/forms/Volunteer event form.json
@@ -1,0 +1,223 @@
+{
+  "title": "Volunteer event form",
+  "form_type": "event",
+  "sections": [
+    {
+      "title": "Event Properties",
+      "section_items": [
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "public_description": "Title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Title",
+          "required": true
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "public_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "registration_policy",
+          "identifier": "registration_policy",
+          "visibility": "normal",
+          "writeability": "normal",
+          "presets": [
+            {
+              "name": "Unlimited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "unlimited",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "signups",
+                    "name": "Signups",
+                    "description": "Signups for this event",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots for larps with NPCs",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "pcs",
+                    "name": "PC",
+                    "description": "Player characters",
+                    "slots_limited": true,
+                    "expose_attendees": true
+                  },
+                  {
+                    "key": "npcs",
+                    "name": "NPC",
+                    "description": "Non-player characters",
+                    "not_counted": true,
+                    "slots_limited": true,
+                    "expose_attendees": true
+                  }
+                ],
+                "prevent_no_preference_signups": true
+              }
+            },
+            {
+              "name": "Limited slots for horde larps",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "cast",
+                    "name": "Cast",
+                    "description": "Players who will have one character for the entire game",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "horde",
+                    "name": "Horde",
+                    "description": "Players who will be playing multiple characters over the course of the game",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited slots by gender (classic Intercon-style)",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "female",
+                    "name": "Female role",
+                    "description": "Female characters",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "male",
+                    "name": "Male role",
+                    "description": "Male characters",
+                    "slots_limited": true
+                  },
+                  {
+                    "key": "flex",
+                    "name": "Flex",
+                    "anything": true,
+                    "description": "Characters that are not strictly defined as male or female",
+                    "slots_limited": true
+                  }
+                ]
+              }
+            }
+          ],
+          "required": true,
+          "allow_custom": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Length of Each Run",
+          "required": true
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "mask_policy",
+          "public_description": "Mask Policy",
+          "default_value": "required",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_vertical",
+          "caption": "**Mask policy**",
+          "choices": [
+            {
+              "value": "required",
+              "caption": "Masks are required for all attendees"
+            }
+          ]
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "public_description": "Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the game. The description should be at least a couple of paragraphs, but can be as long as you like.<br>The game description is used to promote your game and attract players who will enjoy it. Be reasonably clear on where and when the game is set, and what the game is about. Let your players know what can they expect to be doing during the LARP, and make them excited to play your game! (We can offer suggestions if you would like advice on this.)<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "public_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the game to be used for the List of Events page and the\nconvention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "content_warnings",
+          "admin_description": "Player Visible Content Warnings",
+          "public_description": "Content Warnings",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "**Content Warnings**<br>Per NEIL policy, game descriptions must include either a content warning or an explicit statement that no content warnings are applicable. For more information, see the [NEIL policies <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](http://interactiveliterature.org/NEIL/communityPolicies.html#contentWarningsPolicy) page.<br>Please provide a content warning for your game.",
+          "required": false
+        },
+        {
+          "item_type": "age_restrictions",
+          "identifier": "age_restrictions",
+          "admin_description": "Player Visible Age Restrictions",
+          "public_description": "Age Restrictions",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "**Age Restrictions**<br>Please include the preferred ages of players for your larp. Examples are \"Players must be 18 or older\", or \"players under 16 must check with the GMs before playing\", to \"children at least [age] years old are welcome in this game\".",
+          "required": false
+        },
+        {
+          "item_type": "multiple_choice",
+          "identifier": "can_play_concurrently",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "radio_horizontal",
+          "caption": "Can this event be attended concurrently with other events?",
+          "choices": [
+            {
+              "value": "true",
+              "caption": "Yes"
+            },
+            {
+              "value": "false",
+              "caption": "No"
+            }
+          ],
+          "required": false
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/forms/Workshop proposal form.json
+++ b/cms_content_sets/wanderlust/forms/Workshop proposal form.json
@@ -1,0 +1,277 @@
+{
+  "title": "Workshop proposal form",
+  "form_type": "event_proposal",
+  "sections": [
+    {
+      "title": "Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "title",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 1,
+          "caption": "Workshop Title",
+          "required": true
+        },
+        {
+          "item_type": "event_email",
+          "identifier": "event_email",
+          "admin_description": "Event email",
+          "visibility": "normal",
+          "writeability": "normal",
+          "required": true
+        },
+        {
+          "item_type": "timespan",
+          "identifier": "length_seconds",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Event Length",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "description",
+          "admin_description": "Full Description",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 15,
+          "format": "markdown",
+          "caption": "**Description** for use on the {{ convention.name }} website. This information will be displayed on the page users see for the event. The description should be at least a couple of paragraphs, but can be as long as you like. This description is used to promote your presentation and attract attendees who will enjoy it.<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>\n",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "short_blurb",
+          "admin_description": "Short Blurb",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "format": "markdown",
+          "caption": "A **Short Blurb** (50 words or less) for the event to be used for the List of Events page and the\nconvention program. Information in the Short Blurb must also be present in the (full) description above!<br><small class=\"text-muted\">You must use Markdown for formatting. [A quick primer on Markdown syntax is available here. <i class='bi-box-arrow-up-right' aria-hidden='true'></i>](https://en.support.wordpress.com/markdown-quick-reference/)</small>",
+          "required": true
+        }
+      ]
+    },
+    {
+      "title": "Participant Counts",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This will be shown on the Public description of the event."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "{% include \"forum_registration_policy_instructions\" %}"
+        },
+        {
+          "item_type": "registration_policy",
+          "identifier": "registration_policy",
+          "admin_description": "Participant Slots",
+          "visibility": "normal",
+          "writeability": "normal",
+          "presets": [
+            {
+              "name": "Unlimited Interested Attendees",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "interested",
+                    "name": "Interested",
+                    "description": "I'm interested in attending! This will add this event to your con schedule. It will not count against the maximum signups allowed at this time, and will not prevent you from signing up for other events happening at the same time.",
+                    "not_counted": true,
+                    "slots_limited": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Limited Participants",
+              "policy": {
+                "buckets": [
+                  {
+                    "key": "participant",
+                    "name": "Participant",
+                    "description": "Sign up to participate in this session. This will add this event to your con schedule. It will not count against the maximum signups allowed at this time, and will not prevent you from signing up for other events happening at the same time.",
+                    "not_counted": true,
+                    "slots_limited": true
+                  }
+                ]
+              }
+            }
+          ],
+          "required": true,
+          "allow_custom": true
+        }
+      ]
+    },
+    {
+      "title": "Other Event Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Forum@Intercon staff."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "skills",
+          "admin_description": "Skills participants will develop",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "What are the skills that participants will develop in this workshop?",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "skills_background",
+          "admin_description": "Proposer's background with these skills",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "What is your background with these skills?<br><small>(We don't necessarily require professional qualifications; this is a hobbyist convention and we welcome interested hobbyists to share their skills!)</small>",
+          "required": true
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "equipment",
+          "admin_description": "Equipment",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Will you need any special equipment or space setup for this workshop?  If so, please tell us about it here.",
+          "required": false
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "participant_requirements",
+          "admin_description": "Will you need participants to bring anything for this workshop?",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Will you need participants to bring anything for this workshop?  (e.g. dancing shoes, projects they're working on, etc.)  If so, please tell us about it here.",
+          "required": false
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "other_staff_info",
+          "admin_description": "Other Info for the Staff",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "Please enter any additional information you wish to tell the Forum@Intercon staff.<br>This information will be shown only to the staff and will not be available publicly."
+        }
+      ]
+    },
+    {
+      "title": "Scheduling Information",
+      "section_items": [
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "subhead",
+          "content": "This information will only be used by the Forum@Intercon staff."
+        },
+        {
+          "item_type": "static_text",
+          "visibility": "normal",
+          "writeability": "normal",
+          "style": "normal",
+          "content": "<div class=\"alert alert-success\"><strong>New for Intercon T:</strong> we'll be offering Forum session slots throughout the weekend in addition to Thursday and Friday.  We'll prioritize filling Thursday and Friday, but also hope to have Forum content available during afternoon and evening weekend slots.</div>"
+        },
+        {
+          "item_type": "timeblock_preference",
+          "identifier": "timeblock_preferences",
+          "admin_description": "Timeblock Preferences",
+          "visibility": "normal",
+          "writeability": "normal",
+          "caption": "Please pick your top three preferences for when you'd like to run your event. Please also mark all times when you will not be available to run your event.",
+          "timeblocks": [
+            {
+              "label": "Morning",
+              "start": {
+                "hour": 9
+              },
+              "finish": {
+                "hour": 13
+              }
+            },
+            {
+              "label": "Afternoon",
+              "start": {
+                "hour": 14
+              },
+              "finish": {
+                "hour": 18
+              }
+            },
+            {
+              "label": "Evening",
+              "start": {
+                "hour": 20
+              },
+              "finish": {
+                "hour": 24
+              }
+            }
+          ],
+          "omit_timeblocks": [
+            {
+              "date": "2025-02-27",
+              "label": "Morning"
+            },
+            {
+              "date": "2025-02-27",
+              "label": "Afternoon"
+            }
+          ]
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "scheduling_constraints",
+          "admin_description": "Scheduling Constraints",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 4,
+          "caption": "If there are scheduling constraints on your event (for example, if are you proposing another event), or there are times your event cannot be scheduled, please discuss them here."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "space_requirements",
+          "admin_description": "Space Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Space Requirements** for your event."
+        },
+        {
+          "item_type": "free_text",
+          "identifier": "sound_requirements",
+          "admin_description": "Sound Requirements",
+          "visibility": "normal",
+          "writeability": "normal",
+          "lines": 2,
+          "caption": "Please list any **Sound Requirements** for your event.  If your event is going to be loud, or is going to run better in a quieter area, please let us know.  We run in shared space, with rooms near by each other, so perfect sound isolation is impossible, but we want to arrange events to not interfere with each other."
+        }
+      ]
+    }
+  ]
+}

--- a/cms_content_sets/wanderlust/graphql_queries/getBioEligibleUserConProfiles.graphql
+++ b/cms_content_sets/wanderlust/graphql_queries/getBioEligibleUserConProfiles.graphql
@@ -1,0 +1,29 @@
+---
+admin_notes: ''
+---
+query getBioEligibleUserConProfiles {
+  convention: conventionByRequestHost {
+    id
+    bio_eligible_user_con_profiles {
+      id
+      name_inverted
+      name_without_nickname
+      gravatar_url
+      bio_name
+      bio_html
+      
+      staff_positions {
+        id
+        name
+      }
+      
+      team_members {
+        id
+        event {
+          id
+          title
+        }
+      }
+    }
+  }
+}

--- a/cms_content_sets/wanderlust/graphql_queries/getEventsByCategory.graphql
+++ b/cms_content_sets/wanderlust/graphql_queries/getEventsByCategory.graphql
@@ -1,0 +1,35 @@
+---
+admin_notes: ''
+---
+query getEventsByCategory($categoryIds: [Int!]!) {
+  convention: conventionByRequestHost {
+    events_paginated(filters: {category: $categoryIds}, sort: {field: "first_scheduled_run_start", desc:false}) {
+      entries {
+        id
+        title
+        length_seconds
+        event_category {
+          name
+          team_member_name
+        }
+        runs {
+          id
+          starts_at
+          ends_at
+          rooms {
+            id
+            name
+          }
+        }
+        team_members {
+          id
+          display: display_team_member
+          user_con_profile {
+            id
+            name_without_nickname
+          }
+        }
+      }
+    }
+  }
+}

--- a/cms_content_sets/wanderlust/graphql_queries/getMeetups.graphql
+++ b/cms_content_sets/wanderlust/graphql_queries/getMeetups.graphql
@@ -1,0 +1,35 @@
+---
+admin_notes: ''
+---
+query getMeetups {
+  convention: conventionByRequestHost {
+    events_paginated(filters: {category: [517, 515]}, sort: {field: "first_scheduled_run_start", desc:false}) {
+      entries {
+        id
+        title
+        length_seconds
+        event_category {
+          name
+          team_member_name
+        }
+        runs {
+          id
+          starts_at
+          ends_at
+          rooms {
+            id
+            name
+          }
+        }
+        team_members {
+          id
+          display: display_team_member
+          user_con_profile {
+            id
+            name_without_nickname
+          }
+        }
+      }
+    }
+  }
+}

--- a/cms_content_sets/wanderlust/layouts/Auto Refresh Blank Page.liquid
+++ b/cms_content_sets/wanderlust/layouts/Auto Refresh Blank Page.liquid
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {{ content_for_head }}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Roboto+Condensed:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+    {% include "site-css" %}
+    <script type="text/javascript">
+        window.setTimeout(function () { window.location.reload(); }, 60 * 1000);
+    </script>
+    <style type="text/css">
+      body {
+        background: {{css_background_color}};
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container-fluid" style="flex-grow: 1">
+      {{ content_for_layout }}
+    </div>
+  </body>
+</html>

--- a/cms_content_sets/wanderlust/layouts/Intercon W Layout.liquid
+++ b/cms_content_sets/wanderlust/layouts/Intercon W Layout.liquid
@@ -1,0 +1,75 @@
+---
+navbar_classes: fixed-top navbar-expand-md mb-4 intercon-menubar navbar-dark
+admin_notes: ''
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {{ content_for_head }}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Advent+Pro:ital,wght@0,400;0,700;1,400;1,700&family=Lato:ital,wght@0,400;0,700;1,400;1,700&family=Poiret+One&display=swap" rel="stylesheet">
+    {% include "site-css" %}
+  </head>
+  <body>
+    <div id="center-column" class="background-content d-flex flex-column">
+      <div class="container bg-white flex-grow-1"></div>
+    </div>
+    <div class="overall d-flex flex-column">
+      {{ content_for_navbar }}
+      <div id="spacer" style="height: 70px"></div>
+
+      <div id='mainContent' class="container bg-white" style="flex-grow: 1">
+        {{ content_for_layout }}
+      </div>
+      
+      <div class="container bg-medium-gray d-none d-sm-block d-xs-block p-2 pt-4 footer">
+        {% include 'copyright' %}
+      </div>
+    </div>
+    <script>
+      function watchMenu(){
+        const elem = document.querySelector('.menu-header');
+        if (elem){
+          window.onscroll=function(){changeMenu()}
+        }
+      }
+      
+      function changeMenu(){
+        const elem = document.querySelector('.menu-header');
+        if (!elem) { return; }
+        const scrollBarPosition = window.pageYOffset | document.body.scrollTop;
+        if(scrollBarPosition < 72) {
+          elem.style.display = 'none';
+        } else {
+          elem.style.display = 'block';
+        }
+      }   
+
+      function addObserver(){
+        // Select the node that will be observed for mutations
+        var targetNode = document.querySelector('#mainContent');
+        if(!targetNode){
+          return setTimeout(addObserver, 100);
+        }
+        
+        // Options for the observer (which mutations to observe)
+        var config = { attributes: true, childList: true };
+        // Create an observer instance linked to the callback function
+        var observer = new MutationObserver(watchMenu);
+        // Start observing the target node for configured mutations
+        observer.observe(targetNode, config);
+      }
+  
+      function ready(fn) {
+        if (document.readyState != 'loading'){
+          fn();
+        } else {
+          document.addEventListener('DOMContentLoaded', fn);
+        }
+      }
+      
+      ready(addObserver);
+    </script>
+  </body>
+</html>

--- a/cms_content_sets/wanderlust/metadata.yml
+++ b/cms_content_sets/wanderlust/metadata.yml
@@ -1,0 +1,107 @@
+---
+inherit:
+- standard
+navigation_items:
+- item_type: section
+  title: Programming
+  navigation_links:
+  - item_type: link
+    title: Iron GM
+    page_slug: irongm
+  - item_type: link
+    title: Forum@Intercon
+    page_slug: forum
+  - item_type: link
+    title: Boardgames
+    page_slug: boardgames
+  - item_type: link
+    title: Social Events
+    page_slug: social
+  - item_type: link
+    title: Vendors
+    page_slug: vendors-at-intercon
+- item_type: section
+  title: Resources
+  navigation_links:
+  - item_type: link
+    title: Intercon for Beginners
+    page_slug: beginners
+  - item_type: link
+    title: Larp Glossary
+    page_slug: glossary
+  - item_type: link
+    title: Signing Up for Games
+    page_slug: signupfaq
+  - item_type: link
+    title: GM Benefits and Policies
+    page_slug: gmpolicies
+  - item_type: link
+    title: GM Accessibility Guide
+    page_slug: accessibility/gm
+  - item_type: link
+    title: Vending at Intercon
+    page_slug: vending-at-intercon
+  - item_type: link
+    title: Statement - Challenging Content
+    page_slug: statements/challenging-content
+  - item_type: link
+    title: Statement - Queer/Polyamorous Content
+    page_slug: statements/queer-content
+- item_type: section
+  title: About
+  navigation_links:
+  - item_type: link
+    title: Convention Rules
+    page_slug: rules
+  - item_type: link
+    title: Convention Contacts
+    page_slug: contacts
+  - item_type: link
+    title: What Does It Cost?
+    page_slug: pricing
+  - item_type: link
+    title: Hotel Info
+    page_slug: hotel
+  - item_type: link
+    title: Food at Intercon
+    page_slug: food
+  - item_type: link
+    title: Accessibility
+    page_slug: acessibility
+  - item_type: link
+    title: Staff Role Descriptions
+    page_slug: role-descriptions
+  - item_type: link
+    title: Staff and GM Bios
+    page_slug: bios
+  - item_type: link
+    title: Volunteering
+    page_slug: volunteering
+  - item_type: link
+    title: Intercon Calendar
+    page_slug: calendar
+- item_type: link
+  title: COVID FAQ
+  page_slug: covid
+root_page_slug: root
+default_layout_name: Intercon W Layout
+variables:
+  con_theme: Wanderlust
+  con_title: Wanderlust
+  convention_number: twenty-sixth
+  css_background_color: rgba(203, 195, 133, 0.3)
+  css_background_color_2: rgba(135, 156, 125, 0.99)
+  css_backup: rgba(203, 195, 133, 1)
+  css_color_1: "#fbd499"
+  css_color_2: "#f6c25d"
+  css_color_3: "#a52b36"
+  css_header_text_color: "#a52b36"
+  discord_invite: YZ2VyFGrtD
+  hotel_block_code: LAR
+  hotel_double_rate: 157
+  hotel_king_rate: 157
+  propcom_form: https://docs.google.com/forms/d/e/1FAIpQLSe1aCqgtJPYb-VFZJNoF-XDGFi0HDs54gDBqwcH-SNmWGQnmg/viewform
+  shirt_order_deadline: January 19th, 2025
+  show_games_with_openings: false
+  show_run_list: new
+  vendor_deadline: January 26th, 2025

--- a/cms_content_sets/wanderlust/notification_templates/signups/new_signup.liquid
+++ b/cms_content_sets/wanderlust/notification_templates/signups/new_signup.liquid
@@ -1,0 +1,56 @@
+---
+subject: "[{{ convention.name }}: {{ signup.event.title }}] Signup: {{ signup.user_con_profile.name
+  }}"
+body_text: |-
+  {%- assign run = signup.run -%}
+  New signup for {% include 'run_description' %}
+
+  {{ signup.user_con_profile.name }} has signed up for {% include 'run_description' %}. They are currently
+  {%- if signup.bucket %} {{ signup.state }} in the {{ signup.bucket.name }}
+    {%- if signup.requested_bucket %} bucket.
+    {%- else %} bucket (but have no bucket preference).
+    {%- endif -%}
+  {%- else -%}
+    {{ signup.state }}.
+  {%- endif %}
+
+  As of this signup, this event run has:
+  {{ run.signup_count_description | newline_to_br }}
+body_sms: |-
+  {%- assign run = signup.run -%}
+  {{ signup.user_con_profile.name }} has signed up for {% include 'run_description' %}. They are currently
+  {%- if signup.bucket %} {{ signup.state }} in the {{ signup.bucket.name }}
+    {%- if signup.requested_bucket %} bucket.
+    {%- else %} bucket (but have no bucket preference).
+    {%- endif -%}
+  {%- else %} {{ signup.state }}.
+  {%- endif %}
+
+  As of this signup, this event run has:
+  {{ run.signup_count_description | newline_to_br }}
+---
+{% assign run = signup.run %}
+<h1>New signup for {% include 'run_description' %}</h1>
+
+<p>
+  <a href="mailto:{{ signup.user_con_profile.email }}">{{ signup.user_con_profile.name }}</a>
+  has signed up for
+  {% include 'run_description' %}.
+  They are currently
+  {% if signup.bucket %}
+    {{ signup.state }} in the {{ signup.bucket.name }}
+    {% if signup.requested_bucket %}
+      bucket.
+    {% else %}
+      bucket (but have no bucket preference).
+    {% endif %}
+  {% else %}
+    {{ signup.state }}.
+  {% endif %}
+</p>
+
+<p>
+  As of this signup, this event run has:
+  <br>
+  {{ run.signup_count_description | newline_to_br }}
+</p>

--- a/cms_content_sets/wanderlust/notification_templates/signups/signup_confirmation.liquid
+++ b/cms_content_sets/wanderlust/notification_templates/signups/signup_confirmation.liquid
@@ -1,0 +1,73 @@
+---
+subject: |-
+  [{{ convention.name }}: {{ signup.event.title }}]
+  {%- if signup.state == "waitlisted" %} Waitlist
+  {%- else -%}
+    {%- if signup.team_member? %} {{ signup.event.team_member_name }}
+    {%- elsif signup.bucket.name -%}
+      {%- if signup.bucket.name != 'Signups' -%}
+        {%- if signup.bucket.name != 'Interested' %} {{ signup.bucket.name }}{% endif -%}
+      {%- endif -%}
+    {%- endif %} Signup
+  {%- endif -%}
+body_text: |-
+  {%- assign run = signup.run -%}
+  {% if signup.state == "waitlisted"%}Waitlist{% else %}Signup{% endif %} confirmation for {% include 'run_description' %}
+
+  This message is to confirm that you've successfully
+  {%- if signup.state == "waitlisted" %} joined the waitlist for
+  {%- else %} signed up for
+  {%- endif %} {% include 'run_description' %}.
+
+  Your new signup:
+  {{ signup.starts_at | date: "%a %l:%M%P" }} - {{ signup.ends_at | date: "%l:%M%P" }}: {{ signup.run.room_names | join: ', ' }}
+  {{ signup.event.event_category.name | replace: "_", " " | humanize}}: {{ signup.event.title }}
+  {%- if signup.state != 'confirmed' %} [{{ signup.state | capitalize }}]{% endif -%}
+  {%- if signup.team_member? %} [{{ signup.event.team_member_name }}]
+  {%- elsif signup.bucket.name -%}
+    {%- if signup.bucket.name != 'Signups' -%}
+      {%- if signup.bucket.name != 'Interested' %} [{{ signup.bucket.name }}]{% endif -%}
+    {%- endif -%}
+  {%- endif %}
+  {{ signup.event_url | absolute_url }}
+---
+
+{% assign run = signup.run %}
+<h1>{% if signup.state == "waitlisted"%}Waitlist{% else %}Signup{% endif %} confirmation for {% include 'run_description' %}</h1>
+
+<p>
+  This message is to confirm that you've successfully
+  {%- if signup.state == "waitlisted" %} joined the waitlist for
+  {%- else %} signed up for
+  {%- endif %}
+  {% include 'run_description' %}.
+</p>
+
+<div style="border: 1px black solid; border-radius: 5px;">
+  <div style="background-color: black; padding: 10px; color: white; font-weight: bold;">
+    Your new signup
+  </div>
+  <div style="padding: 10px;">
+    <strong>
+      {{ signup.starts_at | date: "%a %l:%M%P" }} - {{ signup.ends_at | date: "%l:%M%P" }}:
+      {{ signup.run.room_names | join: ', ' }}
+    </strong>
+    <br>
+    {{ signup.event.event_category.name | replace: "_", " " | humanize}}:&nbsp;
+    <strong>
+      <a href="{{ signup.event_url | absolute_url }}">{{ signup.event.title }}</a>
+    </strong>
+    {% if signup.state != 'confirmed' %}
+      &nbsp;[{{ signup.state | capitalize }}]
+    {% endif %}
+    {% if signup.team_member? %}
+      &nbsp;[{{ signup.event.team_member_name }}]
+    {% elsif signup.bucket.name %}
+      {% if signup.bucket.name != 'Signups' %}
+        {% if signup.bucket.name != 'Interested' %}
+          &nbsp;[{{ signup.bucket.name }}]
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  </div>
+</li>

--- a/cms_content_sets/wanderlust/pages/about.liquid
+++ b/cms_content_sets/wanderlust/pages/about.liquid
@@ -1,0 +1,52 @@
+---
+name: About
+admin_notes: Landing Page
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">About Intercon</h1>
+
+<table style="width: 100%; max-width: 800px">
+  <tr>
+    <td valign="top">
+      <h2 class="my-3">Attendee Info</h2>
+
+      <ul>
+        <li><a href="{% page_url aboutintercon %}">About Intercon, NEIL, and LARPA</a></li>
+        <li><a href="{% page_url signupfaq %}">Signing up for Games</a></li>
+        <li><a href="{% page_url hotel %}">Hotel Information</a></li>
+        <li><a href="{% page_url rules %}">Convention Rules</a></li>
+        <li><a href="{% page_url aboutlarp %}">About LARP</a></li>
+      </ul>
+    </td>
+    <td valign="top">
+      <h2 class="my-3">Getting Involved</h2>
+
+      <ul>
+        <li><a href="{% page_url volunteering %}">Volunteering</a></li>
+        <li><a href="{% page_url new-proposal%}">Proposing an Event</a></li>
+        <li><a href="{% page_url gmpolicies %}">GM Benefits, Policies and Services</a></li>
+        <li><a href="{% page_url concom-schedule %}">ConCom Schedule</a></li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <h2 class="my-3">People</h2>
+
+      <ul>
+        <li><a href="{% page_url contacts %}">Contact us</a></li>
+        <li><a href="{% page_url bios %}">GM and Staff Bios</a></li>
+      </ul>
+    </td>
+    <td valign="top">
+      <h2 class="my-3">Special Events at Intercon</h2>
+
+      <ul>
+        <li><a href="{% page_url social %}">Social Events</a></li>
+        <li><a href="{% page_url panels %}">Workshops and Panels</a></li>
+        <li><a href="{% page_url irongm %}">Iron GM Competition</a></li>
+      </ul>
+    </td>
+  </tr>
+</table>

--- a/cms_content_sets/wanderlust/pages/aboutintercon.liquid
+++ b/cms_content_sets/wanderlust/pages/aboutintercon.liquid
@@ -1,0 +1,28 @@
+---
+name: About Intercon
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">About Intercon</h1>
+<h2 class="my-3">What is Intercon?</h2>
+Intercon is the biggest all-LARP convention in the New England area.  It is
+run by <a href="http://www.interactiveliterature.org">New
+England Interactive Literature</a>,
+an organization that exists to promote live action roleplaying in New England and beyond.
+
+<h2 class="my-3">I have heard of other Intercons, what's the deal with that?</h2>
+<p>You may have heard of Intercons such as Intercon Mid-Atlantic, and
+Intercon NorthEasts, and even Intercons with numbers after them.  Those are
+Intercons that happened outside the New England area.  They were loads of
+fun, but sadly, all of them are currently defunct.
+
+</p>
+<h2 class="my-3">Who is New England Interactive Literature (NEIL)?</h2>
+<p><a href="http://www.interactiveliterature.org">New England Interactive
+Literature</a> (NEIL) is the
+group of volunteers that brings you the New England Intercons.
+
+</p><h2 class="my-3">Who is LARPA?</h2>
+<p>The Live Action RolePlayers Association (LARPA) owns the Intercon
+trademark.</p>

--- a/cms_content_sets/wanderlust/pages/aboutlarp.liquid
+++ b/cms_content_sets/wanderlust/pages/aboutlarp.liquid
@@ -1,0 +1,57 @@
+---
+name: About Larp
+admin_notes: REVIEW
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h2 class="my-3">What is Larp?</h2>
+<p><b>LARP</b> (now usually written as 'larp') stands for <b>L</b>ive <b>A</b>ction <b>R</b>ole <b>P</b>laying.
+That's what most Larpers will agree on. It is interactive improvisation
+between people who are each playing a persona. After that, ask ten different
+Larpers what they think Larp is, and you may get twelve or thirteen different
+answers!
+</p><p>That's because there are all sorts of games and players. Larp is not
+solely
+medieval fantasy games, or dark games filled with vampires, or mysteries
+where
+everyone tries to find out who did it, or games where people wear armor and
+beat
+on each other with padded weapons, or...
+</p><p>Larp is all of these, and more.
+</p><p>There are some things in common amongst all of these games. Everyone at
+the
+game comes in character. You play a role, like the Russian ambassador to
+Germany, the drummer from the band <i>Toxic Waste</i>, or the doctor on
+board a
+luxury starliner. For the duration of the game, you dress, speak, act and
+live
+the part. You've got an agenda for the game - a list of things that you must
+accomplish. Some tasks are easy, some things are hard. Some players may be
+working towards the same goals as you, while others may be working against
+you.
+</p><p>There's no script. You improvise all your lines. You don't operate in a
+vacuum, because you have a character description, a background history of
+who
+you're trying to be.
+</p><p>You're also not alone. Games can be small, with only a few characters,
+they
+can be large, with upwards of sixty or seventy players, or they can be huge.
+Games can last a few minutes, four, six, or eight hours, an entire weekend,
+or even longer, played in several sessions. A good Larp can be an amazing
+experience and incredibly fun to play.
+</p>
+<h2 class="my-3">Why Larp?</h2>
+<p>
+  Because it's fun! People roleplay for a whole number of reasons.
+Some for escapism because it's lots of fun to be someone else for a few
+hours or a few days at a time, for the social aspects of the game and the
+opportunity to meet new people, and for the pure exhilaration of letting your
+mind run wild in a world of complete fantasy. Some players of LC style games
+like the opportunity to get away from their desks and do something physical
+in the fresh air.
+
+</p>
+<h2 class="my-3">I play tabletop role playing games, is this similar?</h2>
+<p>Yes, there are many similarities, but there are also many differences.
+In a tabletop game you describe what your character is doing, but in a
+Live Action game you do the actions your character does.</p>

--- a/cms_content_sets/wanderlust/pages/accessibility/gm.liquid
+++ b/cms_content_sets/wanderlust/pages/accessibility/gm.liquid
@@ -1,0 +1,104 @@
+---
+name: Accessibility for GMs
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class='my-3'>Intercon GM Accessibility Guide</h1>
+
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>GM Accessibility Guide</h4>
+      </li>
+      <li class="toc-entry"><a href="#introduction">Introduction</a>
+      <li class="toc-entry"><a href="#tips">Tips for Accessability</a>
+        <ul>
+        <li class="toc-entry"><a href="#tips-physical">Physical Exertion</a></li>
+        <li class="toc-entry"><a href="#tips-common">Common Needs</a></li>
+		<li class="toc-entry"><a href="#tips-advance">In Advance</a></li>
+        <li class="toc-entry"><a href="#tips-reading">Expected Reading</a></li>
+        <li class="toc-entry"><a href="#tips-seating">Seating</a></li>
+        <li class="toc-entry"><a href="#tips-safety">Safety Mechanics</a></li>
+        <li class="toc-entry"><a href="#tips-lighting">Dim Lighting</a></li>
+        <li class="toc-entry"><a href="#tips-costuming">Costuming</a></li>
+        <li class="toc-entry"><a href="#tips-color">Color-coding</a></li>
+        <li class="toc-entry"><a href="#tips-effects">Special Effects</a></li>
+      </ul></li>
+      <li class="toc-entry"><a href="#other">Other Items</a></li>
+      <li class="toc-entry"><a href="#resources">Other Resources</a></li>
+</ul>
+</div>
+<div class='col'>
+
+<h2 class="my-3"><a name='introduction'>Introduction</a></h2>
+<p class='lead'>If you’re reading this, then you are thinking of or have signed up to run a LARP at Intercon. Thank you for doing that because Intercon would not be possible without your efforts! The purpose of this document is to provide you with some ideas regarding the topic of accessibility. This document was written by members of Intercon’s Accessibility Team, which includes LARPers with varying disabilities and health conditions.</p>
+
+<p>In order for Intercon to be welcoming to the widest possible range of players, GMs are strongly encouraged to incorporate accessibility considerations into their game planning, recruitment, and player communications. Accessibility, in this context, means providing for the needs of players of all levels of ability. This might seem like a lofty or even daunting goal, but in most cases, accommodating a particular physical, emotional, or sensory need is possible with relatively minor adjustments to your game. If accommodating a particular player is not possible, then communicating openly and honestly about that is the best thing to do. This way, expectations are set and that player can find another game that will work for them.</p>
+<hr>
+<h2 class="my-3"><a name='tips'>Tips for Accessability</a></h2>
+<p>Below are some generalized tips for making your LARP more accessible. Remember that improving accessibility is an ongoing process. The Intercon Accessibility Team asks for effort and open-mindedness, not perfection.</p>
+
+<ul>
+<li><a name='tips-physical'><strong>Physical exertion:</strong></a> All games require different levels of physical exertion. Be as clear as you can about expectations of physical activities in your game description. Furthermore, consider if any of them can be made opt-in, or if only part of the cast needs to do them—in which case, you can ask on your survey who does and doesn’t want to participate in the physical activity.</li></p>
+
+<li><a name='tips-common'><strong>Common and/or straightforward accessibility needs:</strong></a> This is a list of common accessibility needs. You may want to think of how they might affect players in your game, be transparent in your content advisory, proactively plan to accommodate them, etc.
+  <ul type=a class="mb-2">
+  <li>Sensitivity to loud noises, crowding, smells, or other sensory inputs.</li>
+  <li>Difficulty hearing (similar sounding character names, loud spaces, etc).</li>
+  <li>Difficulty walking and/or standing for periods (which could be as little as a couple minutes).</li>
+  <li>Difficulty sitting/being on the floor, or rapidly shifting between floor and standing.</li>
+  <li>Difficulty running, jumping, bending over, or other ways one might move around quickly.</li>
+  <li>Use of a mobility device such as a cane, walker, or wheelchair.</li>
+  <li>Limited vision (particularly in dim light).</li>
+  <li>Difficulty reading lengthy texts quickly.</li>
+  <li>Colorblindness.</li>
+  <li>Difficulty with eye contact.</li>
+  <li>Touch-sensitivity (whether with anyone or just unfamiliar people).</li>
+  <li>A need for rest breaks from game.</li>
+  </ul>
+</li>
+
+<li><a name='tips-advance'><strong>In Advance:</strong></a> Ask about your players’ needs. The best way to open that line of communication in most cases is via the casting survey, with an invitation to players to follow up by email, chat, or voice. For example a GM might write, “This game includes a scene of 5-10 minutes set in complete darkness. If this is going to be problematic, we can instead simply have dim lighting during this scene.” Then, your survey can have radio buttons indicating: (Y) I’m okay with the scene as-is OR (N) I need dim lighting rather than complete darkness OR (O) Other - with a space to input a player's own response.</p>
+
+<p>Many GMs have an open question at the end of their surveys, which will often be something like, “Is there anything else you want the GMs to know in casting you?” However, you will get the best responses if you make it clear that you are inviting players to speak up about their accessibility needs. Disabled people are used to having our needs and concerns ignored or downplayed by the abled world, especially if we haven’t been specifically invited to share them. A better phrasing might be, “Players have a diverse range of needs and preferences. Please tell us anything else we can do to make playing this game a comfortable and welcoming experience for you.”</p>
+
+<p>If your game does not utilize a casting survey, but still has players sign up to play well ahead of the con, then simply emailing them to discuss the game’s requirements can facilitate the necessary conversations. On the other hand, if you are adding multiple players at the last minute—a possibility even for games that do try to cast ahead of time—then thinking about accessibility ahead of time is still the best way to make people feel welcome.</p></li>
+
+<li><a name='tips-reading'><strong>Expected Reading:</strong></a> You should communicate the expected amount of required reading. Make sure to distinguish between what is sent ahead of the game as opposed to during the game.</p>
+
+<p>Of the material sent out ahead of a game, typically players will only expect to fully memorize around a third of a page: their own name and culture, a few important facts or background events, and the names of a few other characters. The rest of it they will usually read and internalize the gist of, but not necessarily the details. Players will often want to be able to consult their materials after the game begins, either in print or via smartphone.
+If someone requests it, and it is feasible for you and/or your team, you may wish to consider offering texts in another format, such as pre-recorded audio or large-print text.</p></li>
+
+<li><a name='tips-seating'><strong>Seating:</strong></a> Offer places to sit! Often the default mode for non-combat LARPs is “people standing around and talking,” but this does not work well for many people with a variety of impairments. If meaningful in-game interaction can be had while standing, chances are very good that those same interactions can happen with some or all of the participants sitting down. Be sure to request an appropriate amount of chairs, once the Intercon GM Coordinator sends you the furniture request form.</p></li>
+
+<li><a name='tips-safety'><strong>Safety Mechanics:</strong></a> You may want to have safety mechanics like Look Down (hand shading eyes to indicate they are OOG) and The Door is Always Open (players can leave at any time for any reason) to give players explicit permission to address their own needs.</p></li>
+
+<li><a name='tips-lighting'><strong>Dim Lighting:</strong></a> Dim light and small fonts (or really any reading at all) is a bad combination! Even for people without particularly limited eyesight, this is often a problem in LARPs. Dim lighting is important for the atmosphere in many cases, but should be forecasted and you should consider accommodations for limited eyesite. Consider small inexpensive handheld flashlights, for reading text.</p>
+
+<p>When formatting text to be read in dim light, consider making use of larger fonts, and bolding important words, especially character names.</p></li>
+
+<li><a name='tips-costuming'><strong>Costuming Expectations:</strong> Be clear to your players on what your costuming expectations are for your game. For GMs new to Intercon, it’s important to note that some players may not costume for games as people don’t have access to the same resources, clothing for all types of bodies is not equally available, or the energy to commit to costuming. You can potentially help by organizing costume borrowing for your game and/or having a few pieces readily available to players at the start of the game.</p></li>
+
+<li><a name='tips-color'><strong>Color-coding:</strong> If puzzle elements or faction costuming is color coded, it can help to include symbols that distinguish those things for players who have difficulty distinguishing particular colors. Also, consider using an accessible color palette.</p></li>
+
+<li><a name='tips-effects'><strong>Special Effects:</strong> You must clearly mention any strobing light effects. We discourage strong or lingering scents at Intercon games, due to concerns of potential sensitivities or allergies, as well as consideration for the people who will be in the space after you.</p></li>
+</ul>
+<hr>
+<h2 class="my-3"><a name='other'>Other Items</a></h2>
+<p>There’s no way to put together a comprehensive list of all possible accessibility-related needs you may encounter as an Intercon GM! If you have questions or concerns, please reach out to the {{convention.staff_positions_by_name.accessibility_coordinator.name_with_email_link}}. This also applies if you yourself as a GM have access needs that you would like help figuring out. We will be happy to answer any questions and work with you on any accessibility needs.</p>
+
+<p>One final piece of advice: solicit feedback! No matter how much you plan ahead, finding out how things actually went during the game is important. Maintaining an attitude of openness to improvement (in general and in terms of accessibility specifically) will go a long way towards helping players feel safe and included in games that you run.</p>
+<hr>  
+<h2 class="my-3"><a name='resources'>Other Resources From Around the Web</a></h2>
+<p>Several of the sources below were consulted in the course of writing and revising this document, so they may contain information that is redundant with the tips offered here. We provide the links in the spirit of academic honesty, as well as for those who may wish to read other perspectives or dig deeper on this topic.</p>
+
+<ul class='list-unstyled'>
+<li><a href="https://accesslarp.wordpress.com/">Access: LARP</a></li>
+<li><a href="https://venngage.com/tools/accessible-color-palette-generator">Accessible Color Palettes</a></li>
+<li><a href="https://calliopegames.com/9699/accomodations-for-color-blind-players/">Making Board Games Accessible to Players With Color-Blindness</a></li>
+<li><a href="https://guardup.com/how-to-make-a-larp-accessible/">How to Make a LARP Accessible</a></li>
+<li><a href="https://pseudodeviant.wordpress.com/2016/08/18/making-larp-more-acessible/">Making LARP More Accessible</a></li>
+</ul>
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/acessibility.liquid
+++ b/cms_content_sets/wanderlust/pages/acessibility.liquid
@@ -1,0 +1,43 @@
+---
+name: Accessibility
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class='my-3'>Accessibility at Intercon</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Accessibility</h4>
+      </li>
+      <li class="toc-entry"><a href="#intro">Introduction</a></li>
+      <li class="toc-entry"><a href="#resources">Resources</a></li>
+  </ul>
+</div>
+<div class='col'>
+
+<h2 class="my-3"><a name='intro'>Introduction</a></h2>
+<p class="lead">
+  {{convention.name}} is committed to inclusion for LARPers from all backgrounds and with a diverse array of needs.  
+</p>
+<p>
+  Improvements that we have made include several resource documents, improved signage, and the creation of a quiet room.
+</p>
+<p>
+  On this page, the Intercon Accessibility team has provided several resources for attendees and GMs that we hope will be useful.
+We want to hear from you! If you have feedback for us about accommodations or access needs at Intercon, please email the {{convention.staff_positions_by_name.accessibility_coordinator.name_with_email_link}}.
+</p>
+  <hr>
+<h2 class="my-3"><a name='resources'>Resources</a></h2>
+<div class='row'>
+
+<div class='col-md-6'>
+  <div class='list-group'>
+<a class='list-group-item list-group-item-action' href={%page_url "beginners" %}><i class="bi bi-file-text"></i> Intercon Beginners Guide</a>
+<a class='list-group-item list-group-item-action' href={%page_url "accessibility/gm" %}><i class="bi bi-file-text"></i> GM Accessibility Guide</a>
+</div>
+</div>
+</div>
+  
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/badgestore.liquid
+++ b/cms_content_sets/wanderlust/pages/badgestore.liquid
@@ -1,0 +1,36 @@
+---
+name: Badge Store
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: true
+---
+{% assign products = convention.available_products|sort: "name" %}
+<h1 class="my-3">{{convention.name}} Products</h1>
+
+<div class="alert alert-warning col-md-10 offset-md-1" role="alert">
+  <i class="bi-exclamation-triangle-fill" aria-hidden="true"></i> The deadline for all orders is {{shirt_order_deadline}}.
+</div>
+<div class="container mt-3">
+  <div class="row ">
+    <div class="card-deck d-flex align-items-stretch">
+      {% for product in products %}
+        {% unless product.name contains 'Staff' or product.provides_ticket_type %}
+          <div class="card mb-4" style="min-width: 18rem; ">
+            
+            <div class="card-body">
+              <h5 class="card-title">{{product.name}}</h5>
+              <p class="card-text">{{product.description}}</p>
+              </div>
+
+              <div class="card-footer">
+                <span class="align-middle" style="font-size:1.6em">{{product.price}}</span>
+                <a role="button" class="btn btn-primary float-end" href="{{product.url}}">Purchase</a>
+            </div>
+          </div>
+        {% endunless %}
+      {% endfor %}
+    </div>
+  </div>
+</div>
+
+ 

--- a/cms_content_sets/wanderlust/pages/beginners.liquid
+++ b/cms_content_sets/wanderlust/pages/beginners.liquid
@@ -1,0 +1,186 @@
+---
+name: Intercon for Beginners
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">Intercon for Beginners</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Intercon for Beginners</h4>
+      </li>
+      <li class="toc-entry"><a href="#intro">Introduction</a></li>
+      <li class="toc-entry"><a href="#signups">Signups</a>
+        <ul>
+          <li class="toc-entry"><a href="#signups-waitlist">Getting waitlisted</a></li>
+          <li class="toc-entry"><a href="#signups-pacing">Pacing yourself</a></li>
+        </ul>
+      </li>
+      <li class="toc-entry"><a href="#before">Before the con</a>
+        <ul>
+          <li class="toc-entry"><a href="#before-characters">Characters</a></li>    
+          <li class="toc-entry"><a href="#before-hotel">Staying at Intercon</a></li>
+          <li class="toc-entry"><a href="#before-packing">Packing for Intercon</a>
+            <ul>
+              <li class="toc-entry"><a href="#before-packing-costuming">Costuming</a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li class="toc-entry"><a href="#atcon">At the con</a>
+        <ul>
+          <li class="toc-entry"><a href="#atcon-checkin">Staying at Intercon</a></li>
+          <li class="toc-entry"><a href="#atcon-larps">Attend larps</a></li>
+          <li class="toc-entry"><a href="#atcon-fillin">Filling in last minute</a></li>
+          <li class="toc-entry"><a href="#atcon-between">Between games</a></li>
+          <li class="toc-entry"><a href="#atcon-takecare">Take care of yourself</a></li>
+          <li class="toc-entry"><a href="#atcon-help">Where to get help</a></li>
+        </ul>
+      </li>
+</ul>
+</div>
+<div class='col'>
+
+<h2 class="my-3"><a name='intro'>Introduction</a></h2>
+<p class="lead">
+  Intercon is exciting and can also be confusing / overwhelming. We’ve put together some information about what to expect. This covers both before the convention and once you arrive so that the overall experience is more approachable for newcomers or anyone who hasn’t attended in a while.
+</p>
+<hr>
+<h2 class="my-3"><a name='signups'>Signups</a></h2>
+<p>
+  Signups happen in a few rounds before the convention. <a href="{% page_url signupfaq %}">More detail can be found in the Signup FAQ</a>.
+</p>
+<h3 class="my-2"><a name='signups-waitlist'>If you are placed on a waitlist</a></h3>
+<p>
+  If you are placed on a waitlist, particularly if you are in the first few waitlist slots and in a larger game, there is a fair chance you’ll get into the game with last-minute drops. It’s a good idea to show up for the game at its scheduled time in case you’ll be filling in, even if you haven’t heard from the GMs yet. Showing up in neutral or black clothing can be helpful if you don’t know about the role you’ll get at the last minute. People will understand that you had limited time to costume.
+</p>
+<h3 class="my-2"><a name='signups-pacing'>Pacing yourself</a></h3>
+<p>
+  Some people like to have a packed schedule, but that can also be tiring. If you end up not getting into a game during a particular time slot, that can be a good opportunity for socializing, napping, hydrating, eating snacks, or preparing for another game you have coming up. Some games run fairly late at night, and sometimes people socialize fairly late after games. Choosing some deliberate downtime or planning not to have both a late game and an early morning game can be part of pacing yourself. Remember to do self-care and rest!
+</p>
+<hr>
+<h2 class="my-3"><a name='before'>Before the con</a></h2>
+<h3 class="my-2"><a name='before-characters'>Creating, choosing, or being assigned to characters</a></h3>
+<p>
+  There are a variety of types of larps at Intercon. For more information on different genres of larp, check out our more general How to larp for Beginners document. (coming soon) 
+</p>
+<p>
+  For many games at Intercon, character descriptions have been created by the authors and will be assigned to players - this is called “casting” players, just as one would cast actors for certain roles in a play. Many games at Intercon cast players in character roles ahead of time so that players can read information about the characters and prepare costuming. Casting is done based on casting surveys. These questionnaires are designed to  indicate what players are interested in seeking out or avoiding so the GMs can assign a character that’s a good fit. One common example is asking players whether there are particular content/warnings they want to play on or not play on.
+</p>
+<p>
+  If you receive a casting survey for a game you’re in, it’s important to fill that out before the deadline so the GMs can match players to characters and distribute character sheets in a timely fashion. Some GMs send an initial short character description or “costuming hint” earlier on before sending longer written materials so that players will have more time to prepare costumes.
+</p>
+<p>
+  Casting surveys and character information are sent to the email address you register with on the Intercon website. Try not to miss those emails! If you’re expecting a survey and it hasn’t arrived, check your Spam folder. GMs may also post on the unofficial Facebook group and/or Discord site when they distribute player surveys.
+</p>
+<p>
+  For some games, players create their own characters ahead of time by communicating with the people running the game. For others, characters are created together with other players at the start of the game’s time slot in a process called Workshopping. If a game is described as “casting at the door”, this means that pre-written characters will be distributed to players when they arrive at the game location at the time the game is scheduled.
+</p>
+<h3 class="my-2"><a name='before-hotel'>Arranging travel plans for spending the night</a></h3>
+<p>
+  Most participants in the convention spend the night at the hotel - some games take place late at night or early in the morning, and it can be convenient to have a room to leave your luggage in and get changed in. If you do not stay at the hotel, you’ll still be able to change costumes in the hotel bathrooms. More information about making your resevervation is available on the <a href="{%page_url hotel%}">Hotel Info Page</a>.
+</p>
+<h3 class="my-2"><a name='before-packing'>Packing for Intercon</a></h3>
+<p>
+  Not every game at Intercon involves costuming, but many games have costuming suggestions, so you may wish to plan for costuming luggage space.
+</p>
+
+<h4 class="my-2"><a name='before-packing-costuming'>What should I wear to an Intercon game?</a></h4>
+<p>
+  At intercon games, you will see attendees wearing a range of costumes. Unless otherwise specified in a game, there are no costuming requirements for larps at the con. You do not need to go to great effort or financial expenditure to play and enjoy games at Intercon. Street clothes are fine, and all black clothes, if you have them, are a safe bet for any game. If you're in doubt about what would fit in, you can also ask the GM(s)!  You can find an email to reach the GM on the event page, or if that isn't working by contacting the {{convention.staff_positions_by_name.attendee_coordinator.name_with_email_link}}.
+</p>
+
+<p>
+  The general range of what you'll see players show up to games at the con is listed below:
+  <ol>
+    <li>Street clothes.</li>
+    <li>All black clothes, like a theater stagehand; might be referred to as “blacks”</li>
+    <li>One or two accessories in theme with the game.</li>
+    <li>Full costumes at the level one might see at a ren faire or con with cosplay.</li>
+    <li>High effort pieces like hoop skirts, armor, glowing wire, wings, etc.</li>
+  </ol>
+</p>
+<p>
+  Anything from 1-5 is fine in any game, unless the game calls out a specific expectation, such as if the game is set at a Venetian masquerade ball and specifies that masks or face paint is required.  In these cases, the expectation is that the GMs will be providing the required items.
+</p>
+<p>
+  Larger, longer games that take place in rich settings, such as high fantasy or historical courts or cyberpunk futures, are likely to have more players in the 3-5 range. In shorter games that are more concept or horde focused, players will more often be in the 1-3+ range.  
+</p>
+<hr>
+<h2 class="my-3"><a name='atcon'>At the con</a></h2>
+<h3 class="my-2"><a name='atcon-checkin'>Checking in at the convention</a></h3>
+<p>
+  When you arrive, visit the operations(ops) / registration desk, where you’ll receive your convention badge, and information like a schedule printout and <a href="{% page_url "hotel/layout" %}">map of the convention space</a>.
+</p>
+<p>
+  You can specify what name and pronouns you want printed on your badge. The convention volunteers typically confirm whether you want to use the name and pronouns you entered in <a href='/my_profile'>your Intercon Profile</a> when registering or something else before printing the badge.
+</p>
+<h3 class="my-2"><a name='atcon-larps'>Attend larps</a></h3>
+<p>
+  Make sure to arrive to your game on time or even 5-10 minutes early if possible. This gives you time to skim over rules and your character sheet so you’ll have the details fresh in your memory. If you are arriving late, please communicate that to the GM. If you need to drop out of a game, please use the Intercon website to do so. Give your GMs as much advance notice as you can, so that they have a chance to find another player to replace you.
+</p>
+<p>
+  You will likely want to reference your game materials at the larp. GMs may or may not provide hard copies so if you want paper copies you should check with them and/or print yourself. You can also have them available on your phone.
+</p>
+<p>
+  Many games will have name tags you can place in the same badge holder you use for your convention badge; some will have additional name badges for you to wear for the duration of the game.
+</p>
+<p>
+  GMs typically have a briefing which will vary in length and complexity depending on the game. It may be just a few announcements and a review of key rules before the game starts, and there’s usually an opportunity for a quick round of introductions so that players can identify the other characters (by a mix of nametag, costuming, face, voice, etc).
+</p>
+<p class="d-none">
+  In case you’re new to larping overall and not just new to this convention, you can check out this intro to larping page about what to expect.
+</p>
+
+<h3 class="my-2"><a name='atcon-fillin'>Filling in last minute</a></h3>
+<p>
+  Sometimes players drop out of games very close to the convention, or even during the convention itself, due to unforeseen circumstances or illnesses. If there’s a time when you are not already signed up for a game but might like to play one, you can check for games that need players to fill in last-minute. You can see games with open slots on <a href='/'>Intercon’s homepage</a>.
+</p>
+<p>
+  There is a sign near the operations desk listing games that need players, and the people running games often announce the need for extra players in the <i>#players-needed</i> channel on the <a href="https://discord.gg/{{discord_invite}}" target="_blank">Intercon Discord Server</a>. Some GMs may also cross-post to the unofficial <a target="_blank" href="https://www.facebook.com/groups/12809145492">Intercon X Facebook community</a>, but Discord is the more common place for last-minute player requests.
+</p>
+<h3 class="my-2"><a name='atcon-between'>Between games</a></h3>
+<p>
+  During times when you are not playing in a larp, there are plenty of places to be other than your own hotel room! 
+</p>
+<p>
+  Players often like to spend time talking about the games they’ve just experienced or what other games they’re looking forward to, so there are places to talk to old or new friends, as well as places to get some food or some peace and quiet if you need some downtime.
+</p>
+<p>
+There are <a href='{%page_url forum %}'>Forum@Intercon</a> and <a href='{%page_url social%}'>Social Events</a> to check out, as well as unstructured social options in the Consuite and vendors. There will be boardgames available and you can always ask if folks want to talk about their latest larp experiences. Intercon has a Quiet Room available for those who need a quiet space to do self-care and/or nap. 
+</p>
+<p>
+You can find more information about the event spaces here.
+</p>
+
+<h3 class="my-2"><a name='atcon-takecare'>Take care of yourself</a></h3>
+<p>
+  Like any exciting convention, Intercon can be tiring if you’ve filled your schedule with events from an early start to a late evening.
+</p>
+<p>
+Remember food, water, and sleep!
+</p>
+<p>
+There is <a href='{%page_url food%}'>food</a> available at the hotel, and there are restaurants a short drive away. There can be long lines at peak times before games, so it’s good to leave plenty of time to get your meal. This is especially true of the restaurant in the hotel! Please note that buying concession food in the Atrium does help Intercon to meet its food & beverage minimums. 
+</p>
+<p>
+Aside from meals, you may also wish to carry some snacks and a water bottle with you. 
+The rooms games take place in usually have water available. There are fridges in the hotel rooms if you wish to bring food to the convention. 
+</p>
+<p>
+Some attendees enjoy signing up for a very full schedule of events and others deliberately choose fewer games so they’ll have more time to rest, socialize, eat, and change costumes between games. 
+</p>
+<h3 class="my-2"><a name='atcon-help'>Where to get help</a></h3>
+<p>
+  During the convention, if you are having a problem related to the hotel, the hotel front desk is the best place to go for help. 
+</p>
+<p>
+If you are having trouble finding your way around, or have other challenges with the convention, the Intercon Operations desk, will have Intercon volunteers at the times and locations listed on the <a href='/schedule'>{{convention.name}} schedule</a>.
+</p>
+<p>
+If you are having problems involving the behavior of other convention guests, game runners, or staff, reach out to our Safety Staff via a call or text to the number on the back of your Intercon badge (313-723-3894).
+</p>
+
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/bios.liquid
+++ b/cms_content_sets/wanderlust/pages/bios.liquid
@@ -1,0 +1,81 @@
+---
+name: Staff and GM Bios
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign_graphql_result result = getBioEligibleUserConProfiles() %}
+<h1 class='my-3'>Staff and GM Bios</h1>
+{% assign user_con_profiles = result.convention.bio_eligible_user_con_profiles | sort_natural:'name_inverted' %}
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px" >
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Staff and GM Bios</h4>
+      </li>
+      <li class="toc-entry"><a href="#concom">Intercon Staff</a>
+        <ul>
+          {% for display_user_con_profile in user_con_profiles %}
+            {% assign position_count = display_user_con_profile.staff_positions | size %}
+            
+            {% if position_count > 1 %}
+              <li class="toc-entry"><a href="#user-{{ display_user_con_profile.id }}">{{ display_user_con_profile.name_without_nickname }}</a>
+            {% endif %}
+
+          {% endfor %}
+        </ul></li>
+        <li class="toc-entry"><a href="#gms">Game GMs</a>
+        <ul>
+          {% for display_user_con_profile in user_con_profiles %}
+            {% assign positions = display_user_con_profile.staff_positions | map: "name" %}
+            {% unless positions contains 'Con Com' %}
+
+              <li class="toc-entry"><a href="#user-{{ display_user_con_profile.id }}">{{ display_user_con_profile.name_without_nickname }}</a>
+            {% endunless %}
+          {% endfor %}
+        </ul></li>
+        <li class="toc-entry"><a href="#volunteers">Volunteers</a>
+        <ul>
+          {% for display_user_con_profile in user_con_profiles %}
+            {% assign positions = display_user_con_profile.staff_positions | map: "name" %}
+            {% if positions contains 'Con Com' %}
+              {% assign position_count = display_user_con_profile.staff_positions | size %}
+              {% unless position_count  > 1  %}
+                <li class="toc-entry"><a href="#user-{{ display_user_con_profile.id }}">{{ display_user_con_profile.name_without_nickname }}</a>
+              {% endunless %}
+            {% endif %}
+          {% endfor %}
+        </ul></li>
+
+    </ul>
+  </div>
+  <div class="col">
+    <p class="lead">
+Intercon can only happen because of all of the work done by many, many people.  The people listed here are the Con Staff, GMs, and Volunteers who make Intercon happen!
+    </p>
+    <h2 class="my-3"><a name='concom'>Intercon Staff</a></h2>
+    {% for display_user_con_profile in user_con_profiles %}
+      {% assign position_count = display_user_con_profile.staff_positions | size %}
+      {% if  position_count > 1 %}
+        {% include 'bio' %}
+      {% endif %}
+    {% endfor %}
+    <h2 class="my-3"><a name='gms'>Game GMs</a></h2>
+    {% for display_user_con_profile in user_con_profiles %}
+      {% assign positions = display_user_con_profile.staff_positions | map: "name" %}
+      {% unless positions contains 'Con Com' %}
+        {% include 'bio' %}
+      {% endunless %}
+    {% endfor %}
+    <h2 class="my-3"><a name='volunteers'>Volunteers</a></h2>
+    {% for display_user_con_profile in user_con_profiles %}
+      {% assign positions = display_user_con_profile.staff_positions | map: "name" %}
+      {% if positions contains 'Con Com' %}
+        {% assign position_count = display_user_con_profile.staff_positions | size %}
+          {% unless position_count > 1 %}
+            {% include 'bio' %}
+          {% endunless %}
+        {% endif %}
+      {% endfor %}
+  </div>
+</div>

--- a/cms_content_sets/wanderlust/pages/boardgames.liquid
+++ b/cms_content_sets/wanderlust/pages/boardgames.liquid
@@ -1,0 +1,26 @@
+---
+name: Boardgames
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">Boardgames at Intercon</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Boardgames</h4>
+      </li>
+      <li class="toc-entry"><a href="#overview">Overview</a></li>
+      <li class="toc-entry"><a href="#library">NEIL Boardgame Library</a></li>
+    </ul>
+  </div>
+  <div class='col'>
+
+
+<h2 class="my-3"><a name="overview">Overview</a></h2>
+<p>If you're looking for something to do between larps, why not find and/or make some friends and grab a board game from the NEIL Board Game library, available in the Rotunda.  We'll have signup sheets available so you can indicate a desire to play a specific game at a later time, and people can sign up to play along with you.
+  <hr>
+<h2 class="my-3"><a name="library">NEIL Boardgame Library</a></h2>
+    {%include 'boardgame_list' %}
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/buckets.liquid
+++ b/cms_content_sets/wanderlust/pages/buckets.liquid
@@ -1,0 +1,7 @@
+---
+name: Bucket System Description
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h3 class="my-3">Game Signup Bucket System</h3>
+{% include "proposal_form_registration_policy_instructions" %}

--- a/cms_content_sets/wanderlust/pages/calendar.liquid
+++ b/cms_content_sets/wanderlust/pages/calendar.liquid
@@ -1,0 +1,11 @@
+---
+name: Intercon Calendar
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<div class="row">
+<div class="col">
+<iframe style="border-width:0; width: 100%;" src="https://calendar.google.com/calendar/embed?title=Intercon%20Calendar&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=rigitech.com_cpcenpfusnrbark9nmdk3alqg4%40group.calendar.google.com&amp;color=%2329527A&amp;ctz=America%2FNew_York" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+</div>
+</div>
+

--- a/cms_content_sets/wanderlust/pages/comp-display-old.liquid
+++ b/cms_content_sets/wanderlust/pages/comp-display-old.liquid
@@ -1,0 +1,48 @@
+---
+name: Game Comps Table - old
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign max_hours = 8 %}
+{% assign max_players = 45 %}
+{% assign comp_ph = 60 %}
+<h1 class="my-3">Game Comps Table</h1>
+<div class='alert text-bg-warning'>This is subject to change for Intercon W</div>
+<div class="table-responsive">
+  <table class='table table-bordered table-sm'>
+  <tr>
+    <th class="text-end">Players</th>
+    {% for i in (1..max_hours) %}
+      <th class="text-center">{{i}} Hours</th>
+    {% endfor %}
+  </tr>
+  {% for j in (1..max_players) %}
+    <tr>
+      <th class="text-end">{{ j }}</th>
+        {% for i in (1..max_hours) %}
+          {% assign comps = j | times: i | divided_by: comp_ph|floor| plus: 1 %}
+          {% assign bg = ''%}
+          {% case comps %}
+          {% when 1 %}
+            {% assign bg = 'table-light'%}
+          {% when 2 %}
+            {% assign bg = 'table-info'%}
+          {% when 3 %}
+            {% assign bg = 'table-warning'%}
+          {% when 4 %}
+            {% assign bg = 'table-success'%}
+          {% when 5 %}
+            {% assign bg = 'table-secondary'%}
+          {% when 6 %}
+            {% assign bg = 'table-light'%}
+          {% when 7 %}
+            {% assign bg = 'table-info'%}
+          {% endcase %}
+
+          <td class="{{bg}} text-center">{{ comps }}</td>
+        {% endfor %}
+      </tr>
+    {% endfor %}
+  </table>
+</div>

--- a/cms_content_sets/wanderlust/pages/comp-display.liquid
+++ b/cms_content_sets/wanderlust/pages/comp-display.liquid
@@ -1,0 +1,57 @@
+---
+name: Game Comps Table - New
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign max_hours = 8 %}
+{% assign max_players = 45 %}
+{% assign comp_ph = 36 %}
+<h1 class="my-3">Game Comps Table</h1>
+<div class='alert text-bg-info'>Updated for for Intercon W</div>
+<div class="table-responsive">
+  <table class='table table-bordered table-sm'>
+  <tr>
+    <th class="text-end">Players</th>
+    {% for i in (1..max_hours) %}
+      <th class="text-center">{{i}} Hours</th>
+    {% endfor %}
+  </tr>
+  {% for j in (1..max_players) %}
+    <tr>
+      <th class="text-end">{{ j }}</th>
+        {% for i in (1..max_hours) %}
+          {% assign comps = j | times: i | divided_by: comp_ph|floor %}
+          {% assign bg = ''%}
+          {% case comps %}
+          {% when 0 %}
+            {% assign bg = 'table-danger'%}
+          
+          {% when 1 %}
+            {% assign bg = 'table-light'%}
+          {% when 2 %}
+            {% assign bg = 'table-info'%}
+          {% when 3 %}
+            {% assign bg = 'table-warning'%}
+          {% when 4 %}
+            {% assign bg = 'table-success'%}
+          {% when 5 %}
+            {% assign bg = 'table-secondary'%}
+          {% when 6 %}
+            {% assign bg = 'table-light'%}
+          {% when 7 %}
+            {% assign bg = 'table-info'%}
+       {% when 8 %}
+            {% assign bg = 'table-warning'%}
+          {% when 9 %}
+            {% assign bg = 'table-success'%}
+          {% when 10 %}
+            {% assign bg = 'table-secondary'%}
+          {% endcase %}
+
+          <td class="{{bg}} text-center">{{ comps }}</td>
+        {% endfor %}
+      </tr>
+    {% endfor %}
+  </table>
+</div>

--- a/cms_content_sets/wanderlust/pages/conlogo.liquid
+++ b/cms_content_sets/wanderlust/pages/conlogo.liquid
@@ -1,0 +1,10 @@
+---
+name: con logo test
+skip_clickwrap_agreement: false
+hidden_from_search: true
+---
+<div class="row py-4">
+<div class="col-8 offset-2">
+<img class="img-fluid" src="{% file_url Intercon w logo.png %}">
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/contacts.liquid
+++ b/cms_content_sets/wanderlust/pages/contacts.liquid
@@ -1,0 +1,40 @@
+---
+name: Convention Contacts
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">Convention Contacts</h1>
+
+<p>The following people are in charge of various aspects of {{ convention.name }}:</p>
+
+{% assign staff_positions = convention.staff_positions | sort_natural:'name' %}
+<div class='table-responsive'>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Position</th>
+      <th>People</th>
+      <th>Contact email</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for staff_position in staff_positions %}
+      {% assign user_con_profiles = staff_position.user_con_profiles | sort_natural:'name_inverted' %}
+      {% assign user_con_profiles_size = user_con_profiles|size %}
+      <tr>
+        <td><a href="{% page_url role-descriptions %}#{{ staff_position.name | downcase | remove: " "|remove: "-deputy"}}">{{ staff_position.name }}</a></td>
+        <td>
+          <ul class="list-unstyled my-1">
+            {% for user_con_profile in user_con_profiles %}
+              <li class='my-1'><img class="me-3" style="border-radius:20px" src="{{ user_con_profile.gravatar_url }}?s=40&r=pg&d=mm" alt="{{ user_con_profile.bio_name}}'s Icon">
+{{ user_con_profile.name_without_nickname }}</li>
+            {% endfor %}
+          </ul>
+        </td>
+        <td>{{staff_position.email_link}}</a></td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</div>

--- a/cms_content_sets/wanderlust/pages/content-formatting.liquid
+++ b/cms_content_sets/wanderlust/pages/content-formatting.liquid
@@ -1,0 +1,44 @@
+---
+name: Content formatting
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: true
+---
+<h1 class="my-3">Content formatting: a crash course</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top">
+      <li class="toc-entry"><a href="#markdown">Markdown</a></li>
+      <li class="toc-entry"><a href="#html">HTML</a></li>
+      <li class="toc-entry"><a href="#css">CSS and Bootstrap</a></li>
+      <li class="toc-entry"><a href="#snippets">Useful Snippets</a>
+        <ul>
+          <li class="toc-entry"><a href="#examplesubheading">Example</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class="col">
+    <h2 class="my-3"><a name='markdown'>Markdown</a></h2>
+    <p>
+      Text here
+    </p>
+    <h2 class="my-3"><a name='html'>HTML (for advanced users)</a></h2>
+    <p>
+      Text here
+    </p>
+    <h2 class="my-3"><a name='css'>Basic CSS and Bootstrap (for advanced users)</a></h2>
+    <p>
+      Text here
+    </p>
+    <h2 class="my-3"><a name='snippets'>Useful Snippets</a></h2>
+    <p>
+      Text here
+    </p>
+    <!-- this is an example of a subheading, note that it's a h3, my-2 vs top level section's h2 my-3 -->
+    <h3 class="my-2"><a name='examplesubheading'>Example</a></h3>
+    <p>
+      Text here
+    </p>
+  </div>
+</div>

--- a/cms_content_sets/wanderlust/pages/covid.liquid
+++ b/cms_content_sets/wanderlust/pages/covid.liquid
@@ -1,0 +1,97 @@
+---
+name: COVID FAQ!
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">COVID FAQ</h1>
+
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>COVID FAQ</h4>
+      </li>
+      <li class="toc-entry"><a href="#overview">Overview</a></li>
+      <li class="toc-entry"><a href="#policy">Current Policies & Logistics</a></li>
+      <li class="toc-entry"><a href="#proof">Submit Vaccination Proof</a></li>
+      <li class="toc-entry"><a href="#FAQ">FAQ</a></li>
+      <li class="toc-entry"><a href="#testing">Testing at and near the Con</a></li> 
+      </li>
+    </ul>
+  </div>
+<div class='col'>
+<h2 class='my-3'><a name='overview'>Overview</a></h2>
+<p>This page contains ongoing information about {{convention.name}} and Covid Policies and Plans! Keep checking in as it continues getting updated with an ongoing FAQ and information about {{convention.name}}, including testing availabilities before and during the convention. Questions and comments can be sent to {{convention.staff_positions_by_name.covid_q_a.email_link}} and will be added to our FAQ!</p>
+  <hr>
+  <h2 class='my-3'><a name='policy'>Current Policies</a></h2>
+  <h4 class='my-2'>Last Updated: 2024-11-01</h4>
+<p><li>Everyone attending {{convention.name}} will be required to provide proof of up-to-date vaccination against COVID-19 as defined by the CDC, including the latest applicable booster(s) available in their country of residence. This proof must be provided in advance (<b>by January 1, {{convention.starts_at|date: "%Y"}}</b>), via email to {{convention.staff_positions_by_name.covid_verification.email_link}}, zoom sessions, or similar. No exemptions will be granted, including for medical or religious reasons. Additionally, this policy applies to everyone entering convention space as an attendee.
+<p>
+<li>Additionally, proof of a negative rapid antigen or PCR Covid test will be required of all attendees. Proof must be uploaded to the convention within 48 hours of the convention. Details on how to do this will be in upcoming announcements. Intercon will provide testing kits at the door (or reimbursement) for those for whom this is a hardship.
+<p>
+<li>All attendees must undergo a COVID health screening in order to attend. Screening may include - but is not limited to - a questionnaire or a temperature check. The screening will also include an attestation that attendees have not had Covid symptoms or household members with Covid within 5 days of the convention.
+<p>
+<li>The Intercon Operations desk and check-in will not be in a mask-required space.  The volunteers staffing the Operations desk and check-in will be masked. The Atrium host the Operations Desk as well as the Hotel Consessions, and will have consuite seating space. This space will be mask-optional, and accommodations will be made if you are uncomfortable entering the space to check in to the convention. The consessions food line requires masking of all attendees while in line and there will be signage explaining this requirement. Additionally, attendees will be given the option to get food as take-out. All mask-optional event food spaces will be clearly marked and optional to attend.
+<p>
+<li>As Forum events are in confined spaces without allowances to move around, all Forum events will require full masking of attendees. 
+<p>
+<li>All on-duty members of the Safety Staff will be required to wear masks so that they are comfortably approachable by every member of the community.
+<p>
+<li>The hallways are public hotel space and we cannot enforce masking in public spaces. Additionally, other hotel guests may be present in any and all public spaces. Intercon encourages masking of all attendees to and from event and food locations.
+<p>
+<li>Currently, event runners will have autonomy to run their games to suit their comfort levels and give attendees the agency to select events that meet their needs and comfort. All events have a mandatory prompt to complete before they will be scheduled. This prompt will have event runners mark their game as <i>"Masks are required for all attendees"</i>, <i>"Masks are required for all attendees unless eating"</i> or <i>"Masks are optional, but attendees are still welcome to mask."</i> This information will be at the top of the game event page and available in time for the live schedule.<br>
+<br><p>
+All attendees will have access to this information before opting into games and events at signups. Event runners will not allowed to change from Mask-Required after the schedule goes live. It is the intention of this policy that both attendees and event runners can be sure that standard will hold for their games and for the games they sign up for. Please note that Mask-Optional games may be required to fully mask if the convention decides to strengthen Covid precautions closer to the con.
+
+<li>These are the current policies for {{convention.name}}. As Intercon is still months away, it is difficult to know what the environment will look like. Intercon holds the ability to add additional policies and precautions, and to strengthen any existing policies.
+  <hr>
+  <h2 class='my-3'><a name='proof'>Submit Vaccination Proof</a></h2>
+<p>Proof of full vaccination as currently defined by the CDC is required by all attendees, by <b>January 1, {{convention.starts_at|date: "%Y"}}. Attendees not verified following this date will be withdrawn from event signups. </b> Attendees joining the convention following this date will be asked to provide proof of vaccination before signing up for any events. We ask attendees to provide proof of vaccination through the methods listed below:
+</p>
+  <p>
+  We accept a variety of options for proof that shows the vaccine given, date, and your name (which can be a government name not matching your website/badge name).  Options include:
+  <ul>
+    <li>A photograph of your vaccine card</li>
+    <li>Your state may have an online vaccine records database, you can send us a screenshot from there.  
+      <br>(<a href='https://www.myvaxrecords.mass.gov/pages/Public' target="_blank">Massachusetts Vax Record Page <i class="bi bi-box-arrow-up-right"></i></a>)
+    </li>
+    <li>If you used CVS, your <a href=" https://care.cvs.com/" target="blank">CVS health dashboard <i class="bi bi-box-arrow-up-right"></i></a> should let you look up your covid vaccinations and download them as a pdf which will show your name, the vaccines administered, and the dates.</li>  
+    <li>If you used Walgreens, they also have an <a href='https://www.walgreens.com/login.jsp?ru=%2Ffindcare%2Fvaccination%2Fcovid%2F19%2Fdigital-dose-card%3Fregister%3Drx?ban=immhub_covidrecord' target='_blank'>online record system <i class="bi bi-box-arrow-up-right"></i></a></li>
+    <li>A picture of the prescription paper given at time of vaccination</li>
+    <li>An email confirmation of the vaccination or appointment from your pharmacy</li>
+  </ul>
+  
+  
+<p><strong>Please email any of the above showing the vaccine given, date, and your name to  {{convention.staff_positions_by_name.covid_verification.email_link}}</strong> - records will be deleted within 30 days of receipt
+</p>
+<p>Or join a video chat to hold up your vaccination card!
+  <p style="margin-left: 40px"><b>Upcoming zoom sessions:</b>
+    <br />Coming soon!  Reach out at {{convention.staff_positions_by_name.covid_verification.email_link}} if you want to schedule a zoom call!
+    </p>
+</p>
+    <hr>
+   <h2 class='my-3'><a name='FAQ'>FAQ</a></h2>
+<p>A continued FAQ will be updated here as additional questions come in.
+  <li><b>Q:</b> "If a GM would like to have a mask policy beyond what the Intercon minimum is, will there be support for this?"
+  </li>
+  <li>
+    <b>A:</b> Yes! GMs are able to indicate additional expectations for their games, even before this year. Intercon will support GMs having further requirements or precautions in their games, for example, a mask policy, indicated formally with the <i>mask required button</i>."
+    <br><p></li>
+  <li>
+    <b>Q:</b> "Badge policy is notoriously difficult to actually enforce. Do y'all have a plan for how to keep people who are unwilling or unable to provide proof of vaccination out of con spaces?</li>
+  <Li>
+    <b>A:</b> The same steps will be taken as anyone who is in con space who has been banned from Intercon (as they would be if they refuse to provide or fake proof of vaccination): We (convention staff, safety team) will ask them to leave, and involve the hotel security/staff if needed to removed the uninvited person from our rented space. The specific wording of the procedure hasn't been worked out yet, but we are preparing our staff policies and training for this situation.
+    <br><p></li>
+    <li><b>Q:</b> "Is it possible for Intercon to get rapid testing kits, so we can test at the door?"</li>
+    <li><b>A:</b> Yes, Intercon will be making available a number of rapid tests throughout the con, available for attendees who becomd symptomatic at the event. As stated in the policy, we will also be doing some amount of additional screening at the door, and the intensity of that screening will depend upon where we are at as the convention gets closer. As with any contagious illness, please do not come to the con already symptomatic. Information on what we can provide will be updated here under the Covid Testing section.<br><p></li>
+    <li><b>Q:</b> "What about medical exemptions?"</li>
+    <li><b>A:</b> Our main priority is to run the safest con possible. The biggest tool that we have for safety are vaccines. Intercon is not a mandatory event (like a job or a essential service) and while we can control our con's vaccination status, we do not have exclusive use of the hotel. As we do not rent the entire facility, there will be non-convention goers present, whose vaccination status we cannot control. We have an obligation to protect our community and as such will not be allowing medical exemptions at this time.<br><p></li>
+    <li><b>Q:</b> "What should I do if I contract COVID shortly before the con?"</li>
+    <li><b>A:</b> The same as if you contract any contagious disease: let us know that you will not be making it to the convention, if we need to contact your GMs for you, and if you need a refund or rollover. Please do not attend Intercon. One of the questions on the Covid screening at the door will ask if attendees have had any Covid symptoms for the previous two weeks.<br><p></li>
+    <li><b>Q:</b> "What happens to my membership if I contract COVID and can’t come to the con?"</li>
+    <li><b>A:</b> After January 1st, if you withdraw from Intercon, your badge can be rolled over to the the next Intercon. If you need a refund instead, please let the con chair know at {{convention.staff_positions_by_name.covid_q_a.email_link}}, and we’ll work with you. If you are no longer attending the con for any reason, please let us know as soon as you can out of respect of event runners, etc.<br><p></li>
+ 
+<hr>
+<h2 class='my-3'><a name='testing'>Testing at or near the Con</a></h2>
+<p>Intercon will have available a number of rapid tests, on site, for those attendees who become symptomatic at the event. Check back as the con approaches to read more about available testing at or near the convention!</p>

--- a/cms_content_sets/wanderlust/pages/flyer.liquid
+++ b/cms_content_sets/wanderlust/pages/flyer.liquid
@@ -1,0 +1,7 @@
+---
+name: Flyer
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<p><a href="{% file_url Intercon_W_Flyer.pdf %}" class="btn btn-secondary">Download PDF</a></p>
+<iframe src="{% file_url Intercon_W_Flyer.pdf %}" style="width: 100%; height: 80vh; border: 1px solid #eee;"></iframe>

--- a/cms_content_sets/wanderlust/pages/food.liquid
+++ b/cms_content_sets/wanderlust/pages/food.liquid
@@ -1,0 +1,68 @@
+---
+name: Food at Intercon
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class='my-3'>Food at Intercon</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Food at Intercon</h4>
+      </li>
+      <li class="toc-entry"><a href="#intro">Introduction</a></li>
+      <li class="toc-entry"><a href="#concessions">Concessions</a></li>
+      <li class="toc-entry"><a href="#restaurant">Restaurant</a></li>
+      <li class="toc-entry"><a href="#cafe">Cafe</a></li>
+      <li class="toc-entry"><a href="#catering">Catering in Larps</a></li>
+      <li class="toc-entry"><a href="#social">Social Events</a>
+        <ul>
+          <li class="toc-entry"><a href="#social-bar">Intercon Bar</a></li>
+        </ul>
+      </li>
+      <li class="toc-entry"><a href="#self">Self-Service</a></li>
+  </ul>
+</div>
+<div class='col'>
+
+<h2 class="my-3"><a name='intro'>Introduction</a></h2>
+<p class='lead'>While at {{convention.name}} there are several food options to keep you larping and socializing through the weekend.  Below is more information about the food available at the convention.
+<hr>
+<h2 class="my-3"><a name='concessions'>Concessions</a></h2>
+<p>
+  {{convention.name}} has arranged with the hotel to provice cash/card concessions in consuite throughout the weekend.  Purchasing food and drink from the concessions helps out {{convention.name}} as it counts towards our food and beverage minimum spend.  More information, including hours and a tentative menu can be found on the <a href="{%page_url "food/concessions"%}">Concessions Page<a>.
+</p>
+<hr>
+<h2 class="my-3"><a name='restaurant'>Restaurant</a></h2>
+<p>
+  The hotel has a restaurant, <a href='https://www.ihg.com/crowneplaza/hotels/us/en/warwick/wrwri/hoteldetail/dining' target="_blank">The Crossings</a>, in the lobby, just outside of Atrium.   They offer American cuisine, with sit down service and are open from 6AM - 10PM every day.
+</p>
+<hr>
+<h2 class="my-3"><a name='cafe'>Cafe</a></h2>
+<p>
+  The hotel has a small cafe, located just outside of the Plaza Foyer, which serves Starbucks coffee and bakery items in the mornings.
+</p>
+<hr>
+<h2 class="my-3"><a name='catering'>Catering in Larps</a></h2>
+<p> 
+  Some larps may have arranged ahead of time to provide food for their players.  This is done via the furniture request system, typically in January.  GMs that provide food in this way will be paying for the food themselves, and may ask for an optional donation to offset the personal cost.  For more information about this, see the Food section of <a href="{% page_url gmpolicies %}#FoodService">GM Policies</a>
+</p>
+<hr>
+<h2 class="my-3"><a name='catering'>Social Events</a></h2>
+<p> 
+  Some Social Events, especially the ones run by Intercon directly, will be providing some amount of food.  Most notably the Thursday night welcome party, the Friday night pizza party, and the Sunday night Sundae Social will all be catered.  Come share a bite with your fellow attendees!  For more information about social events, see <a href='{%page_url social%}'>Social Events</a>
+</p>
+<h3 class="my-2"><a name='catering-bar'>Intercon Bar</a></h3>
+<p>
+  On Friday and Saturday nights, Intercon will be hosting a cash bar for our attendees!  Purchases from this bar also help Intercon meet our Food and Beverage minimum spend.  Please check the <a href='/events/schedule'>Schedule</a> for more information!
+</p>
+<hr>
+<h2 class="my-3"><a name='self'>Self-Service</a></h2>
+<p> 
+  Every hotel room has a mini fridge, and there are microwaves available in the common areas on the second and fifth floors, if you wish to provide your own food for the weekend.
+</p>
+
+  </div>
+</div>
+      
+  

--- a/cms_content_sets/wanderlust/pages/food/concessions.liquid
+++ b/cms_content_sets/wanderlust/pages/food/concessions.liquid
@@ -1,0 +1,261 @@
+---
+name: Concessions
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class='my-3'>Concessions at Intercon</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Concessions</h4>
+      </li>
+      <li class="toc-entry"><a href="#intro">Introduction</a></li>
+      <li class="toc-entry"><a href="#hours">Hours</a></li>
+      <li class="toc-entry"><a href="#menu">Example Menu</a>
+        <ul>
+          <li class="toc-entry"><a href="#menu-breakfast">Breakfast</a></li>
+          <li class="toc-entry"><a href="#menu-lunch">Lunch/Dinner</a></li>
+          <li class="toc-entry"><a href="#menu-desert">Desert</a></li>
+        </ul>
+      </li>
+  </ul>
+</div>
+<div class='col'>
+
+<h2 class="my-3"><a name='intro'>Introduction</a></h2>
+<p class="lead">{{convention.name}} has worked with the hotel to provide cash concessions throughout the weekend.  They are available in <a href="{% page_url hotel/layout %}">Con Suite</a>, during meal times, for cash and credit.  We try to provide a wide variety of options for our attendees.  Purchases made at the concessions help out the convention as they count against our Food and Beverage minumum required spend.
+</p>
+<hr>
+<h2 class="my-3"><a name='hours'>Hours</a></h2>
+  <div class='alert text-bg-warning'>These hours are subject to change, they represent what {{convention.name}} has asked the convention to provide, but hotel staffing may adjust these hours slightly</div>
+  <div class='table-responsive'>
+<table class='table table-sm table-striped'>
+  <thead>
+    <tr>
+      <th>Day </th>
+      <th>Meal </th>
+      <th>Start</th>
+      <th>End</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan=1 class='align-middle'>Thursday</td>
+      <td>Dinner</td>
+      <td>6:00 PM</td>
+      <td>9:00 PM</td>
+    </tr>
+    <tr>
+      <td rowspan=3 class='align-middle'>Friday</td>
+      <td>Breakfast</td>
+      <td>8:00 AM</td>
+      <td>10:30 PM</td>
+    </tr>
+    <tr>
+      <td>Lunch</td>
+      <td>12:00 PM</td>
+      <td>3:00 PM</td>
+    </tr>
+    <tr>
+      <td>Dinner</td>
+      <td>5:30 PM</td>
+      <td>9:00 PM</td>
+    </tr>
+    <tr>
+      <td rowspan=3 class='align-middle'>Saturday</td>
+      <td>Breakfast</td>
+      <td>8:00 AM</td>
+      <td>10:30 PM</td>
+    </tr>
+    <tr>
+      <td>Lunch</td>
+      <td>12:00 PM</td>
+      <td>3:00 PM</td>
+    </tr>
+    <tr>
+      <td>Dinner</td>
+      <td>5:30 PM</td>
+      <td>9:00 PM</td>
+    </tr>
+    <tr>
+      <td rowspan=2 class='align-middle'>Sunday</td>
+      <td>Breakfast</td>
+      <td>8:00 AM</td>
+      <td>10:30 PM</td>
+    </tr>
+    <tr>
+      <td>Lunch</td>
+      <td>12:00 PM</td>
+      <td>3:00 PM</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+<hr>
+<h2 class="my-3"><a name='menu'>Example Menu</a></h2>
+  <div class='alert text-bg-warning'>These menus are based on information provided by the hotel ahead of the convention, and actual options and pricing may differ, based on supply and availability.</div>
+  <p>
+    Gluten Free options available and will be clearly marked at the concessions. Cash and Card accepted
+  </p>
+
+<h3 class="my-2"><a name='menu-breakfast'>Breakfast</a></h3>
+  <div class='table-responsive'>
+  <table class='table table-sm table-striped'>
+    <tbody>
+    <tr>
+      <td>Danish, Muffin</td>
+      <td class='col-md-3'>$3.00</td>
+    </tr>
+    <tr>
+      <td>Assorted Bagels (with Cream Cheese and Jam)</td>
+      <td>$4.00</td>
+    </tr>
+    <tr>
+      <td>Fruit Salad</td>
+      <td>$5.00</td>
+    </tr>
+    <tr>
+      <td>OJ, Apple Juice, Cranberry Juice</td>
+      <td>$3.00</td>
+    </tr>
+    <tr>
+      <td>Scrambled Eggs, Potatoes, Sausage</td>
+      <td>$7.00</td>
+    </tr>
+    <tr>
+      <td>Scrambled Eggs, Potatoes</td>
+      <td>$6.00</td>
+    </tr>
+    <tr>
+      <td>Coffee, Tea, Decaf</td>
+      <td>$3.00<br>(some Intercon-provided first)</td>
+    </tr>
+    <tr>
+      <td>Assorted Greek Yogurt</td>
+      <td>$3.00</td>
+    </tr>
+    <tr>
+      <td>Assorted Granola Bars</td>
+      <td>$2.00</td>
+    </tr>
+  </tbody>
+  </table>
+</div>
+
+  <h3 class="my-2"><a name='menu-lunch'>Lunch/Dinner</a></h3>
+<div class='table-responsive'>
+  <table class='table table-sm table-striped'>
+    <tbody>
+    <tr>
+      <td>Assorted Deli Sandwiches<br><span class='ms-4'>Served with Lettuce and Tomatoes, “aioli” on the side</span></td>
+      <td class='col-md-3'>$7.00</td>
+    </tr>
+    <tr>
+      <td>Roasted Vegetable and Hummus Wrap</span></td>
+      <td>$7.00</td>
+    </tr>
+    <tr>
+      <td>Burger from the Grill<br><span class='ms-4'>Served with Cheese, Lettuce, Tomatoes, and Onions</span></td>
+      <td>$8.00</td>
+    </tr>
+    <tr>
+      <td>Chicken Sandwich from the Grill<br><span class='ms-4'>Served with Cheese, Lettuce, Tomatoes, and Onions</span></td>
+      <td>$8.00</td>
+    </tr>
+    <tr>
+      <td>Caesar Salad</td>
+      <td>$8.00</td>
+    </tr>
+    <tr>
+      <td>Calzones (Spinach or Italian)</td>
+      <td>$8.00</td>
+    </tr>
+    <tr>
+      <td>Grilled Italian Sausage<br><span class='ms-4'>Served with Sautéed Onions, Red and Green Peppers</span></td>
+      <td>$9.00</td>
+    </tr>
+    <tr>
+      <td>All Beef Hot Dog</td>
+      <td>2 for $6.00</td>
+    </tr>
+    <tr>
+      <td>French Fries</td>
+      <td>$5.00</td>
+    </tr>
+    <tr>
+      <td>Chili Cheese Fries (with Meat Chili)</td>
+      <td>$7.00</td>
+    </tr>
+    <tr>
+      <td>Chicken Fingers Served with Choice of Sauce and French Fries</td>
+      <td>$10.00</td>
+    </tr>
+    <tr>
+      <td>Chili and Cheese Nachos (with Meat Chili)</td>
+      <td>$7.00</td>
+    </tr>
+    <tr>
+      <td>Chili with Cheese</td>
+      <td>$5.00</td>
+    </tr>
+    <tr>
+      <td>Assorted Chips and Popcorn</td>
+      <td>$2.00</td>
+    </tr>
+    <tr>
+      <td>Coffee, Tea, and Decaf</td>
+      <td>$3.00</td>
+    </tr>
+    <tr>
+      <td>12oz Soda/Bottled Water</td>
+      <td>$2.00</td>
+    </tr>
+    <tr>
+      <td>Juice</td>
+      <td>$3.00</td>
+    </tr>
+    <tr>
+      <td>Energy Drinks</td>
+      <td>$5.00</td>
+    </tr>
+    <tr>
+      <td>Gatorade/Powerade</td>
+      <td>$3.00</td>
+    </tr>
+    <tr>
+      <td>Imported Beer</td>
+      <td>$7.00</td>
+    </tr>
+    <tr>
+      <td>Domestic Beer Beer</td>
+      <td>$6.00</td>
+    </tr>
+    <tr>
+      <td>Wine</td>
+      <td>$7.00</td>
+    </tr>
+    
+    </tbody>
+  </table>
+</div>
+      
+<h3 class="my-2"><a name='menu-desert'>Desert</a></h3>
+<div class='table-responsive'>
+  <table class='table table-sm table-striped'>
+    <tbody>
+    <tr>
+      <td>Cookies or Brownies	( Gluten Free available )</td>
+      <td class='col-md-3'>$2.00</td>
+    </tr>
+   
+    <tr>
+      <td>Candy</td>
+      <td>$2.00</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+  
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/forum.liquid
+++ b/cms_content_sets/wanderlust/pages/forum.liquid
@@ -1,0 +1,60 @@
+---
+name: Forum@Intercon
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign all_categories = convention.event_categories %}
+{% assign brainstorming_session = (all_categories | where: "name", "Brainstorming session") %}
+{% assign moderated_discussion = (all_categories | where: "name", "Moderated discussion") %}
+{% assign panel = (all_categories | where: "name", "Panel") %}
+{% assign presentation = (all_categories | where: "name", "Presentation") %}
+{% assign workshop = (all_categories | where: "name", "Workshop") %}
+{% assign forum_categories = (brainstorming_session | concat: moderated_discussion | concat: panel | concat: presentation | concat: workshop) %}
+{% assign forum_category_ids_urlencoded = (forum_categories | map: "id" | join: "%2C") %}
+
+<header class="mb-4">
+  <h1 class="mb-0">Forum@{{ convention.name }}</h1>
+  <div class="lead">A dual-track LARP conference at Intercon</div>
+</header>
+
+<div class="row">
+  <div class="col-md-8">
+    <p>Forum@Intercon is dual-track LARP conference that takes place during Intercon.  The sessions include workshops, moderated discussions, presentations, and panel discussions.</p>
+
+    <p>Forum@Intercon was previously known by many names, including "panels," "precon," and "Thursday Thing."</p>
+
+    <section class="mt-4">    
+      <h3>I'd like to lead a session at Forum@{{ convention.name }}!</h3>
+  
+      {% new_event_proposal_button "Propose a session" btn btn-outline-primary mb-2 %}
+
+      <p>Great!  Please click the button above to fill out the proposal form.  If you have more than one session you're interested in leading, you'll need to fill out the form multiple times (similar to how LARP proposals work).</p>
+
+      <p>Once you've filled out the form, we'll get back to you via email to let you know we've received it and give you some information on what you can expect.</p>
+    </section>
+    
+  </div>
+  
+  <div class="col-md-4">
+    <div class="mb-4 d-flex flex-column justify-content-stretch">
+      {% new_event_proposal_button "Propose an session" btn btn-primary btn-lg mb-2 w-100 %}
+      <a href="/events/?filters.category={{ forum_category_ids_urlencoded }}" class="btn btn-outline-primary btn-lg">List of sessions</a>
+    </div>
+    <div class="card bg-light">
+      <div class="card-header">Contact information</div>
+      <div class="card-body">
+        {% assign staff_position = convention.staff_positions_by_name.forum_intercon_coordinator %}
+        
+        <strong>{{ staff_position.name }}</strong>
+        <ul class="list-unstyled">
+          {% for user_con_profile in staff_position.user_con_profiles %}
+            <li>{{ user_con_profile.name_without_nickname }}</li>
+          {% endfor %}
+        </ul>
+        
+        <p class="mb-0">{{ staff_position.email | email_link }}</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cms_content_sets/wanderlust/pages/forum/propose.liquid
+++ b/cms_content_sets/wanderlust/pages/forum/propose.liquid
@@ -1,0 +1,14 @@
+---
+name: Forum@Intercon Proposal
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{% page_url forum %}">Forum@Intercon</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Propose a session</li>
+  </ol>
+</nav>
+
+{% new_event_proposal_button "Propose a session" btn btn-primary btn-lg mb-2 %}

--- a/cms_content_sets/wanderlust/pages/glossary.liquid
+++ b/cms_content_sets/wanderlust/pages/glossary.liquid
@@ -1,0 +1,196 @@
+---
+name: Glossary
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class='my-3'>Larp Glossary</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Larp Glossary</h4>
+      </li>
+      <li class="toc-entry"><a href="#black-box">Black Box</a>
+      <li class="toc-entry"><a href="#bleed">Bleed</a></li>
+      <li class="toc-entry"><a href="#blockbuster">Blockbuster</a></li>
+      <li class="toc-entry"><a href="#bluesheets">Bluesheets</a></li>
+      <li class="toc-entry"><a href="#boffer">Boffer Style</a></li>
+      <li class="toc-entry"><a href="#byoc">BYOC / Bring Your Own Character</a></li>
+      <li class="toc-entry"><a href="#byog">BYOG / Build Your Own Game</a></li>
+      <li class="toc-entry"><a href="#casting">Casting Questionnaire</a></li>
+      <li class="toc-entry"><a href="#character-sheet">Character Sheet</a></li>
+      <li class="toc-entry"><a href="#contingency">Contingency Envelope</a></li>
+      <li class="toc-entry"><a href="#debrief">Debrief</a></li>
+      <li class="toc-entry"><a href="#elevator">Elevator Game</a></li>
+      <li class="toc-entry"><a href="#freeform">Freeform</a></li>
+      <li class="toc-entry"><a href="#interactive-literature">Interactve Literature</a></li>
+      <li class="toc-entry"><a href="#horde">Horde Larp</a></li>
+      <li class="toc-entry"><a href="#iron-gm">Iron GM</a></li>
+      <li class="toc-entry"><a href="#lines-and-veils">Lines and Veils</a></li>
+      <li class="toc-entry"><a href="#litform">Litform</a></li>
+      <li class="toc-entry"><a href="#npc">NPC / Non Player Character</a></li>
+      <li class="toc-entry"><a href="#pve">PvE / Player vs Environment</a></li>
+      <li class="toc-entry"><a href="#pvp">PvP / Player vs Player</a></li>
+      <li class="toc-entry"><a href="#safety">Safety Mechanics</a></li>
+      <li class="toc-entry"><a href="#snp">Secrets and Powers</a></li>
+      <li class="toc-entry"><a href="#theatre">Theater Style</a></li>
+      <li class="toc-entry"><a href="#vampire">Vampire</a></li>
+      <li class="toc-entry"><a href="#workshop">Workshop Game</a></li>
+    </ul>
+  </div>
+  <div class="col document">
+    <p class="lead">
+      Larp is not well defined and that’s ok!  The below is not meant to be a list of exact definitions, it is meant to give you an idea of some answers you might get from different community members if you ask them about these terms.  Ask 10 larpers about larping and you’ll get 14 answers 🙂
+    </p>
+    
+    <h3 class="my-2"><a name='black-box'>Black Box</a></h3>
+    <ol>
+      <li>A LARP run with minimal to no set dressing, costuming, and/or props.</li>
+      <li>"A black box is a room with black walls, no windows, flat floor and no furniture…The black box is frequently used as a meta room where the players can go during the runtime of a longer larp. In the meta room the players may enrich the stories of the characters beyond the time and space of the "main" larp, and to give players a break and an opportunity to think through their larping without having to go off-game."
+- <a href='https://nordiclarp.org/wiki/Black_Box' target='_blank'>Nordic Larp Wiki <i class="bi bi-box-arrow-up-right"></i></a></li>
+      <li>This term might also emerge from theater; a black box theater fits the definition in 1. and is often home to more ‘experimental’ and minimalist theater that focuses on a close audience connection with the actor(s), rather than the spectacle of the performance.</li>
+    </ol>
+
+    <h3 class="my-2"><a name='bleed'>Bleed</a></h3>
+      <p>
+        "Bleed" is a term for where the thoughts or emotions of a player affect their character’s thoughts or emotions, or vice versa. It refers to the way that intense roleplaying can feed off of a player's real-life experience, or feed back into it.  While this can heighten the experience, it has the potential to cause damage, so it is common to include Safety Mechanics during the Debrief in an attempt to reduce the after-effects.
+<br>
+        Defined also at <a href='https://nordiclarp.org/wiki/Bleed' target='_blank'>Bleed - Nordic Larp Wiki <i class="bi bi-box-arrow-up-right"></i></a>
+      </p>
+
+    <h3 class="my-2"><a name='blockbuster'>Blockbuster (aka "Destination LARP")</a></h3>
+    <p>On a real battleship! In a real castle! On the darkened streets of real New Orleans! A blockbuster larp has as part of its appeal an exotic, unusual, or spectacular real-world venue. High production values and a ticket price to match. 
+      <br>
+      Defined also at <a href='https://nordiclarp.org/wiki/Blockbuster' target='_blank'>Blockbuster – Nordic Larp Wiki. <i class="bi bi-box-arrow-up-right"></i></a>
+    </p>
+
+    <h3 class="my-2"><a name='bluesheets'>Bluesheets</a></h3>     
+    <p>
+      Information, usually about some elements of the setting, that is sent to every player in a game or every player in a team or faction of players, telling them information that everyone else in the game / team / faction knows as well.  These used to be printed on blue paper, hence the name.
+    </p>
+    <p>
+      The term originates from MIT Assassins' Guild (<a href='http://web.mit.edu/jemorris/Rules/standard-rules.pdf' target='_blank'>http://web.mit.edu/jemorris/Rules/standard-rules.pdf <i class="bi bi-box-arrow-up-right"></i></a>) but at Intercon, people don't usually differentiate between bluesheets, greensheets, and whitesheets the way the Assassins' Guild does.
+    </p>
+        
+    <h3 class="my-2"><a name='boffer'>Boffer Style</a></h3>
+    <p>
+      A Boffer game is one where conflict/combat resolution is done via simulated combat, typically using padded foam weapons or nerf darts. Compare to <a href='#theatre'>Theater Style.</a>
+    </p>
+            
+    <h3 class="my-2"><a name='byoc'>BYOC / Build (or Bring) Your Own Character</a></h3>
+    <p>
+      BYOC games are ones where rather than being given a character sheet by the game runner(s), players are expected to either create a character within certain parameters before the game begins.  There are some blurry edges in usage between this and “workshop” games (below).
+    </p>
+        
+    <h3 class="my-2"><a name='byog'>BYOG / Build Your Own Game</a></h3>
+    <p>
+      A once-common process at Intercon, where the creators gather at the beginning of the convention, figure out what they want to write, spend the weekend writing it, and then run it at the end of the convention for players who sign up in advance.  Largely replaced by the Iron GM Competition today.
+    </p>
+        
+    <h3 class="my-2"><a name='casting-questionaire'>Casting Questionnaire</a></h3>
+    <p>
+      Common to most <a href='#litform'>Litform</a> games, this is a survey sent to players before a game is run, allowing them to express their preferences so that the GMs can assign them a suitable character in the game.  Not usually necessary for Workshop games, although those will sometimes provide a survey to determine the <a href='#lines-and-veils'>Lines and Veils</a> for the game.
+    </p>
+        
+    <h3 class="my-2"><a name='character-sheet'>Character Sheet</a></h3>
+    <p>
+      Common to most <a href='#litform'>Litform</a> games, this is a document pre-written by the game's authors, given to a player, describing the character that they will be playing in this game.
+    </p>
+        
+    <h3 class="my-2"><a name='contingency'>Contingency Envelopes</a></h3>
+    <p>
+      Envelopes that contain additional information, memories, character snippets, etc, which have a trigger to be opened (a contingency). For example, “open when Event A happens” or “open if someone uses the name ‘Blackbird’ around you”.  These are often used to suggest behaviors that you should be trying to participate in or be aware of.
+    </p>
+        
+    <h3 class="my-2"><a name='debrief'>Debrief</a></h3>
+    <p>
+      Common in many one-shot games, the Debrief is a period immediately after the game in which the players and GMs can talk about the game and how it went. This may be more or less structured depending on the preferences of the GMs, and may include <a href='#safety'>Safety Mechanics</a> in order to reduce undesirable <a href='#bleed'>Bleed</a>.
+    </p>
+        
+    <h3 class="my-2"><a name='elevator'>Elevator Game</a></h3>
+    <p>
+      An emerging common subset of <a href='#boffer'>Boffer Style</a> games run indoors where players move back and forth between episodes of simulated combat and safe spaces intended for RP and/or other non-combat challenges.
+    </p>
+        
+    <h3 class="my-2"><a name='freeform'>Freeform</a></h3>
+    <p>
+      In the US, often refers to lower-prep games descended from traditions coming out of indie tabletop rpgs, such as games that are part of the yearly <a href='https://www.goldencobra.org/' target=_blank>Golden Cobra contest <i class="bi bi-box-arrow-up-right"></i></a>.
+    </p>
+    <p>
+      "The Brits use 'Freeform' to mean what we call ''<a href='#litform'>Litform</a>'. Larps that use different mechanics than non-freeform larps. If there’s a combat resolution mechanic, it’s probably not a freeform; if there’s a mechanic where you speak the thoughts of your character out loud, it probably is."
+    </p>
+        
+    <h3 class="my-2"><a name='interactive-litearture'>Interactive Literature</a></h3>
+    <p> 
+      This is what New England Interactive Literature (NEIL, the current parent organization of Intercon), the Interactive Literature Foundation (ILF, which preceded it), and the Society for Interactive Literature (SIL, the original progenitor of what would eventually become Intercon, nee SILicon) were named for.  Fun fact: this term actually predates the better known term ‘Interactive Fiction’ (i.e. computer text adventure games) by a year or two, in the early 1980s.
+    <br>
+      See also: <a href='https://blog.knotaffront.com/2018/03/07/what-is-interactive-literature/' target='_blank'>What is Interactive Literature?  <i class="bi bi-box-arrow-up-right"></i></a> (Written before ‘litform’ was coined, a few months later, at LGC2018) 
+    </p>
+        
+    <h3 class="my-2"><a name='horde'>Horde Larp</a></h3>
+    <p>
+      A larp style in which one group of players (“cast”) each play a single character throughout the duration of the larp, while a second group (“horde”) play a series of short-duration roles one after the other.
+    </p>
+        
+    <h3 class="my-2"><a name='irongm'>Iron GM</a></h3>
+    <p>
+      A competition, often run at Intercon, in which teams of writers receive a genre, a theme, an element, and a prop, construct games around those in a limited period of time, and then run those games at the convention.  For more information, see <a href='{% page_url 'Iron GM' %}'>Iron GM</a>
+    </p>
+        
+    <h3 class="my-2"><a name='lines-and-veils'>Lines and Veils</a></h3>
+    <p>
+      A <a href='#safety'>safety mechanic</a> developed by Ron Edwards for his tabletop game “Sorcerer.” Lines and veils are descriptive terms for describing content that is intentionally kept out of the game space. Something behind a “line” never enters the fiction; something under a “veil” can be referenced or alluded to but is never the subject of player or GM attention or emphasis.
+    </p>
+        
+    <h3 class="my-2"><a name='litform'>Litform</a></h3>
+    <p>
+      A style of larp where the plot web, character backstory, and character relationships are written by the GM/GMs.  'Lit', as the key differentiator for the style is the literature, that is, the game's written content, has been written by the game writers (as opposed to the players, either beforehand or as part of a workshop during game), and '-form', which is a common ending to imply 'larp style', as in 'freeform', 'jeepform', etc. Litform games may be <a href='#theatre'>theater-style</a> or <a href='#boffer'>boffer</a>. The more modern name for what some used to call <a href='#secrets-and-powers'>"Secrets and Powers"</a> or <a href='#interactive-literature'>"Interactive Literature"</a>, although those are both subsets of what we now consider to be Litform.  Coined by Susan Weiner, at the Living Games Conference, 2018.
+    </p>
+        
+    <h3 class="my-2"><a name='npc'>NPC (Non-Player Character)</a></h3>
+    <p>
+      An NPC is a character in the game that is either played by a GM, or a person whose actions are substantially driven by the GMs.  NPCs may be used to inject information in a game, to provide PVE conflict, and so on – they are a general mechanism for GMs to steer the game in particular directions.
+    </p>
+        
+    <h3 class="my-2"><a name='pve'>PvE / Player vs. Environment</a></h3>
+    <p>
+      A style where tension is introduced into the game via forces external to the players.  (For example, NPCs or puzzles.)  PVE is somewhat more common in <a href='#boffer'>Boffer-style</a> larps, although all types of games may include a measure of PVE.
+    </p>
+        
+    <h3 class="my-2"><a name='pvp'>PvP / Player vs. Player</a></h3>
+    <p>
+      A style where the tension in the game is more due to conflicting goals between the player's characters.  PVP is somewhat more common in <a href='#litform'>Litform</a> larps, although all types of games may include a measure of PVP
+    </p>
+        
+    <h3 class="my-2"><a name='safety'>Safety Mechanics</a></h3>
+    <p>
+      Usually refers to a set of conventions that a game chooses to use to provide emotional safety for the participants: signs that players can use to indicate that are or are not okay, rules for what is or is not allowed in the game, processes before / after the game to help with <a href='#bleed'>Bleed</a>, and so on.  There are a number of such conventions that a game may choose from, such as <a href='#lines-and-veils'>Lines and Veils.</a>
+    </p>
+        
+    <h3 class="my-2"><a name='snp'>Secrets and Powers</a></h3>
+    <p>
+      A style of larp typified by gameplay involving secrets where conflicts are resolved using characters’ mechanical abilities, i.e. “powers” (but do not need to).  This was used by some to describe some <a href='#interactive-literature'>Interactive Literature</a> games, and has been largely replaced by <a href='#litform'>'Litform’</a>, though others used "Secrets and Powers" to describe only the subset of games now categorizes as <a href='#litform'>'Litform'</a>. Now that <a href='#litform'>'Litform'</a> exists, games described this way do almost always use Powers for conflict resolution.  There’s a lot of overlap between these and <a href='#litform'>Litform</a>, although Secrets and Powers games almost always use <a href='#theatre'>Theatre-style</a> resolution mechanics instead of <a href='#boffer'>Boffer</a> ones.
+    </p>
+    <p>
+      The term "Secrets and Powers" was probably first defined formally in the article "The Parlor Sandbox: Counter-Players and Ephemera in American Freeform" by Evan Torner and Katherine Castiello Jones, in the <a href='https://www.sarahlynnebowman.com/wp-content/uploads/2017/10/2014-Wyrd-Academic-Book.pdf' target='_blank'>2014 Wyrd Con Companion Book <i class="bi bi-box-arrow-up-right"></i></a>.  See also "Decoding the Default" by Nat Budin in the <a href='https://www.sarahlynnebowman.com/wp-content/uploads/2017/10/WCCB15-Final-1.pdf' target='_blank'>2015 Wyrd Con Companion Book <i class="bi bi-box-arrow-up-right"></i></a>.
+    </p>
+        
+    <h3 class="my-2"><a name='theater'>Theater Style</a></h3>
+    <p>
+     A theater style game is one where conflict resolution is done via abstracted game mechanics, such as dice rolls, rock-paper-scissors, cards, or simply comparing a combat score.  Often these games do not have combat at all. Compare to <a href='#boffer'>Boffer Style</a>.
+    </p>
+        
+    <h3 class="my-2"><a name='vampire'>Vampire</a></h3>
+    <p>
+      A genre of urban fantasy larps set in the World of Darkness milieu created by White Wolf in the 1990s. Vampire larps are generally BYOC theater-style games (mechanics can be found under the name “Mind’s Eye Theater”) with some player-generated conflict among characters (see PVP) expected as part of play. Often, vampire larps are maintained as ongoing campaigns by larger organizations that link them in a kind of persistent universe.
+    </p>
+        
+    <h3 class="my-2"><a name='workshop'>Workshop Game</a></h3>
+    <p>
+      Workshop games generally have no pre-written characters, or minimally pre-written.  A portion of the game time (usually at the outset) is used to engage the players in the creation of characters and connections between them.  The level of structure given to this process by the writers varies.  Both <a href='#byoc'>BYOC</a> and Workshop are contrasted against the default assumptions of <a href='#litform'>Litform</a>
+    </p>
+  </div>
+</div>
+
+  

--- a/cms_content_sets/wanderlust/pages/gmpolicies.liquid
+++ b/cms_content_sets/wanderlust/pages/gmpolicies.liquid
@@ -1,0 +1,309 @@
+---
+name: GM Benefits, Policies and Services
+admin_notes: ''
+skip_clickwrap_agreement: true
+hidden_from_search: false
+---
+{% assign proposal_chair = convention.staff_positions_by_name.game_proposals_chair %}
+{% assign gm_coordinator = convention.staff_positions_by_name.gm_coordinator %}
+{% assign con_chair = convention.staff_positions_by_name.con_chair %}
+{% assign ops_chair = convention.staff_positions_by_name.operations_coordinator %}
+
+<h1 class="my-3">GM Benefits, Policies and Services</h1>
+<div class="row">
+  <div class="col-md-3">
+<ul class="section-nav sticky-top" style="top:72px">
+  <li class="toc-entry menu-header" style='display:none'>
+        <h4>GM Benefits and Policies</h4>
+      </li>
+<li class="toc-entry"><a href="#GMCoordinator">GM Coordinator</a></li>
+<li class="toc-entry"><a href="#Benefits">Benefits</a>
+<ul>
+  <li class="toc-entry"><a href="#CompedMemberships">Comped Memberships</a></li>
+  <li class="toc-entry"><a href="#Advertising">Advertising</a></li>
+</ul></li>
+<li class="toc-entry"><a href="#Policies">Policies</a>
+<ul>
+  <li class="toc-entry"><a href="#RegistrationPolicy">Game Registrations</a></li>
+  <li class="toc-entry"><a href="#Communication">Communication</a></li>
+  <li class="toc-entry"><a href="#canceling">Canceling Your Game</a></li>
+  <li class="toc-entry"><a href="#non-responsive">Non-Responsive Players</a></li>
+  <li class="toc-entry"><a href="#NPCBadges">NPC Badges</a></li>
+  <li class="toc-entry"><a href="#WeaponPolicy">Weapons</a></li>
+  <li class="toc-entry"><a href="#AlcoholPolicy">Alcohol</a></li>
+  <li class="toc-entry"><a href="#FirePolicy">Candles or Fire</a></li>
+  <li class="toc-entry"><a href="#WallHangingPolicy">Wall Hangings</a></li>
+</ul></li>
+
+<li class="toc-entry"><a href="#Services">Services</a>
+<ul>
+  <li class="toc-entry"><a href="#SpaceService">Game Space</a></li>
+  <li class="toc-entry"><a href="#FurnitureService">Furniture</a></li>
+  <li class="toc-entry"><a href="#FoodService">Food</a></li>
+  <li class="toc-entry"><a href="#BarService">Bartenders</a></li>
+  <li class="toc-entry"><a href="#OpsService">Intercon Ops Staff</a></li>
+  <li class="toc-entry"><a href="#HotelService">Hotel Negotiations and Arrangements</a></li>
+</ul></li>
+</ul>
+</div> <!-- end col -->
+<div class="col">
+<h2 class="my-3"><a name="GMCoordinator">GM Coordinator</a></h2>
+<p>If you have questions about anything having to do with your game and Intercon, please reach out to the {{gm_coordinator.name_with_email_link}} who will be happy to assist.</p>
+
+<hr>
+<h2 class="my-3"><a name="Benefits">Benefits</a></h2>
+<p>
+There are some benefits to being an Intercon GM (besides being a GM at the
+largest multi-genre all-LARP convention in the world).
+
+<h3 class="my-2"><a name="CompedMemberships">Comped Memberships</a></i></h3>
+  <div class="alert text-bg-info">
+    This policy has been updated for Intercon W. 
+    <br> 
+    We now provide one comp badge per 36 player-hours of larp content, but more can be given at Con Chair's discression.
+  </div>
+<p>
+Each game is eligible to get a number of comped memberships to the convention based on the number of player-hours of content they are providing. They may request one comp badge for every <strong>36 player-hours</strong> of content provided by contacting the  {{gm_coordinator.name_with_email_link}}.  Player-hours are the number of players that the game can take multiplied by the total number of hours of the game, across all runs.  For example, a 9 player, 4 hour game may receive one comp, as would a 6 player, 4 hour game that runs twice during the convention, while a 6 player, four hour game would not be eligible to get a comp.  A 18 player, 4 hour game would receive two comps. If your player numbers do not completely cover the number of attendees you are providing content for, (e.g. if you have NPCs pulled from existing attendees) please mention that in your Game Proposal, and the Proposal chair will work with you before your game is accepted.
+</p>
+<p>
+For help figuring out how many comps your game can ask for, please refer to <a href="{% page_url comp-display%}">this handy chart</a>.
+</p>
+  <p>
+    In addition, the Conchair has a number of Discretionary Comps that they can use to address GM or attendee financial need/hardship.  If the comp policy would make it harder to or prevent you from being able to attend Intercon, please reach out to the {{gm_coordinator.name_with_email_link}} or {{con_chair.name_with_email_link}} and they will work with you.
+    <p>
+<p>
+  These comped memberships can be assigned by the GM team in any manner they see fit. These memberships are full memberships and allow the 
+  holder to sign up for games in advance and have full access to all Intercon convention events and resources for the weekend.  GMs can assign their comp(s) using the "Edit GMs" link on their game page.
+</p>
+<p> 
+  Intercon runs on a tight budget and while we'd like to comp every GM, it is not financially possible for us to provide more than a small number of comped full memberships for each game over a baseline size. If you have additional GMs for your game that wish to enjoy the rest of the Intercon convention, they will have to either purchase full memberships to the convention or you can request no-cost <a href='#NPCBadges'>NPC Badges</a> for them.
+</p>
+<p>Operations has a number of comps available for people who commit to a larger amount of at-con work.  Please reach out to the {{ops_chair.name_with_email_link}} to inquire about these.</p>
+  
+<p>Comped memberships may also be provided to people organizing non-larp events at Intercon. These include Forum@Intercon and Hospitality events.  One non-transferrable comped registration may be given to people who have had three or more hours of events accepted through the regular proposal process for Forum@Intercon or Hospitality. These comps are given only to the organizers of the events (so does not include guests on a panel or performers).</p>
+  
+<h3 class="my-2"><a name="Advertising">Advertising</a></h3>
+<p>We make a concerted effort to get word about all of our games out as far and
+as wide as we can. Your game is part of that advertising. If you have specific
+advertising material, please make sure that we have it, by working with the GM coordinator, so
+that we can distribute it wherever we go.
+</p><p>Word of mouth is the most powerful tool we have in promoting Intercon, and
+our GMs are our best promoters. We'd appreciate your help in getting players to
+register for your game, and for others. The Con Committee always works to make
+sure that Intercon is the best all-LARP con there is, to attract players from
+all around the world. With your help, we can make this the best Intercon ever.
+</p><p>Try and encourage other folks to register now, if you can. We want to start a
+positive feedback loop. The earlier we can announce a strong schedule, the more
+players will be attracted to the con. That will mean we'll have to go out and
+find more games, which will draw more players, and so on... If you know of
+people who want to play in your game, tell them the best way to guarantee their
+spot is to <i>register now</i>. That will allow them to sign up online as soon
+as we open registration for your game.
+</p>
+
+<hr>
+
+<h2 class="my-3"><a name="Policies">Policies</a></h2>
+<p>For the most part, the staff of the New England Intercon convention and the hotel are fairly lax about what you can and cannot do during the convention. There are a few rules, however, that do need to be followed. It is important to follow these policies; otherwise, the convention may not be welcomed back to the hotel. Other policies exist to ensure that everyone enjoys the convention.  If you have questions about any of these policies, or need help resolving any issues, please reach out to the {{gm_coordinator.name_with_email_link}} for assistance.</p>
+</p>
+
+<h3 class="my-2"><a name="RegistrationPolicy">Game Registrations</a></h3>
+<p>
+  Intercon follows a strict first come, first serve policy when it comes to game registrations. If there is someone who <i>must</i> be in your game, the best solution is to have them sign up early, to make sure they get in. Alternatively, you have the option of making them a GM for your game.
+</p>
+<p>
+  We require you to cast your game based on the buckets that were indicated by your players at signup time.  For example, if someone signs up for a female role in your game, we expect you to cast them in a female role, or get their permission before casting them differently.
+</p>
+
+<p>
+  We recognize the fact that there are players out there that may be difficult to deal with. However, we cannot and do not discriminate. If a player signs up for your game, we expect that you will do your best to give them a part that is appropriate. 
+</p>
+  
+<p>
+  We understand that your game may have certain restrictions that exclude certain players from participating. For example, if a game is a boffer combat game, there may be insurance reasons that require restrictions such as for players under the age of 18. Other games may deal with adult subject matter and be inappropriate for minors. If there is such a restriction, we expect that you will make it clear in your Proposal Form and game description. If there is a conflict with someone who has signed up for your game violating the restrictions on it, please work with the GM Coordinator to modify any game registrations.
+</p>
+
+<p>
+  If your game has an age restriction, you must provide a public text description of the restriction, and can optionally provide a private numeric cutoff age.  The numeric cutoff age will be used to display if the player signed up for your game is below the specified age or has not disclosed their age, but does not block them from signing up.  The site does not enforce age restrictions; you must do so yourself.
+</p> 
+
+<h3 class="my-2"><a name="Communication">Communication</a></h3>
+<p>
+  We also recognize that just as GMs need to hear from their players before the convention, players also need to hear from their GMs as well. Players can become anxious when they do not hear from the GMs of the game(s) they have signed up for that seem to require advance information. The timing of any communications from you, as GMs, to your players will vary depending on the amount of information you need or want to give them, what information you need from them, how quickly your game fills, and your own readiness.  During the proposal process, we ask you to state your communications plan, and it is displayed on your game page to help set players’ expectations.  
+</p>
+
+<p>
+  We recommend contacting your players by early January, even if your game does not require much advance preparation (e.g. if all information is given “at the door”).  Concerned players may contact you directly or through the Attendee or GM Liaison.
+</p>
+<h4 class='my-2'><a name="canceling">Canceling your game</a></h3>
+<p>
+  If the worst should happen and you are unable to attend the New England Intercon convention or will be unable to run the game you have proposed to the convention, please contact the {{gm_coordinator.name_with_email_link}} as soon as possible so that we are aware of the problem.  Please reach out to us <strong>before</strong> communicating with your players, as we may be able to find a replacement game or GMs, or work with you in some other way to resolve the situation, and we would want to communicate that to your players at the same time.  When you do contact your players about a cancelation, please CC {{gm_coordinator.email_link}} on your email.
+</p>
+
+<h3 class="my-2"><a name="non-responsive">Non-Responsive Players</a></h3>
+<p>
+  We understand that your game may be tightly plotted or depend on pre-convention communication from the players who have signed up for the game. In these cases, non-responsive players can be troubling for your plans to ensure that everyone in your game has a great time. Start early and reach out to your players well before the convention.
+</p>
+
+<p>
+  If you have made a good faith effort to contact a player and have not received any response for over <strong>two weeks</strong>, please reach out to the {{gm_coordinator.name_with_email_link}}, who will attempt to get in touch with the player on your behalf.  If at <strong>one month</strong> prior to the convention, they are not able to reach the player themselves,  they will work with you to modify any game registrations.
+</p>
+
+
+
+<h3 class="my-2"><a name="NPCBadges">NPC Badges</a></h3>
+<p>For some games, you may need to bring in some help from outside the
+convention to run your event.  This could be a GM who knows the game, but is
+not planning on attending Intercon, or NPCs who are only going to show up for
+your event.   We ask that you attempt to fill the need from the pool of
+Intercon attendees, but we understand that at times that may not be possible.</p>
+<p>If you have a need for NPCs, please mention it on your proposal, or send an email
+to the Proposal Chair (before your game is accepted) or the GM Coordinator (after
+your game has been accepted) detailing how many NPC badges you will need, and
+why.</p>
+<p>The convention staff will evaluate your request, and let you know how many
+NPC badges we will provide.  If there are a lot of requests in one year, we may
+work with multiple GM teams to share resources where appropriate.</p>
+<p>
+NPC badges grant limited access to the convention.  A holder of an NPC badge
+may substitute for last-minute openings in other games but may not sign
+up for games in advance. The primary purpose of an NPC badge is to allow
+additional people to help your game.</p>
+<p>
+There is no cost for NPC badges.  A list of names associated with these badges
+must be provided to the GM Coordinator no later than one week before the
+convention.  The NPC can pick up their convention badge at the Operations desk.  NPCs, as with all attendees, must comply with the <a href="{% page_url covid%}">covid policy</a></p>
+
+<h3 class="my-2"><a name="WeaponPolicy">Weapons</a></h3>
+<p>
+The hotel is very concerned about scaring the mundanes with real looking
+weapons (and rightfully so). As such, they have requested that <i>any weapons
+used in a game must be obvious fakes</i>. The Intercon staff recognizes that
+this may not be practical for all games as tone and mood setting are very
+important aspects of a LARP. If your game requires the use of weapons that could
+be construed as real, we ask the following:
+</p><ul>
+<li>If at all possible, please keep all weapon props behind closed doors.
+</li>
+<li>If the players need to leave the function space (or travel from one function
+room to another), make sure your players have blades sheathed and guns hidden.
+We will be on extra alert for this given that recent current events have
+hypersensitized people to any threats of violence.
+</li>
+<li>
+<i>Absolutely no combat (with fake or real-looking weapons) may take place in the
+<b>public</b> hallway areas</i>. </li>
+</ul>
+<p>If this policy is not strictly adhered to, the hotel has the right to expel
+the player or game in question without warning. Intercon staff will issue one
+warning; if this policy is violated a second time, the player may be asked to leave and/or the game
+may be closed down.
+</p>
+
+<h3 class="my-2"><a name="AlcoholPolicy">Alcohol</a></h3>
+<p>Because of the hotel's liquor license and strict Rhode Island state law,
+alcohol in function spaces may only be served by a bartender from the hotel. Players and GMs may
+not bring their own alcohol into the game space. If a GM would like to have a
+real bar for their game, we can <a href="#BarService">make arrangements with the
+hotel</a>.
+</p><p>Players, GMs, or Games found in violation of this policy will be asked to
+remove the alcohol from the game space immediately. If they do not comply, they
+will be asked to leave the hotel. If you opt to have a bartender, the bartender
+will card your players.
+</p><h3 class="my-2"><a name="FirePolicy">Candles or Fire</a></h3>
+<p>Candles are allowed as long as they are contained in a glass holder that is
+at least one inch taller than the flame.
+</p><h3 class="my-2"><a name="WallHangingPolicy">Wall Hangings</a></h3>
+<p>
+You may hang things on the wall, doors, pillars, columns, etc. provided you use mounting putty. Intercon Ops may have a small amount of approved putty on hand, but it is recommended that you bring your own supply.
+</p>
+
+<hr>
+
+<h2 class="my-3"><a name="Services">Services</a></h2>
+<p>There are several services that the con can provide for your game. There are
+other services that we can arrange with the hotel.
+</p>
+
+<h3 class="my-2"><a name="SpaceService">Game Space</a></h3>
+<p>Intercon rents almost all the conference space available in the hotel. We encourage
+you to review the <a href="{% page_url hotel/layout %}" target="_blank">conference space layout</a> and the <a href="https://docs.google.com/document/d/1dzNp_HzsMJnHOGK3NIDLJ71VYFtotTIHaiIQB8pJH-Y">Hotel FAQ</a>.
+</p><p>It is important that you let us know your space requirements as soon as you
+understand those requirements. We cannot guarantee that you will receive the
+room(s) that you request. We need to know your sense of space requirements in
+general; we will do our best to give you the best possible game space. However,
+we have to fit all of the games at the con in your timeslot(s), which may mean
+some creativity in meeting your space needs. Final space assignments are
+probably not possible until a month or so before the convention.
+</p>
+
+<h3 class="my-4"><a name="FurnitureService">Furniture</a></h3>
+<p>The hotel has the following furniture available:
+</p>
+<ul>
+<li>Tables and Chairs
+<ul>
+<li>Standard conference chairs</li>
+<li>A very limited number of 6' Classroom Tables (18"-wide rectangles)</li>
+<li>A very limited number of 6'x30" Rectangles</li>
+<li>60" Rounds (seats 8)</li>
+</ul></li>
+<li>Other Items
+<p>Supplies of these are limited. If you require one or more of these
+items, please let us know as soon as possible. These will be allocated on a
+first request, first serve basis.</p>
+<ul>
+<li>Digital projector and portable screen</li>
+<li>Dance floor</li>
+<li>Riser/platform</li>
+<li>Lecterns</li>
+<li>Room dividers</li>
+</ul>
+</li>
+</ul>
+<h3 class="my-2"><a name="FoodService">Food</a></h3>
+<p>The contract we have with the hotel grants them the exclusive right to cater
+events.  Event organizers are not allowed to serve outside food or drinks to
+their attendees.  If you wish to serve food or drinks, the hotel will happily
+cater your event for a fee.
+</p><p>The hotel has many <a href="{% page_url hotel/menu %}">standard menus</a> ranging from
+snacks to full meals. Menus start around $4.00 per person (for snacks / very
+light meals) and go up from there. Prices on the menu do not include the 1% Food and Beverage Tax, 7% sales tax, and 21% service charge that you will be responsible for.  The hotel is also willing to work with the GMs to provide a specialized meal for your game.
+</p>
+<p>Food orders are due by the end of January in order to give us time to finalize the
+menu, so, if you are considering ordering food, you must work with the {{gm_coordinator.name_with_email_link}} in advance. <strong>Intercon cannot pay for food for your game. GMs are
+responsible for payment</strong>.  Intercon will pay for the food on the master hotel bill, and bill you for what you are responsible for after the convention.
+</p>
+  <p>
+    Intercon arranges for water and disposable cups to be provided for every room by the hotel for all events as a standard service.
+  </p>
+
+<h3 class="my-2"><a name="BarService">Bartenders</a></h3>
+<p>Bartenders are available from Monday through Saturday, from 11:00am to
+1:00am. Costs for the bartender are $100.00 for up to 6 hours, plus a 21% service fee.  Because providing a bartender is
+not cheap, you may ask your players to make a donation to cover the costs of the
+food. They are not required to pay in order to play, however. <i>Intercon cannot
+pay for these items. GMs are responsible for payment</i>.  You will be billed by Intercon after the convention.
+</p>
+
+<h3 class="my-2"><a name="OpsService">Intercon Ops Staff</a></h3>
+<p>
+Intercon Operations Staff are available throughout the Con to assist you. They will help you set up if time and people are available. If you need anything from the hotel staff, please contact Ops.  Ops and hotel staff will also be around during the running of your game to make sure you have water, etc.
+</p><p>
+If you know that your game may have a difficult set up or break down, let the GM Coordinator and Proposal Chair know so we can schedule your game appropriately.
+</p>
+
+<h3 class="my-2"><a name="HotelService">Hotel Negotiations and Arrangements</a></h3>
+<p>
+We ask that you let the Intercon Staff make the arrangements for the
+equipment and food. Depending on the demands of the con, we may be able to
+negotiate a lower rate for you individually. (At the very least, if we know
+several people want to use a resource, the cost can be split evenly among them).
+GMs will pay Intercon for the rentals and food. Payment for everything is due by
+mid-February. If payment is not received by this date, the order will be
+cancelled. (If more than one GM is sharing a resource, the other GM(s) will be
+asked to pick up the additional cost). If you meet the deadlines stated above,
+we will be able to give you a final price for the food and final equipment
+rental prices no later than February 1<sup>st</sup>. If you miss the above deadlines, we cannot guarantee that you will receive your requested items.</p>
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/hotel.liquid
+++ b/cms_content_sets/wanderlust/pages/hotel.liquid
@@ -1,0 +1,163 @@
+---
+name: Hotel Information
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign hotel_liaison = convention.staff_positions_by_name.hotel_liaison %}
+<h1 class="my-3">Hotel Information</h1>
+<div class="row">
+ <div class='col order-md-1'>
+   <div class="card">
+    <div class="card-header">
+      <p>
+        <h5 class="text-center"><a href="http://www.crownehotelwarwick.com" target="_blank">Crowne Plaza Providence-Warwick</a></h5>
+      </p>
+      <p class="text-center">
+        801 Greenwich Ave
+        <br>Warwick, RI 02886
+      </p>
+    </div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">
+          <h5 class='card-title'> Details </h5>
+          <dl class="row">
+            <dt class="col-md-6">Phone:</dt>
+            <dd class="col-md-6"><a href="tel:+14017326000">(401) 732-6000</a></dd>
+            <dt class="col-md-6">Block code:</dt>
+            <dd class="col-sm-6">{{hotel_block_code}}</dd>
+            <dt class="col-md-6">Checkin<span class="d-inline d-md-none d-lg-inline"> time</span>:</dt>
+            <dd class="col-md-6">3:00 PM</dd>
+            <dt class="col-md-6">Checkout<span class="d-inline d-md-none d-lg-inline"> time</span>:</dt>
+            <dd class="col-md-6">11:00 AM</dd>
+            <dt class="col-md-6">King bed<span class="d-inline d-md-none d-lg-inline"> rate</span>:</dt>
+            <dd class="col-md-6">${{hotel_king_rate}}/night</dd>
+            <dt class="col-md-6"><span class="d-inline d-md-none d-lg-inline">Two </span>Queen beds<span class="d-inline d-md-none d-xl-inline"> rate</span>:</dt>
+            <dd class="col-md-6">${{hotel_double_rate}}/night</dd>
+          </dl>
+        </li>
+        <li class="list-group-item">
+          <h5 class="card-title">
+            How to make a reservation for Intercon
+          </h5>
+          <p>
+            It's easy! Call the Crowne Plaza at  <nobr>(401) 732-6000</nobr> or use their website, providing the above room block code.
+          </p>
+        </li>
+        <li class="list-group-item">
+          <p>
+            The above rates cover up to 4 people per room. 
+            If you make a reservation for more than 4 people, you may be charged additional fees at the discretion of the hotel.
+          </p>
+          <p>
+            If you would prefer a quiet room (floors 4-5), or an active room (floor 6), please mention that when you make your reservation.
+          </p>
+        </li>
+        <li class="list-group-item">
+	  <p>
+            <b>Note:</b> It is <a href="#whyReserve">very important</a> that
+            you make the reservation as part of the Intercon group!
+            </p>
+<p>The convention runs from 
+  {% assign startMonth = convention.starts_at | date: "%m" %}
+    {% assign endMonth = convention.ends_at | date: "%m" %}
+    
+    {{ convention.starts_at | date: "%A %d-%b-%Y" }} to {{convention.ends_at|date: "%A %d-%b-%Y"}}.
+    
+            If there are any problems or questions, please
+            feel free to send email to our {{ hotel_liaison.name_with_email_link}}.
+          </p>
+          </li>
+        </ul> 
+     </div>
+  </div>
+  <div class="col-md-7">
+    <p>
+      Intercon takes place at the <a href="http://www.crownehotelwarwick.com/" target="_blank">Crowne Plaza</a> in Warwick, Rhode Island!
+    </p>
+    <p>
+      The Crowne Plaza is <a href="https://goo.gl/maps/GbEtaHyedfQ2" target="_blank">conveniently located</a> just off Route 95 and 295 in Warwick, and there is a shuttle bus from nearby T. F. Green airport and commuter rail station.
+    </p>
+    <p>
+      We've put together a <a href="{% page_url hotel/faq %}">Hotel FAQ</a> with images of all the function spaces to answer many of your questions, which will be updated as we gather more information.
+    </p>
+    <p>
+      We encourage you to review the <a href="{% page_url hotel/layout %}">conference space layout</a>.
+    </p>
+    <p class='text-center'>
+      <img class='img-fluid' src="{% file_url "crowneplaza.jpg" %}" border="0">
+    </p>
+   
+    <p>
+      The hotel allows up to four people to occupy a room. 
+    </p>
+    <p>
+      ADA-accessible rooms are available on request.  The Crowne Plaza is a non-smoking hotel.
+    </p>
+    <p>
+      In 2020, the hotel renovated all guest rooms.  <a href="{% page_url hotel/renovation %}">See their flyer</a>.
+    </p>
+    <p>
+      All rooms include:
+    </p>
+    <ul>
+      <li>Alarm clock / radio</li>
+      <li>In-room coffee maker</li>
+      <li>Minifridge</li>
+      <li>Hair Dryer</li>
+      <li>Iron and ironing board</li>
+      <li>Television with cable channels and video check-out</li>
+      <li>Complimentary high speed Internet</li>
+    </ul>
+    <p>The hotel also has additional guest services:
+    </p>
+    <ul>
+      <li>Complimentary shuttle to T.F. Green Airport</li>
+      <li>Business amenities including fax, copier, and personal computer</li>
+      <li>Printing and photocopying services</li>
+      <li>Laundry and dry cleaning</li>
+      <li>24 hour room service</li>
+      <li>Wake up service</li>
+      <li>Indoor heated swimming pool with fitness room</li>
+      <li>Cribs</li>
+      <li>Microwaves available in the common areas on the second and fifth floors</li>
+    </ul>
+  </div>
+ 
+</div>
+
+<div class='row'>
+  <div class='col'>
+    <h4 class='my-2'>
+      <a name="earlyAndLate">Early Arrival and Late Departure</a>
+    </h4>
+    <p>
+      Should you arrive on Friday before checkin, or for the remainder of
+      the con after Sunday checkout, Intercon and Hotel Staff can provide
+      a secure area for your belongings.
+    </p>
+    <h4  class='my-2'>
+      <a name='issues'>Hotel Issues and Questions</a>
+    </h4>
+    <p>
+      If there are any problems or questions before the con,
+      please contact our {{ hotel_liaison.name_with_email_link}}. The
+      Hotel Liaison will also be available at the con to solve any problems.
+      Please let the Ops Desk know of any issues; they will know where the
+      Hotel Liaison is at any given time. We are very good at expediting
+      solutions with the hotel, so it's best if you come find us to help out
+      first.
+    </p>  
+    
+    <div class="card border-info">
+      <h5 class="card-header">
+        <a name="whyReserve">Why reserve in the Intercon block?</a>
+      </h5>
+      <div class="card-body">
+        <p class="card-text">
+We know it may be possible to get a slightly cheaper hotel rate by booking outside the Intercon room block.  If you want to do that, we totally understand!  But we'd really appreciate it if you could reserve a room within the block, because we've made a guarantee to the hotel for a number of room nights. In addition, each room night booked reduces Intercon's function space cost, which lets us improve the convention in many ways, and helps fund the other cool LARP-related things we do.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cms_content_sets/wanderlust/pages/hotel/faq.liquid
+++ b/cms_content_sets/wanderlust/pages/hotel/faq.liquid
@@ -1,0 +1,403 @@
+---
+name: Hotel FAQ
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">{{convention.name}} Hotel FAQ and Room Images</h1>
+<div class="row">
+  <div class="col-lg-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Hotel FAQ</h4>
+      </li>
+      <li class="toc-entry"><a href="#logistics">Logistics</a>
+        <ul>
+          <li class="toc-entry"><a href="#logistics-getting-there">Getting There</a></li>
+          <li class="toc-entry"><a href="#logistics-reservations">Reserving a Room</a></li>
+          <li class="toc-entry"><a href="#logistics-hotel-rooms">Hotel Rooms</a></li>
+          <li class="toc-entry"><a href="#logistics-parlors">Parlors</a></li>                                                                       
+          <li class="toc-entry"><a href="#logistics-larp-space">Space for Larps</a></li>
+          <li class="toc-entry"><a href="#logistics-food">Food</a></li>
+          <li class="toc-entry"><a href="#logistics-floor-plan">Hotel Map</a></li>
+        </ul>
+      </li>
+      <li class="toc-entry"><a href="#rooms">Function Rooms</a>
+        <ul>
+          <li class="toc-entry"><a href="#rooms-table">Sizes and Locations</a></li>
+          <li class="toc-entry"><a href="#rooms-atrium">Atrium</a></li>
+          <li class="toc-entry"><a href="#rooms-basement">Barrington, Greenwich, Kingston</a></li>
+          <li class="toc-entry"><a href="#rooms-bristol">Bristol A & B</a></li>
+          <li class="toc-entry"><a href="#rooms-naragansett">Naragansett</a></li>
+          <li class="toc-entry"><a href="#rooms-newport">Newport & Wickford</a></li>
+          <li class="toc-entry"><a href="#rooms-ocean">Ocean</a></li>
+          <li class="toc-entry"><a href="#rooms-patriots">Patriots</a></li>
+          <li class="toc-entry"><a href="#rooms-rhode-island">Rhode Island</a></li>
+          <li class="toc-entry"><a href="#rooms-rotunda">Rotunda</a></li>
+          <li class="toc-entry"><a href="#rooms-tiverton">Tiverton</a></li>
+          <li class="toc-entry"><a href="#rooms-parlors">Parlors A-D</a></li>
+          <li class="toc-entry"><a href="#rooms-boardrooms">Elms & Wellington</a></li>
+          <li class="toc-entry"><a href="#rooms-plaza-foyer">Plaza Foyer</a></li>
+          <li class="toc-entry"><a href="#rooms-guest-room">Intercon-Provided Guest Room</a></li>
+        </ul>
+      </li>
+</ul>
+</div>
+<div class='col'>
+
+<h2 class="my-3"><a name='logistics'>Logistics</a></h2>
+
+<h3 class="my-2"><a name='logistics-getting-there'>Getting There</a></h3>
+<p><strong>By car:</strong> The Hotel is just over an hour from downtown Boston via I-95.</p>
+<p><strong>By public transit:</strong> The Providence/Stoughton Line of the MBTA commuter rail goes to TF Green Airport from Boston's South Station during the week, and there is a shuttle from there to the hotel which runs regularly until the evening, and then will do pickups by request. (1-401-732-6000).  Please note that, at this time, the MBTA commuter rail does not go all the way to TF Green on the weekends.</p>
+<p><strong>By air:</strong> Fly to Logan (BOS) and take the MBTA as above, or tor TF Green (PVD) and take the shuttle to the airport.
+  <br>
+The hotel runs a shuttle to the airport 7 days a week, on the :05, :25, :45 of every hour between 4:00am-1:00am. If you need pickup from the airport, you can call the hotel directly once at baggage claim and a shuttle will be sent. The shuttle picks up from the second curb.</p>
+
+<h3 class="my-2"><a name='logistics-reservations'>Room Reservations</a></h3>
+  <p>
+You can reserve a room on <a href="https://www.crownehotelwarwick.com/" target="_blank">the hotel's webpage</a> or by calling 1-401-732-6000 and using the group code <strong>‘{{ hotel_block_code }}’</strong>.  Rooms are ${{hotel_king_rate}} per night, and are available with a king bed or two queen beds.  More information about the rooms, including sizes is available on <a href="http://www.crownehotelwarwick.com/accommodations" target="_blank">The hotel's accomodations page.</a>
+  </p>
+
+<h3 class="my-2"><a name='logistics-hotel-rooms'>Hotel Rooms</a></h3>
+<p>
+  Attendee rooms are about the same size as at other hotels we have used previously, although all rooms have been recently renovated.
+</p>
+  <div class='row'>
+    <div class='col'>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-guest-room.jpg" %}" border="0">
+    King Room
+  </p>
+    </div>
+    <div class='col'>
+       <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-guest-room-queen.jpg" %}" border="0">
+         Two Queen Room
+  </p>
+    </div>
+  </div>
+
+  <h3 class="my-2"><a name='logistics-parlors'>Parlors</a></h3>
+  <p>
+    The hotel has four parlors, which Intercon has rented for game space.  Each parlor has a living room area, dining room area, and a kitchenette area, and a bathroom, but is one large space other than the bathroom.  These will be used for function / game space.
+  </p>
+  
+<h3 class="my-2"><a name='logistics-larp-space'>Space for Larps</a></h3>
+  <p>
+    Because the Crowne Plaza has very large rooms, it is unlikely that any game will have more than one space to run in.  Intercon and NEIL own room dividers to break up rooms into multiple spaces.  You can request these when you request furniture for your game.
+  </p>
+
+  <h3 class="my-2"><a name='logistics-food'>Food</a></h3>
+  <p>
+    Intercon has contracted with the Crowne Plaza to provide concessions.  These have been reliably of good quality, better than at previous hotels, and Intercon has committed to a Food & Beverage minimum in order to get the contract with the hotel.  Please be aware that the hotel restaurant and room service will not count towards the fee.  Intercon negotates with the hotel to provide vegetarian and gluten-free options at the consessions.
+  </p>
+
+  <h3 class="my-2"><a name='logistics-floor-plan'>Hotel Floor Plan</a></h3>
+  <p>
+This is the map of the hotel provided by the hotel, along with the number of attendees that they would regularly use each space for.  We also have a <a href="{% page_url hotel/layout %}">nicer verson</a> available.
+  </p>
+  <p class='text-center'>
+    <img class='img-fluid' src="{% file_url "crowne-plaza-hotel-map.png" %}" border="0">
+  </p>
+
+  <h2 class="my-3"><a name='rooms'>Function Rooms</a></h2>
+  <h3 class="my-2"><a name='rooms-table'>Sizes and Locations</a></h3>
+  <div class='alert alert-warning d-md-none mt-2'>
+    Room Details and Category are hidden due to small screen size.  To view additional details, please use a larger screen.
+  </div>
+  <div class="table-responsive">
+  <table class='table table-sm table-striped'>
+    <thead>
+      <tr>
+        <th>Room</th>
+        <th>FT<sup>2</sup></th>
+        <th>Dimensions</th>
+        <th>Height</th>
+        <th>Floor</th>
+        <th class='d-none d-md-table-cell'>Details</th>
+        <th class='d-none d-md-table-cell'>Size Category</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="#rooms-atrium">Atrium</a></td>
+        <td>2800</td>
+        <td></td>
+        <td></td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'>Consuite/Boffers</td>
+        <td class='d-none d-md-table-cell'>Large</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-basement">Barrington</a></td>
+        <td>960</td>
+        <td>30' L x 32' W</td>
+        <td>12'</td>
+        <td>Lower</td>
+        <td class='d-none d-md-table-cell'>Has Bar</td>
+        <td class='d-none d-md-table-cell'>Medium</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-bristol">Bristol A</a></td>
+        <td>1188</td>
+        <td>44' L x 27' W</td>
+        <td>12'</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'>Divided</td>
+        <td class='d-none d-md-table-cell'>Medium</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-bristol">Bristol B</a></td>
+        <td>1188</td>
+        <td>44' L x 27' W</td>
+        <td>12'</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'>Divided</td>
+        <td class='d-none d-md-table-cell'>Medium</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-basement">Greenwich</a></td>
+        <td>960</td>
+        <td>30' L x 32' W</td>
+        <td>12'</td>
+        <td>Lower</td>
+        <td class='d-none d-md-table-cell'>Has Bar</td>
+        <td class='d-none d-md-table-cell'>Medium</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-basement">Kingston</a></td>
+        <td>960</td>
+        <td>30' L x 32' W</td>
+        <td>12'</td>
+        <td>Lower</td>
+        <td class='d-none d-md-table-cell'>Has Bar</td>
+        <td class='d-none d-md-table-cell'>Medium</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-naragansett">Naragansett</a></td>
+        <td>960</td>
+        <td>40' L x 24' W</td>
+        <td>14'</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'>Divided</td>
+        <td class='d-none d-md-table-cell'>Medium</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-newport">Newport</a></td>
+        <td>900</td>
+        <td>30' L x 30' W</td>
+        <td>12'</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'></td>
+        <td class='d-none d-md-table-cell'>Medium</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-ocean">Ocean</a></td>
+        <td>600</td>
+        <td>40' L x 15' W</td>
+        <td>14'</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'>Divided</td>
+        <td class='d-none d-md-table-cell'>Small</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-patriots">Patriots</a></td>
+        <td>960</td>
+        <td>40' L x 24' W</td>
+        <td>14'</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'>Divided</td>
+        <td class='d-none d-md-table-cell'>Medium</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-plaza-foyer">Plaza Foyer</a></td>
+        <td>1800</td>
+        <td>100'L x 30'</td>
+        <td>12'</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'>Vendors/Services</td>
+        <td class='d-none d-md-table-cell'>Large</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-rhode-island">Rhode Island</a></td>
+        <td>600</td>
+        <td>40' L x 15' W</td>
+        <td>14'</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'>Divided</td>
+        <td class='d-none d-md-table-cell'>Small</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-rotunda">Rotunda</a></td>
+        <td>3060</td>
+        <td>84' X 22' + 115' cir</td>
+        <td>16' (32')</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'>Boffers/Consuite</td>
+        <td class='d-none d-md-table-cell'>Large</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-tiverton">Tiverton</a></td>
+        <td>1209</td>
+        <td>39' L x 31' W</td>
+        <td>12'</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'></td>
+        <td class='d-none d-md-table-cell'>Large</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-newport">Wickford</a></td>
+        <td>900</td>
+        <td>30' L x 30' W</td>
+        <td>12'</td>
+        <td>Ground</td>
+        <td class='d-none d-md-table-cell'></td>
+        <td class='d-none d-md-table-cell'>Medium</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-parlors">Parlors A-D</a></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td>6th</td>
+        <td class='d-none d-md-table-cell'>Parlor</td>
+        <td class='d-none d-md-table-cell'>Small</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-boardrooms">Elms</a></td>
+        <td>200</td>
+        <td>20' L x 10' W</td>
+        <td>10'</td>
+        <td>3rd</td>
+        <td class='d-none d-md-table-cell'>Board</td>
+        <td class='d-none d-md-table-cell'>Small</td>
+      </tr>
+      <tr>
+        <td><a href="#rooms-boardrooms">Wellington</a></td>
+        <td>200</td>
+        <td>20' L x 10' W</td>
+        <td>10'</td>
+        <td>6th</td>
+        <td class='d-none d-md-table-cell'>Board</td>
+        <td class='d-none d-md-table-cell'>Small</td>
+      </tr>
+     
+      <tr>
+        <td><a href="#logistics-hotel-rooms">Extra Rooms</a></td>
+        <td>377</td>
+        <td></td>
+        <td>10'</td>
+        <td>1st-6th</td>
+        <td class='d-none d-md-table-cell'>Guest Room</td>
+        <td class='d-none d-md-table-cell'>Small</td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+  
+  <p class='d-none d-md-block'>
+    Notes:
+<ul class='d-none d-md-block'>
+  <li>A Small room can easily fit a larp with 5-15 players.</li>
+  <li>A Medium room can fit a larp with 15-50 players, depending on the larp.</li>
+  <li>A Large room can fit a conference-sized event, or a larp that requires a lot of movement.</li>
+  <li>Boardrooms have 10 chairs around a large table.</li>
+  <li>Parlors have seating for ~18 people, in various locations.</li>
+  <li>Bar rooms have a bar in one corner, which can be used for GM staging space, or any other use.</li>
+  <li>Divided rooms are parts of larger ballrooms, and have an air-wall dividing them from adjacent space.</li>
+  <li>Guest rooms, rented by Intercon, are used as additonal larp spaces (typically next to Parlors), or for additional convention services space (i.e. Quiet Room)
+</ul>
+</p>
+
+  <h3 class="my-2"><a name='rooms-atrium'>Atrium</a></h3>
+  <p class='text-center'>
+      <img class='img-fluid rounded' src="{% file_url "hotel-atrium.jpg" %}" border="0">
+    </p>
+  
+  <h3 class="my-2"><a name='rooms-basement'>Barrington, Greenwich, Kingston</a></h3>
+  <p>Greenwich is pictured</p>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-greenwich.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-bristol'>Bristol A & B</a></h3>
+  <p>Bristol B is pictured</p>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-bristol-b.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-naragansett'>Naragansett</a></h3>
+  <p>Patriots is pictured</p>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-patriots.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-newport'>Newport & Wickford</a></h3>
+  <p>Newport is pictured</p>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-newport.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-ocean'>Ocean</a></h3>
+  <p>Patriots is pictured, which is 9' wider, but the same length</p>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-patriots.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-patriots'>Patriots</a></h3>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-patriots.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-rhode-island'>Rhode Island</a></h3>
+  <p>Patriots is pictured, which is 9' wider, but the same length</p>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-patriots.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-rotunda'>Rotunda</a></h3>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-rotunda.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-tiverton'>Tiverton</a></h3>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-tiverton.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-parlors'>Parlors A-D</a></h3>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-parlor.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-boardrooms'>Elms & Wellington</a></h3>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-boardroom.jpg" %}" border="0">
+  </p>
+
+  <h3 class="my-2"><a name='rooms-plaza-foyer'>Plaza Foyer</a></h3>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-plaza-foyer.jpg" %}" border="0">
+  </p>
+  <h3 class="my-2"><a name='rooms-guest-room'>Intercon-Provided Guest Rooms</a></h3>
+<p>
+  These are guest rooms, attached to the Parlors, which may be used for small games or for overflow/additional space for the games in parlors.
+</p>
+  <div class='row'>
+    <div class='col'>
+  <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-guest-room.jpg" %}" border="0">
+    King Room (most likely to be used for larp)
+  </p>
+    </div>
+    <div class='col'>
+       <p class='text-center'>
+    <img class='img-fluid rounded' src="{% file_url "hotel-guest-room-queen.jpg" %}" border="0">
+         Two Queen Room (less likely to be used for larp)
+  </p>
+    </div>
+  </div>
+
+
+

--- a/cms_content_sets/wanderlust/pages/hotel/layout.liquid
+++ b/cms_content_sets/wanderlust/pages/hotel/layout.liquid
@@ -1,0 +1,12 @@
+---
+name: Hotel Layout
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">Crowne Plaza Providence-Warwick</h1>
+<div class="row justify-content-center">
+    <div class="col-12 text-center">
+<img src="{% file_url "InterconV_CrownePlaza_map.png" %}" class="img-fluid" border="0">
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/hotel/menu.liquid
+++ b/cms_content_sets/wanderlust/pages/hotel/menu.liquid
@@ -1,0 +1,7 @@
+---
+name: Hotel Menu
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<p><a href="{% file_url "Crowne_Plaza_Menu_2024.pdf" %}" class="btn btn-secondary">Download PDF</a></p>
+<iframe src="{% file_url "Crowne_Plaza_Menu_2024.pdf" %}" style="width: 100%; height: 80vh; border: 1px solid #eee;"></iframe>

--- a/cms_content_sets/wanderlust/pages/hotel/renovation.liquid
+++ b/cms_content_sets/wanderlust/pages/hotel/renovation.liquid
@@ -1,0 +1,7 @@
+---
+name: Hotel Room Renovations
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<p><a href="{% file_url "Renovated_Rooms.pdf" %}" class="btn btn-secondary">Download PDF</a></p>
+<iframe src="{% file_url "Renovated_Rooms.pdf" %}" style="width: 100%; height: 80vh; border: 1px solid #eee;"></iframe>

--- a/cms_content_sets/wanderlust/pages/intercode2-presentation.liquid
+++ b/cms_content_sets/wanderlust/pages/intercode2-presentation.liquid
@@ -1,0 +1,12 @@
+---
+name: Intercode 2 Presentation
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-2">Intercode 2 Presentation</h1>
+<div class="row justify-content-center">
+<div class="embed-responsive embed-responsive-4by3 col-xl-10">
+  <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/tWpLm55CXoU?rel=0&showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/irongm.liquid
+++ b/cms_content_sets/wanderlust/pages/irongm.liquid
@@ -1,0 +1,275 @@
+---
+name: The NEIL Iron GM Competition Overview
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign iron_gm = convention.staff_positions_by_name.iron_gm_coordinator %}
+<h1 class="my-3">Iron GM {{convention.starts_at | date: '%Y'}} - A LARP Writing Contest!</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Iron GM {{convention.starts_at | date: '%Y'}}</h4>
+      </li>
+      <li class="toc-entry"><a href="#prizes">Prizes</a></li>
+      <li class="toc-entry"><a href="#overview">Overview</a></li>
+      <li class="toc-entry"><a href="#writing">Contest Rules</a>
+        <ul>
+            <li class="toc-entry"><a href="#entering-registration">Contest Registration</a>
+              <ul>
+            <li class="toc-entry"><a href="#entering-signingup">Signing Up</a></li>
+          </ul></li>
+          <li class="toc-entry"><a href="#writing">Writing</a>
+          <ul>
+            <li class="toc-entry"><a href="#writing-teams">Writing Teams</a></li>
+            <li class="toc-entry"><a href="#writing-process">Writing Process</a></li>
+          </ul></li>
+        <li class="toc-entry"><a href="#running">Running</a>
+          <ul>
+            <li class="toc-entry"><a href="#running-printing">Printing</a></li>
+            <li class="toc-entry"><a href="#running-materials">Materials</a></li>
+            <li class="toc-entry"><a href="#running-space">Game Space</a></li>
+  
+          </ul></li>
+          <li class="toc-entry"><a href="#judging">Judging</a>
+            <ul>
+              <li class="toc-entry"><a href="#judging-readers">Readers</a></li>
+             <li class="toc-entry"><a href="#judging-players">Players</a></li>
+              <li class="toc-entry"><a href="#judging-scoring">Scoring</a></li>
+            </ul></li>
+
+        <li class="toc-entry"><a href="#publishing">Publishing</a></li>
+    </ul>
+  </li>
+  </ul>
+  </div>
+  <div class="col">
+
+<h2 class="my-3"><a name="registration">Team registration is OPEN!</a></h2>
+
+<h2 class="my-3"><a name="prizes">Prizes</a></h2>
+<ul class="list-unstyled">
+  <li>First Prize - $250<li>
+  <li>Second Prize - $150<li>
+  <li>Third Prize - $100</li>
+</p>
+</ul>
+<hr>
+<h2 class="my-3"><a name="overview">Overview</a></h2>
+<p>
+    Iron GM will be running at Intercon W! The competition will run from 8pm Friday January 10th to 8pm Saturday January 11th EST. 
+If you are interested in writing a game, sign up at <a href="https://forms.gle/2w78zChc75tRUhNP6" target="_blank" rel="noopener noreferrer">https://forms.gle/2w78zChc75tRUhNP6</a> by midnight December 31st. 
+</p>
+<p>
+  Iron GM is a LARP writing contest where teams of writers create games over 24 hours. Games are reviewed by a team of readers, and then the writers run them at Intercon where they are scored by players. Running at Intercon is required in order to be eligible for prizes, but anyone can sign up to write just for fun.
+</p>
+<p>
+  GM teams write a two-hour game, scalable for 5-12 players, based on three secret ingredients and one secret prop in 24 hours on a designated weekend prior to Intercon. The secret items are revealed to the GMs at the start of the writing period and to players at the start of playing (players may opt out if they wish to be surprised at the end of game). As an example, Intercon V's challenge was using a genre of Mystery, the theme of Community, the element of Meddling Gods/Supernatural Forces, with an additional secret prop of kaleidoscope glasses.
+</p>
+<p>
+  The goal is to have a complete game that can be run by any other GM team without major revisions. 
+</p>
+<p>
+  The dates for the 24-hour game-writing portion are 8pm Friday January 10th to 8pm Saturday January 11th EST. Can’t make those dates? Need a time adjustment? Can’t start on a Friday? Contact {{iron_gm.email_link}} – we are excited to work with you to find an alternative time!
+</p>
+<p>
+  The finished games will be run by the GM teams (or members of their teams) and played by Intercon attendees on Sunday, March 2nd 2025.
+</p>
+<p>
+  The games are judged on LARP craft, playability, enjoyability, and the integration of the secret ingredients. The winning GM teams receive prizes and bragging rights. (See more detailed rules below.)
+</p>
+<p>
+  We also deeply appreciate anyone willing to read and give constructive criticism or to play the games at the convention. Feedback from readers and players also helps decide which team will win the cash prize!  If you are interested in reading games, please fill out the form here: <a href="https://forms.gle/S22AvY4YHcT7nniz5" target="_blank" rel="noopener noreferrer">https://forms.gle/S22AvY4YHcT7nniz5</a>.
+</p>
+    
+<p>If you are interested in playing games, you can sign up for Iron  GM game slot on the Intercon website (or just come by on Sunday -- we almost always have openings for more players!
+</p>
+<p>
+  We don’t know what the games will be like yet, but we do know that the teams will have put a lot of creativity and effort into the finished product. We’re really excited every year to see what they come up with. So come join us: get a team together to write, or sign up to play.
+</p>
+{% assign num_igmc = iron_gm.user_con_profiles | size %}
+{% if num_igmc != 0 %}
+  <p>
+    This year, the {{iron_gm.name}} {% if num_igmc == 1 %}is{% else %}are{% endif %} {{iron_gm.user_con_profiles|map:'name_without_nickname'|to_sentence}}
+  </p>
+{% endif %}
+<p>
+  Contact us with any questions at {{iron_gm.email_link}}</a>.
+</p>
+
+<p>
+  Please, review the Rules below before signing up.
+</p>
+<hr>
+<h2 class="my-3"><a name="rules">Contest Rules</a></h3>
+<p>The contest and adherence to the rules below are overseen by the {{iron_gm.name}}. All inquiries and comments can be addressed to the {{iron_gm.name}} at {{iron_gm.email_link}}</a>. The {{iron_gm.name}} will make themselves available by Google chat and email during the writing process and at the convention.</p>
+
+<h3 class="my-2"><a name="entering-registration">Registration</a></h3>
+
+<p>Team registration for Iron GM will open soon. There is space for 6 competing teams. These spaces are on a first come first serve basis. Additional teams are welcome to sign up and write; if any of the first 6 teams is not able to finish their game or run it at Intercon, writing teams who signed up  later will be given the opportunity to compete by running their game at Intercon.
+</p>
+    
+<p>Players may register at any point after general game registration opens.</p>
+
+<h4 class="my-2"><a name="entering-signingup">Signing Up an Iron GM Team</a></h4>
+<p>Sign ups for teams are now open! See the top of this page for a link.
+ If you have questions or problems, or are looking for a group to join, please email the {{iron_gm.name}} at {{iron_gm.email_link}}.</p>
+
+<h3 class="my-3"><a name="writing">Writing</a></h3>
+<h4 class="my-2"><a name="writing-teams">Writing Teams</a></h4>
+<p>
+  Teams may consist of between 2 and 5 people. Individuals may enter the contest, but given the 24 hour limit on writing, doing so places single person teams at a disadvantage.  Part of the fun of the writing is the collaboration process.
+</p>
+<p>
+  Teams are asked to provide a team name and the names of the members of each team and their e-mail addresses.</p>
+    <p>The following people are not eligible to compete in the contest (although they may write for fun, read or play the games): NEIL board members or their immediate families, NEIL board advisors or their immediate families, the {{iron_gm.name}} or their immediate family.</p>
+
+<h4 class="my-2"><a name="writing-process">Writing Process</a></h4>
+<p>
+  No writing may be done before 8:00 PM Eastern Time on the first day of the contest, which marks the start of the Writing Phase. If a team has arranged an alternative writing time, no writing may be done before their alternative start time.
+</p>
+<p>
+  At 8:00 PM Eastern Time on the day of the contest, or at a team's alternative start time, the {{iron_gm.name}} will email the secret ingredients to all the teams, and will subsequently be available online to answer any questions they may have.
+</p>
+<p>
+  The secret ingredients will include a Genre, a Theme, an Element, and a Prop. (i.e. High Fantasy, Inner Conflict, The Philosopher’s Stone, and a cooking timer) All of the secret ingredients should be used in the game, but writers should feel free to have fun with them and interpret them in their own way. The prop can be used in any way, literally or otherwise, for plot, set dressing, or mechanics.
+</p>
+<p>
+<strong> (new) Iron GM is a competition for people. By participating, teams agree that human team members are creating the materials and are not using ChatGPT or other large language models in any way. Teams are welcome to use tools like randomizers or spell checkers, but should NOT use any tool to generate writing, even if that writing is later edited. Any team doing so forfeits any reward in the competition.</strong>
+</p>
+<p>
+Each team must write a game that can be run in two hours, and can be played by as few as 5 and as many as 12 players (and any number in between). A "game" must contain at least the following components (plus anything else the authors deem necessary). These must be provided in MSWord (.doc/.docx) or Adobe Acrobat (.pdf) format, and be printed on standard 8.5"x11" paper:
+</p>
+
+<ul>
+<li>
+  A one-paragraph blurb describing your game
+</li>
+<li>
+  <strong>(updated) A statement of what age range the game is appropriate for. Games must be appropriate for players 18+. Writers may choose to make their games appropriate for younger players. </strong>
+</li>
+<li>
+  <strong>(new) A statement of how long after the start time additional players can join the game (if at all). </strong>
+</li>
+<li>
+  12 character sheets, or equivalent character creation instructions
+</li>
+<li>
+  Runtime instructions, including specifications for how to scale to fit a cast of any size from 5 to 11
+</li>
+<li>
+  Any rulesheets or world background information (sometimes called blue sheets) needed for players to understand the game
+</li>
+<li>
+  Printing instructions, including how many copies of each sheet is required (Does everyone get a rules sheet? A background sheet? How many copies of gm information needs to be printed?)
+</li>
+<li>
+  Distribution/envelope-stuffing instructions (Which characters get which sheets? Are there paper props that go in with certain characters? What are they? Have you included those pre written in your paperwork?)
+</li>
+<li>
+  A plot reference book - This is a reference document used for information on the characters, settings, and other elements. It should outline briefly various plots, characters, and built-in gametime events, as well as instructions on running any mechanics. These components should make it possible for a team of GMs unfamiliar with the game to download it and run it without any additional development or writing.
+</li>
+<li>
+  <a href="https://interactiveliterature.org/NEIL/communityPolicies.html">Content warnings</a>
+</li>
+</ul>
+<p>
+  The game must comply with all Intercon GM Policies, listed on <a href="{% page_url gmpolicies %}">this page</a>.
+</p>
+
+<p>
+All written game materials must be submitted by 8:00 PM Eastern Time on the second day of the contest. Late submissions will still be accepted, but be penalized during scoring.
+</p>
+
+<h3 class="my-2"><a name="running">Running</a></h3>
+<p>
+Games will be run at Intercon, on Sunday.
+</p>
+<p>
+Games must run for two hours, including any pregame player prep and post-game wrap-up. GMs will be given some extra time during the con to set up/tear down their games, but they will only have access to the players for two hours.
+</p>
+<p>
+GMs will not have access to their player list before game. All casting must be done at game-start. The game can be run by any GM team as long as it involves at least one member of a registered competing team and no members of another team or anyone not eligible to participate in the contest.
+</p>
+<p>
+Game slots will be assigned at random; GMs can request slots, but must be prepared to run their game in any of the scheduled slots. The Iron GM Coordinator does not guarantee any preferred time will be available. GMs will be notified of which slot they are in as early as possible, so that they can sign up for games in the other slot if they so desire. GMs should not sign up to play another team's game.
+</p>
+
+<h4 class="my-2"><a name="running-printing">Printing</a></h4>
+<p>
+  Before the convention, the teams should follow the printing instructions to print, stuff and prepare their game. If this is a problem for your team, please contact the contest organizer and arrangements can be made.
+</p>
+<p>
+The character sheets and bluesheets and any other printing to be done on paper should be printed on regular weight (20lb) paper only. This paper may be any color you wish. The printing itself, however, must be all in black. For example, you may have blue sheets be on blue paper and character sheets be on yellow, but the actual words on the page must all be black. Images may be used on printed material, but they must either be of your own design or free-use images (please contact us if you have questions or concerns about this). Stipulations on color likewise apply to printing on index cards.
+</p>
+<h4 class="my-2"><a name="running-materials">Materials</a></h4>
+<p>
+The following materials may be included in the game; please include a list of any materials required in the plot reference book. GMs are expected to provide these materials. If this would be a hardship, contact {{iron_gm.name}} at least one week prior to the convention to arrange an alternative. 
+</p>
+<ul>
+<li>Enough blank name badges for one each for all the players and GMs</li>
+<li>12 large envelopes</li>
+<li>A reasonable number of index cards (contact the contest organizer with any questions about what is reasonable)</li>
+<li>A reasonable number of letter-sized envelopes (contact the contest organizer with any questions about what is reasonable)</li>
+<li>Two decks of playing cards</li>
+<li>12 six-sided dice</li>
+<li>A box of pens</li>
+<li>A sharpie</li>
+<li>Mounting Putty (for mounting paper to the wall) </li>
+<li>A pair of scissors</li>
+</ul>
+<p>
+In addition, up to $25 worth of other items may be brought for use in the game. If included, list those items in the plot reference book as well..
+</p>
+
+<h4 class="my-2"><a name="running-space">Game Space</a></h4>
+<p>
+The games will be taking place in small function spaces.  The following furniture will be available to you:</p>
+<ul>
+<li>At least 20 chairs</li>
+<li>At least two 5' round tables</li>
+</ul>
+
+
+<h3 class="my-2"><a name="judging">Judging</a></h3>
+<p>
+Games will be judged as follows:
+</p>
+<h4 class="my-2"><a name="judging-readers">Readers</a></h4>
+<p>
+The game materials (as submitted at the end of the Writing Phase) will be read by a blind panel, and evaluated on completeness, compliance with the contest rules, readiness for boxing, and writing. If you are interested in being a reader, please contact the Iron GM Coordinator.
+</p>
+<p>
+At this stage the game materials should contain all the writing necessary for the game to be run by any group of GMs. All components mentioned above should be present and complete.
+</p>
+<p>
+Writing will be judged on basic grammar, spelling, and punctuation, not style. Please proofread your game materials before submitting. Writing materials will also be judged on cohesiveness of the game.
+</p><p>
+For each of these categories, the game will be judged either "complete" or "incomplete," with points awarded for each "complete." Readers will also be allowed to pick one favorite game to award a small number of extra points to.
+</p>
+<h4 class="my-2"><a name="judging-players">Players</a></h4>
+<p>
+Players will be asked to fill out a questionnaire after the game in which they will rate the game on the usability and style of the written materials, on their experience of their characters, on the use of the secret ingredients, on runtime GMing quality, on the fit between plot and mechanics, and their overall enjoyment of the game. Please see the questionnaire form for exact questions.
+</p>
+<p>
+The questionnaires will be distributed when the games are run, and available both on paper and digitally. Questionnaires will be returned after the game ends, and then scored.
+</p>
+<p>
+As part of this evaluation, players may choose to learn the secret ingredients before or after they play. Players, writers, and readers are asked not to otherwise share the secret ingredients until after the last Iron GM game ends.
+</p>
+<h4 class="my-2"><a name="scoring">Scoring Procedures</a></h4>
+<p>The scoring procedures consist of tallying the reader scores with the player scores, and determining the winner based on the most points earned.</p>
+<p>
+If any contestant plays in any other team's Iron GM game, the player and their team are then disqualified from the Iron GM Competition. They may still run their game.
+</p>
+<p>
+The prizes will be awarded as follows: the team with the highest score will get $250, the team with the second highest score will get $150 and the team with the third highest score will get $100. The prize money will be given to the main entrant, who will be responsible for splitting it among the team.
+</p>
+<h3 class="my-2"><a name="publishing">Publishing</a></h3>
+<p>
+With permission of the authors, games will be available to the public after the results of the contest are announced. Permission will not be solicited until after the results are announced; it is not a necessary condition to win.
+</p>
+
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/larps.liquid
+++ b/cms_content_sets/wanderlust/pages/larps.liquid
@@ -1,0 +1,49 @@
+---
+name: Larps
+admin_notes: Work in progress
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign proposal_chair = convention.staff_positions_by_name.proposal_chair %}
+<h1 class="my-3">Larps at Intercon - WORK IN PROGRESS</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top">
+      <li class="toc-entry"><a href="#annual">Annual Social Events</a>
+        <ul>
+          <li class="toc-entry"><a href="#friday">Friday Night Party</a></li>
+          <li class="toc-entry"><a href="#saturday">Saturday Night Dance</a></li>
+          <li class="toc-entry"><a href="#raffle">Raffle and Plugs</a></li>
+        </ul>
+      </li>
+      <li class="toc-entry"><a href="#other">Other Social Events</a>
+        <ul>
+          <li class="toc-entry"><a href="#yourevent">Your Event Here!</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class='col'>
+
+
+<p class="lead">
+Intercon is first and foremost a larp convention.  Last year, over 100 seperate larps ran at Intercon, in wildly diverse genres.  When we're not playing larps, we are talking about larp, both <a href="{% page_url forum%}">formally</a> and <a href="{% page_url social%}">informally</a>
+</p>
+
+<h2 class="my-3"><a name="annual">What Kind of Larps</a></h2>
+
+<h3 class="my-2"><a name="friday">Friday Night Party</a></h3>
+<p>After games wrap up on Friday night, we host a social event in function space, near the con suite.  The theme of this event changes every year, and has not yet been chosen for Intercon S.
+</p>
+
+<h3 class="my-2"><a name="saturday">Saturday night dance</a></h3>
+<p>Every year on Saturday around midnight, we have a dance in Tiverton.</p>
+
+<h3 class="my-2"><a name="raffle">Raffle and Plugs</a></h3>
+<p>On Sunday, in the early afternoon, gather with us for the annual Raffle and Plugs.  We'll be running the raffle itself, and giving out lots of wonderful prizes, and, if you have an larp event or item to plug, come talk to us about it.  There will be a signup sheet at ops if you want to make a plug.
+</p>
+<h2 class="my-3"><a name="other">Other Social Events</a></h2>
+<h3 class="my-2"><a name="yourevent">Your Event Here</a></h3>
+<p>Want to run a meetup for your larp organization?  <a href="mailto:{{ hospitality.email }}">Drop us a line!</a></p>
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/nat-debugs-an-image-he-uploaded.liquid
+++ b/cms_content_sets/wanderlust/pages/nat-debugs-an-image-he-uploaded.liquid
@@ -1,0 +1,16 @@
+---
+name: Nat debugs an image he uploaded
+skip_clickwrap_agreement: false
+hidden_from_search: true
+---
+<h1>Straight up file_url:</h1>
+
+{% file_url "interconu-web-480.png" %}
+
+<h1>file_url in a partial:</h1>
+
+{% include 'nat_image_debug' %}
+
+<h1>conintro:</h1>
+
+{% include 'conintro' %}

--- a/cms_content_sets/wanderlust/pages/new-proposal.liquid
+++ b/cms_content_sets/wanderlust/pages/new-proposal.liquid
@@ -1,0 +1,88 @@
+---
+name: New Proposal
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign proposal_chair = convention.staff_positions_by_name.game_proposals_chair %}
+
+<div class="row">
+  <div class="col-md-7">
+    <h1>Propose an Event for <span class="text-nowrap">{{ convention.name }}</span></h1>
+    <p>Intercon is looking for a diverse selection of larps, in as many different styles and genres as we can find! But we're not just looking for established authors &mdash; we also encourage authors who are new to Intercon or new to larp writing. Whether it's a new game or one that's been run before, we're interested in what you have to propose.</p>
+    <p>
+
+    <p>We're also looking for a varied and interesting set of content for <a href="{% page_url forum %}">Forum@Intercon</a> and <a href="{% page_url social %}">Social Events</a> to offer diverse programming all weekend long, in addition to LARPs! These are our tracks of discussions, presentations, panels, and workshops, and as well as social and special interest meetups and parties!</p>
+
+    {% if convention.accepting_proposals %}
+      <div class="d-flex flex-wrap justify-content-center my-4">
+        {% new_event_proposal_button "Propose an event!" btn btn-primary m-2 %}
+      </div>
+
+      <p>Please fill out the proposal form with as much information as possible. This is the best way to help us evaluate your proposal quickly!</p>
+
+    <div class="col-md-10 offset-md-1">
+<!--
+      <div class="card mb-4 text-white bg-info">
+      <div class="card-header">
+        <h5 class="m-0">Limited Space Available</h5>
+      </div>
+      
+      <div class="card-body">
+<i>Updated October 26, 2022</i>       
+<p>Please be aware that, at this time, we have very limited space available to add new larps to our schedule. While we do still have space for games of various sizes, especially a small number of larger ones, we'd like to ensure that we have enough slots in games based on demand around mask requirements.  Therefore, we won't be accepting additional new games until we see how signups go, and then we will pull from the proposals based on demand.</p>
+      </div>
+    </div>
+      -->
+    </div>
+    {% else %}
+      <p>{{ convention.name }} is not currently accepting event proposals.</p>
+    {% endif %}
+
+    <section class="mt-4">
+      {% assign show_all_proposals = true %}
+      {% include 'user_event_proposals' %}
+    </section>
+  </div>
+  
+  <div class="col-md-5">
+    <div class="card mb-4">
+      <div class="card-header">
+        <h5 class="m-0">Proposal Deadlines</h5>
+      </div>
+      
+      <div class="card-body">
+        <p>Intercon solicits and reviews proposals for events on a rolling basis all through the year. That said, there are some reasons to get your proposal in as early as possible:</p>
+        
+        <ul class="mb-0">
+          <li>Events are scheduled in order to maximize efficient use of space. After size, proposal order will be considered. </li>
+          <li>Your event gets more publicity by being on the site when the schedule is first published! The first round of registration this year is on {{ convention.maximum_event_signups.timespans[1].start | date: "%B %e, %Y" }}, and the initial schedule will be published some time in October; late proposals may not be on that initial schedule.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h5 class="m-0">Space Limitations for Larps</h5>
+      </div>
+
+      <div class="card-body">
+        <p class="mb-0">We are dedicated to providing diverse programming, including smaller games and boffer style games, in all time periods throughout the entire weekend. However, in an effort to optimize the space available and to provide the greatest number of player slots in prime time periods, minimum size requirements will be in effect on Saturday afternoon, Saturday evening, and Friday evening for most rooms. Smaller larps (fewer than 10 players) and boffer-style larps (or other larps) which require large space needs may be accepted on a conditional basis during these time periods until after initial scheduling takes place. Morning, Sunday, Thursday, and Midnight time periods will be easier to schedule for small games and boffer style games.  Also, if you are willing to run your small game in part of a larger space alongside a second game, please indicate on your form.</p>
+      </div>
+    </div>
+    
+    <div class="card mt-4">
+      <div class="card-header">
+        <h5 class="m-0">More Information</h5>
+      </div>
+      
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item"><a href="{% page_url proposalfollowup %}">What happens when I submit my proposal?</a></li>
+        <li class="list-group-item"><a href="{% page_url proposalfaq %}">Larp Proposal FAQ</a></li>
+        <li class="list-group-item"><a href="{% page_url hotel/faq %}">Hotel FAQ</a></li>
+        <li class="list-group-item"><a href="{% page_url gmpolicies %}">Con GM Policies and Services</a></li>
+        <li class="list-group-item">Questions? Contact our {{proposal_chair.name_with_email_link}}, {{ proposal_chair.user_con_profiles[0].name }}.</li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/cms_content_sets/wanderlust/pages/news.liquid
+++ b/cms_content_sets/wanderlust/pages/news.liquid
@@ -1,0 +1,8 @@
+---
+name: News
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">{{convention.name}} News</h1>
+{% include 'all-news' %}

--- a/cms_content_sets/wanderlust/pages/open-roles.liquid
+++ b/cms_content_sets/wanderlust/pages/open-roles.liquid
@@ -1,0 +1,41 @@
+---
+name: Open Roles
+skip_clickwrap_agreement: true
+hidden_from_search: false
+---
+{% assign gm_coordinator = convention.staff_positions_by_name.gm_coordinator %}
+{% assign ops_coordinator = convention.staff_positions_by_name.operations_coordinator %}
+<h1 class="my-3">Open Positions</h1>
+<p class='lead'>Do you want to help make Intercon awesome? We're still looking for volunteers to fill these important roles.</p>
+
+<h3 class="my-2">Deputy Operations Coordinator</h3>
+<p>The primary responsibility of the Deputy Operations Coordinator takes place at Intercon itself. They are responsible for:</p>
+<ul><li>Opening and closing the Ops desk</li>
+  <li>Staffing Ops on one day of the con (Thursday, Friday, Saturday, or Sunday; you do not necessarily need to be present for the full day, but will have to be available to cover as needed)</li>
+  <li>Checking people in to the con</li>
+  <li>Following incident reporting policy in the event that an attendee needs to report an incident</li>
+  <li>Managing con supplies and suite keys, including checking them out to GMs</li></ul>
+
+<p>If interested and available, the Deputy Operations Coordinator can take on some pre- and post-con responsibilities as well, including:</p>
+<ul><li>Helping the Ops chair to coordinate orders of shirts, patches, and any other swag</li>
+  <li>Assisting with transportation of Ops supplies between storage unit and hotel</li>
+  <li>Coordinating with Safety coordinator to ensure that incident reporting policy exists</li>
+  <li>Doing a print run at Staples for con booklets, flyers, etc.</li></ul>
+
+<p>All of the pre-/post-con responsibilities are strictly voluntary and would be performed in collaboration with the Operations Coordinator.</p>
+
+<p>Additional documentation is available on these; please feel free to contact the Operations Coordinator, {{ ops_coordinator.user_con_profiles[0].name_without_nickname }}, at {{ops_coordinator.email_link}} if you have any questions or need further clarification.</p>
+
+<h3 class="my-2">Deputy GM Coordinator</h3>
+<p>The GM Coordinator is the primary contact for people running games for information, either asking questions or for receiving information related to running games at the con. The GM Coordinator is looking for a volunteer to be a deputy for this position. The deputy GM Coordinator would :</p>
+<ul><li>Observe, read email, and learn more about how the GM Coordinator role works</li>
+  <li>Assist the GM Coordinator, {{ gm_coordinator.user_con_profiles[0].name_without_nickname }}, with pre-con logistics as needed</li></ul>
+
+<p>If you're interested in filling this role, please reach out to the GM Coordinator at {{gm_coordinator.email_link}}.</p>
+
+<h3 class="my-2">Operations Crew</h3>
+<p>The Intercon Operations Crew takes care of ensuring the cogs of the con keep on turning. Whether it's checking people in to the con, helping players find games, or any of the dozens of other things that come up, Ops needs volunteers like you to make it happen. Volunteering for Ops shifts is a valuable use of your time and effort. To volunteer, go to the <a href="/events/5043-ops">Ops event page</a> and click on the time slot(s) for which you want to volunteer.</p>
+
+<p>Please note that we're especially looking for volunteers in the hour before and the hour after each game slot starts, and most especially in those times on Friday afternoon and Saturday morning. You can still sign up for shifts outside of those slots, and we'll still welcome the company, but there may not be as much to do.</p>
+  
+<p>For information on what volunteering entails, email {{ops_coordinator.email_link}}.</p>

--- a/cms_content_sets/wanderlust/pages/open-slots.liquid
+++ b/cms_content_sets/wanderlust/pages/open-slots.liquid
@@ -1,0 +1,11 @@
+---
+name: Larps with openings
+skip_clickwrap_agreement: true
+hidden_from_search: false
+layout_name: Auto Refresh Blank Page
+---
+<section class="my-4">
+  <h3 class="my-h3 mb-3 text-white">There's still openings in all these great games!</h3>
+  
+  {% include "run_availability_grid" %}
+</section>

--- a/cms_content_sets/wanderlust/pages/pricing.liquid
+++ b/cms_content_sets/wanderlust/pages/pricing.liquid
@@ -1,0 +1,77 @@
+---
+name: Convention Pricing
+admin_notes: ''
+skip_clickwrap_agreement: true
+hidden_from_search: false
+---
+<h1 class='my-3'>Convention Pricing</h1>
+
+{% if convention.ended %}
+  <div class="alert alert-warning">
+    {{ convention.name }} is over.  The following was the price schedule for {{ convention.name }}:
+  </div>
+{% endif %}
+<div class="row">
+  <div class="col-md-6">
+    {% for ticket_type in convention.ticket_types %}
+      {% if ticket_type.publicly_available %}
+        <section class="card" >
+          <div class="card-header">
+            {{ ticket_type.description }}
+          </div>
+          <div class="card-body">
+            <p>
+              Current price: {{ ticket_type.price }}
+              {% if ticket_type.pricing_schedule.next_value_change %}
+                <br>
+                {{ ticket_type.pricing_schedule.next_value.format }}
+                starting {{ ticket_type.pricing_schedule.next_value_change | date: "%b %d, %Y"}}
+              {% endif %}
+            </p>
+
+            <ul class="list-unstyled">
+              {% for timespan in ticket_type.pricing_schedule.timespans %}
+                <li>
+                  <small><strong>{{ timespan.value }}</strong> {{ timespan.short_description_without_value }}</small>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </section>
+      {% endif %}
+    {% endfor %}
+  </div>
+</div>
+
+<div class="row mt-3">
+  <div class="col">
+    <div class="card">
+      <div class="card-header">
+        Why does it get cheaper closer to the convention?
+      </div>
+      <div class="card-body">
+        <p>
+Intercon uses a sliding pricing model, where our rates first increase and then drop as the convention approaches. This is because initial signups for playing in games happens across four weeks in October or November. After this period many games are full, and signing up for the con after that point in time is generally less desirable. We have adopted a pricing model that encourages people to sign up who learn about the con late, or who find themselves able to attend after all.
+        </p>
+        <p>
+This way, players are charged less for fewer options, and GMs are benefitted by drawing in these extra players, even if only for that one game that interests them. It is better for everyone when games have a full complement of players, and this approach helps that to happen.
+        </p>
+        </div>
+     </div>
+   </div>
+</div>
+  
+<div class="row mt-3">
+  <div class="col">
+    <div class="card">
+      <div class="card-header">
+        What about Child rates?
+      </div>
+      <div class="card-body">
+        <p>
+  We do charge less for children to attend, because we recognize that we do not typically offer a full set of activities sutable for children.  The full children's policy and pricing can be found in our <a href="{% page_url rules%}#policies-children">Convention Rules</a>.
+        </p>
+      </div>
+    </div>
+  </div>
+ </div>

--- a/cms_content_sets/wanderlust/pages/propcom.liquid
+++ b/cms_content_sets/wanderlust/pages/propcom.liquid
@@ -1,0 +1,161 @@
+---
+name: Proposal Committee Procedures
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign proposal_chair = convention.staff_positions_by_name.game_proposals_chair %}
+<h1 class="my-3">Welcome to the Intercon Proposal Committee!</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry"><a href="#goal">Our Goal</a></li>
+      <li class="toc-entry"><a href="#responsibilities">Responsibilities</a>
+        <ul>
+          <li class="toc-entry"><a href="#evaluate">Evaluate Proposals</a></li>
+          <li class="toc-entry"><a href="#solicit">Solicit Proposals</a></li>
+          <li class="toc-entry"><a href="#outside">What's outside the scope?</a></li>
+        </ul>
+      </li>
+      <li class="toc-entry"><a href="#process">Process</a>
+        <ul>
+          <li class="toc-entry"><a href="#fasttrack">Fast Tracking Proposals</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class='col'>
+
+
+<h2 class="my-3"><a name='goal'>Our goal</a></h2>
+<p class='lead'>
+The goal of the Proposal Committee is to solicit and select the best possible slate of games for the upcoming convention.
+</p>
+
+<h2 class="my-3"><a name='responsibilities'>Responsibilities of the Proposal Committee</a></h2>
+<h3 class="my-2"><a name='evaluate'>Evaluate game proposals for the con, as they come in</a></h3>
+<p>As proposals come in, the Proposal Chair will notify the Committee about new 
+submissions. They will appear on the con website, on the <a href="/admin_event_proposals">Admin Event Proposals</a> page. Read through them. Look at each proposal coolly and objectively. Ask yourself: 
+</p><ul>
+<li>
+  Is it a game that people will enjoy? 
+</li>
+<li>
+  Is it an interesting game? 
+</li>
+<li>
+  Is this a game that helps to create a rich and varied mix of games at the con? 
+</li>
+<li>
+  Is it a game that fits logistically with the Intercon environment? (<i>e.g. </i>A game for 100 probably doesn't fly.) 
+</li>
+<li>
+  Is this a game that will appeal to the typical Intercon audience? How about attracting new audiences?
+</li>
+<li>
+  Is the author known? Do they have a track record? Is it a good one? Has this author proposed games for Intercons before? Have they pulled their proposals? 
+</li>
+<li>
+  Is the author new? We want to encourage new authors. 
+</li>
+<li>
+  Can we schedule the game reasonably based on the desired duration? (<i>e.g. </i>A weekend-long game is harder to schedule and fill than a 4 hour game.) As mentioned below, don't worry about if it fits into the current schedule for the convention.
+</li>
+<li>
+  Will the game bring people into the con? 
+</li>
+    <li>
+       Is the game adequately described? After reading it, do you have questions about the game, how it is organized, or how it will be run?
+    </li>
+    <li>
+       Is the game’s public description clear and evocative? Does it give a reasonable impression of what players will be doing during the game? Will it “find its audience” by attracting enough people to play it?
+    </li>
+</ul>
+<p>
+  Raise any questions or objections you might have with the rest of the proposal 
+committee. Tell us why you advise yes, no, or can't tell yet on the game. Be 
+explicit in your reasons. Don't be shy. <b><i>These discussions MUST be 
+private. They are not for public consumption, and may be 
+non-politic.</i></b> If the game looks like a typical 
+"we-know-it's-going-to-suck-White-Wolf-cliche", then say so. If you know the GM 
+had players that walked away from a game <i>en masse</i>, or was unable to deliver their game in a previous year, then say so. It's much 
+better to reject a game early and then work harder to get a better one than to 
+have players gripe after the con. It is not necessary for us to accept every 
+game that comes in. That said, we want to work with GM's to make their proposals
+work where at all possible. If a game has potential, focus feedback on the constructive.
+</p>
+    <p>
+      If you have some specific issue that isn't something that you're willing to put before the Proposal Committee, then please let the Proposal Chair know. It's important that all the relevant information about a game and a GM is put before the committee in some fashion. 
+    </p>
+    <p>
+      If you are the author of the game, or one of the GMs, then please recuse yourself from advising if the game should be accepted. Feel free to answer any questions about the game, but remember, we need to talk freely and openly about the game. 
+</p>
+    <p>
+      <b>Timeliness is important here!</b> Please try to be prompt about your responses and followups, so that we can come to consensus quickly. We expect to respond to the submitter within 4 weeks.  Proposal Committee discussions of a proposal should be wrapped up within at most 2 weeks.
+    </p>
+    <p>
+<b>The Proposal Chair <i>must</i> be the conduit for raising the questions with the GMs, if there are any that come up in discussions.</b> It's better if we have one voice doing the asking, instead of a potential GM being bombarded from several of us at once. The Proposal Chair may choose to delegate the conduit responsibility for a specific GM to one of you, if it makes sense. 
+</p>
+    <p>
+There's also a consideration, less common but occasionally important, about whether the game and/or GMs are going to cause problems for the convention. GMs who are known to be a major pain in the ass to work with should be looked at skeptically. 
+</p><p>
+Historically, we tend to err on the side of giving games a chance. That's allowed one or two bad LARPs to get through, but it's also given a lot of new GMs a chance to stretch themselves. This is generally the right attitude. That said, if we do have strong reason to suspect that the game <i>is</i> going to be bad, then we need to seriously consider whether it should run at Intercon.
+</p>
+
+<h3 class="my-2"><a name='solicit'>Solicit game proposals for the con from GMs</a></h2>
+<p>
+Point potential GMs at the <a href="{% page_url new-proposal %}">Propose an Event</a> link.
+</p><p>
+While it is the responsibility of everyone on the con staff to do this recruiting, we are the people who have to know what the con is looking for and what we've already seen. As such, we're in the best position to be proactive about the process. We each have contacts and connections in various places. Use them. It's up to us to reach out to those contacts and find games for the con. 
+</p>
+    <p>
+    The personal touch works well: if you have played in and enjoyed a game, suggest that the GM(s) run it at Intercon; or, if you hear that someone is working on a new game, ask if they are thinking of running it at Intercon. If they come up with questions that you can’t answer, direct them to the website, or have them email the {{proposal_chair.name}} at {{proposal_chair.email_link}}.
+    </p>
+    <p>
+      The benefits of running games at Intercon also make for good discussion points:
+      <ul>
+        <li>Promotion, via the Intercon website and related word-of-mouth.</li>
+        <li>A hotel venue, where the space and the time their game can be run has all been arranged (and paid!) for.</li>
+        <li>An audience, a large group of enthusiastic larpers from which to recruit players for their game.</li>
+        <li>If your game is accepted, you will receive one or more free comped admissions to the convention. These can be used by the GMs, their co-GMs, or even their friends.</li>
+    </ul>
+    </p>
+    <p>
+Please let the  {{proposal_chair.name_with_email_link}} know who you're contacting, if you don't CC them on 
+any solicitation email. The Proposal Chair will keep a master list of contacts, so that 
+we know the state of our efforts and don't duplicate efforts.
+
+</p>
+
+<h3 class="my-2"><a name='outside'>What's NOT the Responsibility of the Proposal Committee</a></h3>
+<p>
+Each game should be evaluated on its own merits. Whether or not the game 
+actually fits into the current con schedule should <i>not</i> be a 
+consideration. Whether or not a game actually fits into the current con function 
+space allotment should <i>not</i> be a consideration. These are important 
+considerations, but time and space may be more fluid than are apparent. There 
+may be alternatives that allow a game to fit into the schedule. That's best left 
+to the Scheduling Committee (Proposal Chair, GM Liaison, the Hotel Liaison, Panel Coordinator, and the Con Chair) to 
+figure out.  Scheduling is typically done in October, a few weeks before game registration.
+A notable exception to this is small games (~15 or fewer players) that request large spaces during
+prime time slots (Fri night, Sat afternoon, Sat night). If the game has size OR timing flexibility, no
+problem. If it's not flexible on either of those axes, we may need to give the game only provisional
+acceptance, because of space and player slot limitations.
+
+<!------------------------------------------------------------------------>
+
+</p>
+<h2 class="my-3"><a name='process'>Process</a></h2>
+<p>
+The Proposal Chair will inform the Proposal Committee that it's time to discuss a specific game or set of games. Email discussing the game should be sent to the entire Proposal Committee. The Proposal Chair will encourage the committee to find a consensus. 
+</p><p>
+Once the Committee has evaluated a game, the Proposal Chair will pass the recommendation to the Con Chair for final approval. The Proposal Chair will also let the Con Chair know about any proposals we reject. In the end, it's the Con Chair's final call, although it's highly doubtful that the Con Chair would go against our suggestions. Please let the Proposal Chair be the conduit here as well. The Con Chair has a lot on their plate; it's best if there's a single channel for Proposal Committee communications. 
+</p><p>
+When a game proposal is accepted or rejected, the proposal Chair will send a note to the GM informing them of the decision, copying the GM Liaison. At that point, the GM Liaison takes over the process of managing the game for the con. Our job, as the Proposal Committee, is done for that game.
+
+</p>
+<h3 class="my-2"><a name='fasttrack'>Fast-tracking Proposals</a></h3>
+<p>
+There may be times when a game needs to be fast-tracked.  Fast-tracking must be a consensus between the Proposal Chair and Con Chair.  In those cases, the Proposal Chair is the representative of the Proposal Committee, and should inform the Proposal Committee about the game as soon as possible.  Fast-tracking should only be used when there's extreme time pressure and the Proposal Committee cannot be convened.</p>
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/proposalfaq.liquid
+++ b/cms_content_sets/wanderlust/pages/proposalfaq.liquid
@@ -1,0 +1,248 @@
+---
+name: Larp Proposal FAQ
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign con_chair = convention.staff_positions_by_name.con_chair %}
+{% assign proposal_chair = convention.staff_positions_by_name.game_proposals_chair %}
+<h1 class="my-3">Larp Proposal FAQ</h1>
+
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Larp Proposal FAQ</h4>
+      </li>
+      <li>
+        <a href="{% page_url new-proposal %}" class="btn btn-secondary ms-4 mb-4">Back to propose an event</a>
+      </li>
+      <li class="toc-entry"><a href="#intercon">What is Intercon? Why would I want to run a game there?</a></li>
+      <li class="toc-entry"><a href="#audience">What kind of larpers come to Intercon?</a></li>
+      <li class="toc-entry"><a href="#gameKind">What kind of larps are you looking for?</a></li>
+      <li class="toc-entry"><a href="#notJustNew">Are you only looking for new games?</a></li>
+      <li class="toc-entry"><a href="#conTheme">Does my game have to fit into the con theme?</a></li>
+      <li class="toc-entry"><a href="#newAuthors">What if I've never written a game before?</a></li>
+      <li class="toc-entry"><a href="#gameSize">What size games are you looking for?</a></li>
+      <li class="toc-entry"><a href="#smallGames">Are you really interested in small games?</a></li>
+      <li class="toc-entry"><a href="#bigGames">Are you interested in really big games?</a></li>
+      <li class="toc-entry"><a href="#gameLength">What length games are you looking for?</a></li>
+      <li class="toc-entry"><a href="#playerAges">How old are players at Intercon?</a></li>
+      <li class="toc-entry"><a href="#scheduling">How do you schedule games at the con?</a></li>
+      <li class="toc-entry"><a href="#fourHourSlots">Do I have to write a four hour game, to fit into your schedule slots?</a></li>
+      <li class="toc-entry"><a href="#gameSpace">What kind of space can I get for my game at a hotel?</a></li>
+      <li class="toc-entry"><a href="#nonPrewrittenGame">Does my LARP need to have prewritten characters?</a></li>
+      <li class="toc-entry"><a href="#campaignGame">I run a very successful campaign game. Can I bring an episode of my game to the con?</a></li>
+      <li class="toc-entry"><a href="#weirdGame">My game is really weird, unlike any game I've ever seen before. Are you interested?</a></li>
+      <li class="toc-entry"><a href="#restrictions">My game has strong and challenging themes that might be offensive to some, or can't be played by some people because of physical requirements, or is only for adults. Are you interested?</a></li>
+      <li class="toc-entry"><a href="#acceptanceRate">Do you accept every proposal you get?</a></li>
+      <li class="toc-entry"><a href="#notAGame">Can I propose an event that's not a game?</a></li>
+    </ul>
+  </div>
+  
+  <div class="col">
+    <section class="mt-4">
+      <h3 class="my-2"><a name="intercon">What is Intercon? Why would I want to run a game there?</a></h3>
+      <p>Intercon is the premiere LARP convention, running games of as many different and varied genres as we can find. Intercon attracts LARPers and LARP writers from all around the world. We're the largest multi-genre LARP convention in the world.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="audience">What kind of larpers come to Intercon?</a></h3>
+      <p>We get a very diverse crowd of larpers. For some, this is their first experience with LARPs. For others, they've been playing games for decades. Some have been writing games for that long. Our players enjoy a variety of game styles, including theater-style, live combat ("boffer"), and experimental art games.</p>
+      <p>
+        We get a lot of great larpers. Generally, they're looking for games with strong characterization, with lots of plot and great storylines. These are people who aren't just looking to stand around and wait for the GM to direct the action. These are players that want to create memorable scenes, dramatic or comedic. They want to immerse themselves in their roles. Many of these players like to costume to the hilt. It's not an easy group to write for, because they have a lot of gaming experience, but the results can be very satisfying.
+      </p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="gameKind">What kind of larps are you looking for?</a></h3>
+      <p>All kinds. Light, dark, serious, silly, short, or long, we need a mix of games for the convention. We're looking for murder mysteries, science fiction, high fantasy, historical set pieces, theater style, live combat, and just about any other genre you could name. We're looking for something that isn't already on our schedule, and we're willing to run experimental games, too.</p>
+      <p>Ask ten larpers what larp is about and you'll get thirteen different answers. We're trying to find interesting games that satisfy as many of those possibilities as we can.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="notJustNew">Are you only looking for new games?</a></h3>
+      <p>No. If you have a game that's been run successfully before, we're interested. Some of our favorite games have run many times, at other Intercons, privately, or both.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="conTheme">Does my game have to fit into the con theme?</a></h3>
+      <p>No. Every year, the con comes up with a marketing theme or two.  Intercon D had a theme of <i>deja vu</i>. Intercon C "celebrated a century of LARP", Intercon B had a theme of "B movies", and so on.  We use this theme in our advertising.  If your game fits into the theme naturally, that's great! We may try to use it specially in our advertising.  If your game doesn't fit the theme, it will not factor into our decision processes.  We look at all games on their own merits.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="newAuthors">What if I've never written a game before?</a></h3>
+      <p>Intercon encourages new writers to propose games. While many of the names on the schedule may be familiar, there are always new authors as well. We look for new writers, because we know what's involved in the process. We know that those familiar writers had to start somewhere. Having a great group of players to play in the game also helps new games succeed.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="gameSize">What size games are you looking for?</a></h3>
+      <p>We are looking for games of different sizes, all as part of the mix. We've had games as small as 4 players and as large as 50+ players. Most of  the games at the con range from 20 to 40 players. Some games have fixed sizes. (<i>e.g. </i>a game needs 24 players) Some games are more flexible. (<i>e.g. </i>a game can take from 20 to 30 players.)</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="smallGames">Are you really interested in small games?</a></h3>
+      <p>Sure. We've run games for four and six players before. Be advised that if your game is small (15 players or fewer especially) AND requires a lot of space (multiple rooms) AND can only run during "prime time," (Fri night, Sat afternoon, Sat night), it may be difficult to schedule, but we will work with you as best we can.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="bigGames">Are you interested in really big games?</a></h3>
+      <p>That depends on your definition of big. The New England Intercons typically attract more than 400 people, all looking for an intense experience. That typically means they are looking for a more intimate game experience. Games of 20 to 40 people generally do very well. Because we always have a great selection of games, players have tough choices to make when signing up. There's a lot of competition in every time slot. We try to do our best to make all of the games successful, but it can be difficult for games needing more than 40 players to get enough players.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="gameLength">What length games are you looking for?</a></h3>
+      <p>A typical game at Intercon runs for between two and four hours, but we're open to games that run from five minutes to those that run for a full day.  Longer games, spanning multiple "slots" will be scheduled early (Thursday/early Friday) or late (Sunday)</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="playerAges">How old are players at Intercon?</a></h3>
+      <p>We have players as young as 8 who play games at Intercon.  We ask that all games list their age restrictions in the game description, both to avoid signups by players who are too young for the content in your game and to help young players and their guardians in finding appropriate games to play. If you set a minimum age in the system, players who are underage will be specifically labeled as such in the GM's view of the player list, but they WILL still be able to sign up, so exceptions can be made on a case-by-case basis.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="scheduling">How do you schedule games at the con?</a></h3>
+      <p>There are twelve primary time slots used to schedule games. We try to schedule games to give the most choices to the players.</p>
+
+      <div class='table-responsive'>
+        <table class='table table-striped table-sm'>
+          <tbody>
+            <tr>
+              <th valign="top" align="middle">Day</th>
+              <th valign="top" align="middle">Slot start time</th>
+              <th valign="top" align="left">Typical game length in this slot</th>
+            </tr>
+            <tr>
+              <th valign="center"rowspan="2">Thursday</th>
+              <th>8 PM</th>
+              <td>4 hours.  We have a limited selection of rooms at this time, so we do not schedule as many games. We also like to stagger a few shorter games during this block, as Panels are typically also running.</td>
+            </tr>
+            <tr>
+              <th>Midnight</th>
+              <td>Up to 3 hours, although 2 is preferred.</td>
+            </tr>
+
+            <tr>
+              <th valign="center"rowspan="4">Friday</th>
+              <th>9 AM</th>
+              <td>4 hours.  We have a limited selection of rooms at this time, so we do not schedule as many games.</td>
+            </tr>
+            <tr>
+              <th>2 PM</th>
+              <td>4 hours.  We have a limited selection of rooms at this time, so we do not schedule as many games.  We also like to stagger a few shorter games during this block, as Panels are typically also running.</td>
+            <tr>
+              <th>8 PM</th>
+              <td>4 to 6 hours, although games can run longer if the players are willing to stay up that late.</td>
+            </tr>
+            <tr>
+              <th>Midnight</th>
+              <td>Up to 3 hours, although 2 is preferred.    Some games have run even later into the night, but most players want to get up in the morning to play</td>
+            </tr>
+
+            <tr>
+              <th valign="center"rowspan="4">Saturday</th>
+              <th>9 AM</th>
+              <td>4 hours. This slot is followed by an hour for lunch, so games can run longer. Games also have the option of starting earlier.</td>
+            </tr>
+            <tr>
+              <th>2 PM</th>
+              <td>4 hours. This slot is followed by a two hour dinner break. Games have run into the dinner slot in the past.</td>
+            <tr>
+              <th>8 PM</th>
+              <td>4 to 6 hours, although games can run longer if the players are willing to stay up that late.</td>
+            </tr>
+            <tr>
+              <th>Midnight</th>
+              <td>
+                Up to 3 hours, although usually shorter. Some games have run even later into the night, but most players want to party, to socialize, or just to get up in the morning to check out or to play.
+              </td>
+            </tr>
+
+            <tr>
+              <th valign="center"rowspan="3">Sunday</th>
+              <th>9 AM</th>
+              <td>4 hours.  We often schedule a number of 2 hour games during this slot, some at 9am and some at 11am.</td>
+            </tr>
+            <tr>
+              <th>2 PM</th>
+              <td>4 hours. This is a great slot for pickup games.</td>
+            </tr>
+            <tr>
+              <th>Later</th>
+              <td>2 to 4 hours. Most people leave the con sometime Sunday afternoon, but there are always a few people who stay overnight at the hotel on Sunday night. Occasionally we'll put a game or two on the schedule for later on Sunday, but it's not something you should count on.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p>The proposal form asks you to rank the slots you'd prefer for running your game. We try our best to give you your preferred slot, but it isn't always possible. Scheduling the con is always an interesting puzzle. The more flexible you are and the more choices you give us for scheduling makes it easier for us to put that puzzle together.</p>
+
+      <p>We also have to consider the time and effort that are needed to tear down a game and set up the next one. Some games require significant setup, and the time for that setup has to be factored into the schedule.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="fourHourSlots">Do I have to write a four hour game, to fit into your schedule slots?</a></h3>
+      <p>No. It's true that most of our game slots are four hours long. While it helps if your game fits nicely into one of our slots, it's not absolutely necessary. Most successful Intercon games fit into a single slot.</p>
+
+      <p>Two hour games are quite common. Clearly two of them fit nicely into a four hour slot. We try to pack slots in order to maximize player options.</p>
+
+      <p>Games up to about six hours can fit into the Thursday, Friday, and Saturday night slots. Friday games may be able to run even later, stretching to seven hours, if the players are willing to stay up.</p>
+
+      <p>Games that are even longer must span more than one slot. Intercon will schedule a <i>strong</i> game across more than one slot. However, if a game spans just two slots, it means that game must compete for players with as many as <i>twenty-five to thirty</i> other games. We always schedule a lot of great games opposite each other. That means players must choose between playing in a multislot game or in two (or more) single slot games. It takes a special game and special writers to meet that challenge. We want the games at the con to be a success, able to attract the number of players they need. It's why we encourage games that fit into a single slot.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="gameSpace">What kind of space can I get for my game at a hotel?</a></h3>
+      <p>The Crowne Plaza has <a href="{% page_url hotel/layout %}" target="_blank">great function space</a>, and we take almost all of it. We also fill it up. <i>We can typically guarantee one function space room per game</i>. If you need more than that, we may be able to make it work, depending on the size of your game. This does limit us, but we encourage GMs to think creatively, as we know you can.</p>
+
+      <p>We also need to know what special spatial needs you may have beyond enough room for your players. This includes things like a need for high ceilings, making sure that any delicate furniture is out of the way, the desire for a small secondary room for side activities, or specific traffic flow demands. We'll do what we can to give you a workable space. However, be aware that we do fill up all the function space in the hotel, and you have to share with six or seven other games. It may not be physically possible to give you the ideal space.</p>
+      
+      <p>More details about the hotel's function space are available in the <a href="https://docs.google.com/document/d/1l46enA3-oIpZ0mOUUgA1SEL4Bi7iSeP0eibT3c3x3bk/edit" target="_blank">Hotel FAQ</a>.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="nonPrewrittenGame">Does my LARP need to have prewritten characters?</a></h3>
+      <p>"Workshop"-style games, where aspects of characters or relationships are built by players at game time, have become more popular over the past decade and are well loved at Intercon. In these games, a writer has typically provided a number of very brief character concepts fitting within the world and themes of the LARP that players flesh out together, and/or core questions to answer.</p>
+
+      <p>"Bring your own character" games, however, where a player creates a detailed character on their own as they might in a campaign LARP or D&D, are less likely to be accepted since players at Intercon typically favor more interrelated characters and plots. This doesn't mean that we won't accept these kinds of games - but they are less likely to get through the proposal process. One solution is to have a deadline for character submission well before the con, so that you can take the characters and build them into the game.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="campaignGame">I run a very successful campaign game. Can I bring an episode of my game to the con?</a></h3>
+      <p>If you're going to bring a lot of your usual players, then sure. It's harder asking a lot of new players to come into an existing campaign, unless you really have something special for the episode. It has to be something that's going to excite others, in a way that doesn't require the new players to know all sorts of background material. The new players also have to feel like equals to those who have been playing a long time. It's not a lot of fun to come into a game where there is a clique of players who outclass you in every way.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="weirdGame">My game is really weird, unlike any game I've ever seen before. Are you interested?</a></h3>
+      <p>We're always looking for interesting games. If you can sell the Proposal Committee on the game, it's likely you'll get players, no matter how strange the game. In fact, many players have told us that they come to Intercon just to play games that aren't like the ones they usually play with their local group. We're looking for unique games, and we do our best to see that they'll be successful.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="restrictions">My game has strong and challenging themes that might be offensive to some, or can't be played by some people because of physical requirements, or is only for adults. Are you interested?</a></h3>
+      <p>Yes. Intercon does not shy away from challenging games. Almost all Intercon attendees are adults, and we let them choose the games that are right for their sensibilities and capabilities. We look for games that push the envelope. We do understand that some game efforts are not for everyone. We try to make that clear up front by the game descriptions you provide. There are questions in the proposal form specifically for these cases; the details are important, so please be explicit.  That being said, we are unlikely to accept games that do any of the following:</p>
+      <ul>
+        <li>Trivialize the held beliefs of a minority culture</li>
+        <li>Exploit the pain and degradation of a minority group</li>
+        <li>Trivialize subject matter that may be deeply offensive to attendees, i.e. child abuse</li>
+      </ul>
+      <p>If you have questions or concerns, please raise those concerns with the {{proposal_chair.name_with_email_link}}.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="responsetime">How soon can I expect to hear from you?</a></h3>
+      <p>The Proposal Chair will contact you soon if there are any questions about your game. We will make every effort to get back to you with a decision about your game within 4 weeks.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="acceptanceRate">Do you accept every game proposal you get?</a></h3>
+      <p>We accept most reasonable proposals, but there are usually one or two proposals that don't make it into a given con. All game proposals are <a href="{% page_url proposalfollowup %}">evaluated by the Proposal Committee</a>, using a <a href="{% page_url proposalfollowup %}">number of criteria</a>. We try to work with proposers to make all the proposals successful, but it doesn't always happen. When a proposal fails, we try to make it clear why the proposal was rejected. The most frequent reasons a proposal is rejected is because we already have a similar game scheduled, or because a proposal insists on specific time slots and the schedule is nearly full.</p>
+    </section>
+
+    <section class="mt-4">
+      <h3 class="my-2"><a name="notAGame">Can I propose an event that's not a game?</a></h3>
+      <p>Yes!  If you're interested in proposing a session such as a moderated discussion, a presentation, a panel discussion or a workshop, please see <a href="{% page_url forum %}">Forum@Intercon</a> for that track of content.</p>
+      <p>If you're interested in proposing a social event or meetup, please see <a href="{%page_url social %}">Social Events</a> for that track of content.</p>
+      <p>If you're interested in proposing a larp-like event that isn't a game, it's best to check with the {{proposal_chair.name_with_email_link}} or the {{con_chair.name_with_email_link}}.</p>
+    </section>
+  </div>
+</div>

--- a/cms_content_sets/wanderlust/pages/proposalfollowup.liquid
+++ b/cms_content_sets/wanderlust/pages/proposalfollowup.liquid
@@ -1,0 +1,53 @@
+---
+name: Proposal Followup
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign proposal_chair = convention.staff_positions_by_name.game_proposals_chair %}
+<h3 class="my-3">The Game Proposal Process</h3>
+<p>Here's what happens once you've filled out the <a href="{% page_url new-proposal %}">proposal form</a>: 
+</p><ol>
+<li>The {{ proposal_chair.name_with_email_link}} will be 
+notified of your proposal. The {{ proposal_chair.name }} will read the information you've 
+supplied. If there are any immediate questions, the {{ proposal_chair.name }} will contact 
+you, to work with you to clarify your proposal.<br>  
+</li>
+<li>The {{ proposal_chair.name }} notifies the Proposal Committee of the new proposal. The Proposal 
+Committee consists of several con volunteers, with a wide variety of LARP 
+experience, at Intercon and elsewhere. The Proposal Committee is deliberately large 
+and varied, in order to represent the diversity of people who come to the con. 
+Several people will look at your proposal.<br>  
+</li>
+<li>The Proposal Committee discusses each proposal. <a name="whatWeLookFor">They'll be 
+looking at the proposal for answers to questions such as:</a><br>  
+<ul>
+  <li>Does the game look interesting? </li>
+  <li>Does it look like a game that people will enjoy? </li>
+  <li>Is it clear what this game is about?</li>
+  <li>Has the proposal answered all questions on the proposal form?</li>
+  <li>Is this a game that will appeal to the <a href="{% page_url proposalfaq %}">typical Intercon audience</a>? </li>
+  <li>Is it a game that's different from games already accepted for the convention? </li>
+  <li>Is this a game that helps to create a rich and varied mix of games at the con? </li>
+  <li>Do the game space and time requirements fit within the Intercon budget for space and time? </li>
+  <li>Will the game bring new people into the con?</li>
+</ul>
+<p>This may result in further questions back to you. It is why it's so important 
+that you fill in the proposal form completely to begin with.<br>  </p>
+</li>
+<li>Once the discussion has completed, the {{ proposal_chair.name }} will notify the Con 
+Chair. The Con Chair is the final arbiter of game acceptance. When the Con Chair 
+has made a decision, the {{ proposal_chair.name }} will let you know what has been 
+decided.<br>  
+</li>
+<li>If the proposal is accepted, it will be added to the schedule. The Scheduling team meets in October to put together the initial schedule, and larps accepted after that point will be scheduled as they are accepted. Announcements 
+about the con will contain advertisements about all the open games in the 
+schedule, including yours! We also encourage you to advertise your game (and 
+Intercon) in your LARP group. 
+<p>If the proposal is rejected, we'll try to explain why it doesn't meet our needs. 
+We get a lot of game proposals, and some just don't fit. If your proposal is rejected, we 
+hope you'll still come to the convention, to have a great time in all of the 
+other LARPs.<br>  </p>
+</li>
+</ol>
+<p>Still have questions? Please drop a note to the {{ proposal_chair.name_with_email_link}}. We want to make it easy 
+for you to propose your game. </p>

--- a/cms_content_sets/wanderlust/pages/role-descriptions.liquid
+++ b/cms_content_sets/wanderlust/pages/role-descriptions.liquid
@@ -1,0 +1,254 @@
+---
+name: Role descriptions
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class='my-3'>Staff Role Descriptions</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Staff Role Descriptions</h4>
+      </li>
+      <li class="toc-entry"><a href="#individual">Individual Roles</a>
+        <ul>
+          <li class="toc-entry"><a href="#conchair">Conchair</a></li>
+          <li class="toc-entry"><a href="#gameproposalschair">Proposal Chair</a></li>
+          <li class="toc-entry"><a href="#gmcoordinator">GM Coordinator</a></li>
+          <li class="toc-entry"><a href="#operationscoordinator">Operations Coordinator</a></li>
+          <li class="toc-entry"><a href="#roomdividercoordinator">Room Divider Coordinator</a></li>
+          <li class="toc-entry"><a href="#safetycoordinator">Safety Coordinator</a></li>
+          <li class="toc-entry"><a href="#hotelliaison">Hotel Liaison</a></li>
+          <li class="toc-entry"><a href="#forumcoordinator">Forum@Intercon Coordinator</a></li>
+          <li class="toc-entry"><a href="#attendeecoordinator">Attendee Coordinator</a></li>
+          <li class="toc-entry"><a href="#volunteercoordinator">Volunteer Coordinator</a></li>
+          <li class="toc-entry"><a href="#vendorliaison">Vendor Liaison</a></li>
+          <li class="toc-entry"><a href="#registrar">Registrar</a></li>
+          <li class="toc-entry"><a href="#treasurer">Treasurer</a></li>
+          <li class="toc-entry"><a href="#advertising">Booklet / Advertisement</a></li>
+          <li class="toc-entry"><a href="#outreach">Outreach</a></li>
+          <li class="toc-entry"><a href="#news">Newsletter / Social Media Coordinator</a></li>
+          <li class="toc-entry"><a href="#art">Art</a></li>
+          <li class="toc-entry"><a href="#hospitalitycoordinator">Hospitality Coordinator</a></li>
+          <li class="toc-entry"><a href="#irongmcoordinator">Iron GM Coordinator</a></li>
+          <li class="toc-entry"><a href="#raffle">Raffle Coordinator</a></li>
+          <li class="toc-entry"><a href="#plugs">Plugs Coordinator</a></li>
+        </ul>
+      </li>
+          
+      <li class="toc-entry"><a href="#group">Group Roles</a>
+        <ul>
+          <li class="toc-entry"><a href="#propcom">Proposal Committee</a></li>
+          <li class="toc-entry"><a href="#safetystaff">Safety Team</a></li>
+          <li class="toc-entry"><a href="#websiteteam">Website Team</a></li>
+          <li class="toc-entry"><a href="#opsstaff">Operations Volunteers</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class="col document">
+    <h2 class="my-3"><a name='individual'>Individual Roles</a></h2>
+
+    <h3 class="my-2"><a name='conchair'>Conchair</a><a name='conchair-deputy'></a></h3>
+    <ul>
+      <li>Oversees all aspects of the convention</li>
+      <li>Is part of the post-incident response team</li>
+      <li>Is on the Scheduling team</li>
+      <li>Has at-con responsibilities</li>
+    </ul>
+    <h3 class="my-2"><a name='gameproposalschair'>Proposal Chair</a><a name='gameproposalschair-deputy'></a></h3>
+    <ul>
+      <li>Runs the proposal committee</li>
+      <li>First point of contact for GMs proposing to run games at the convention</li>
+      <li>Works with Game submitters to fix obvious issues, missing fields, etc, before the proposal goes to the committee</li>
+      <li>Works with Game submitters to fix deeper issues as advised by the Proposal Committee </li>
+      <li>Advises the Con Chair of the feedback from the Proposal Committee</li>
+      <li>Informs GMs that their game has been accepted, and they're being handed off to the GM coordinator.  Also informs GMs if their game has been rejected.</li>
+      <li>Is on the Scheduling Team</li>
+    </ul>
+
+    <h3 class="my-2"><a name='gmcoordinator'>GM Coordinator</a></h3>
+    <ul>
+      <li>Is the point of contact between GMs of accepted games and the convention</li>
+      <li>Shares information and answers questions about convention policy and procedures with the GMs</li>
+      <li>Sends out the link to the furniture request system, and works with GMs to get their data entered there.</li>
+      <li>Is on the Scheduling Team</li>
+    </ul>
+    <h3 class="my-2"><a name='operationscoordinator'>Operations Coordinator</a></h3>
+    <ul>
+      <li>Runs the at-the-con operations desk</li>
+      <li>Runs at-the-con check in / registration</li>
+      <li>Orders shirts, badges, patches, before the convention</li>
+      <li>Orders convention programs</li>
+      <li>Purchases consumables for the convention</li>
+      <li>Inventories Intercon/NEIL owned items</li>
+      <li>Arranges transport for the NEIL-owned items between the storage unit and the con.</li>
+      <li>Has at-con responsibilities - running at-the-con activities</li>
+    </ul>
+    <h3 class="my-2"><a name='roomdividercoordinator'>Room Divider Coordinator</a></h3>
+    <ul>
+      <li>Subdivision of Ops</li>
+      <li>Has at-con responsibilities:
+      <ul>
+       <li>Makes sure room dividers get assembled on Thursday, and disassembled on Sunday</li>
+       <li>Works with Ops Coordinator to ensure that periodic walkthroughs of con space happen to bring stray room dividers to the correct location</li>
+      </ul>
+    </ul>
+    <h3 class="my-2"><a name='safetycoordinator'>Safety Coordinator</a></h3>
+    <ul>
+      <li>Oversees the Safety team, selects members, arranges for training</li>
+      <li>Is part of the post-incident response team.</li>
+      <li>Has at-con responsibilities - coordinating the safety team</li>
+    </ul>
+
+    <h3 class="my-2"><a name='hotelliaison'>Hotel Liaison</a></h3>
+    <ul>
+      <li>Manages the relationship with the hotel, signs the contract, etc.</li>
+      <li>Colates the GM furniture requests and works with the hotel to arrange the needed items</li>
+      <li>Communicates with the hotel to arrange food service</li>
+      <li>Is on the Scheduling team</li>
+      <li>Has at-con responsibilities - being available for hotel issues</li>
+    </ul>
+
+    <h3 class="my-2"><a name='forumcoordinator'>Forum@Intercon Coordinator</a></h3>
+    <ul>
+      <li>Puts together the schedule of workshops, panels, and discussions for the con</li>
+      <li>Works with the Hotel Liaison to arranges for these events to have items they need</li>
+      <li>Is on the Scheduling team</li>
+      <li>Has at-con responsibilities - coordinating these events</li>
+    </ul>
+
+    <h3 class="my-2"><a name='attendeecoordinator'>Attendee Coordinator</a></h3>
+    <ul>
+      <li>Is the point of contact between attendees of the convention and the convention staff</li>
+      <li>Answers inbound questions from attendees, or hands them off to the correct staffer</li>
+    </ul>
+
+    <h3 class="my-2"><a name='volunteercoordinator'>Volunteer Coordinator</a></h3>
+    <ul>
+      <li>Recruits volunteers for at-the-con positions</li>
+      <li>Works with Artwork to design and purchase volunteer thank you items</li>
+    </ul>
+
+    <h3 class="my-2"><a name='vendorliaison'>Vendor Liaison</a></h3>
+    <ul>
+      <li>Finds and arranges vendors for the convention</li>
+      <li>Collects vendor fees for space and games.</li>
+      <li>Designs the layout of the vendor area</li>
+      <li>Handles vendor questions before the convention.</li>
+      <li>Has at-con responsibilities - directing vendors, answering questions</li>
+    </ul>
+
+    <h3 class="my-3"><a name='registrar'>Registrar</a></h3>
+    <ul>
+      <li>Handles registrations and issues with them, including vendor badges, comps that need manual processing, and other registration issues</li>
+      <li>Handles refund and rollover requests</li>
+    </ul>
+
+    <h3 class="my-2"><a name='treasurer'>Treasurer</a></h3>
+    <ul>
+      <li>Appointed by the NEIL board; not an individual con position</li>
+      <li>Handles money for the convention</li>
+      <li>Has access to the bank account and the Paypal/Stripe/Square/etc. accounts</li>
+      <li>Processes reimbursements for items purchased by other convention staff</li>
+      <li>Pays deposits, etc, to the hotel</li>
+    </ul>
+
+    <h3 class="my-2"><a name='advertising'>Booklet / Advertisement</a></h3>
+    <ul>
+      <li>Designs and lays out the convention program book</li>
+    </ul>
+
+    <h3 class="my-2"><a name='outreach'>Outreach</a></h3>
+    <ul>
+      <li>Promotes the convention outside of the existing community</li>
+      <li>This role is not always a specific person</li>
+    </ul>
+
+   <h3 class="my-2"><a name='news'>Accessibility Coordinator</a></h3>
+    <ul>
+      <li>Survey the community to identify accessibility needs</li>
+      <li>Work with con chair to prioritize accessibility needs to be met this year</li>
+      <li>Coordinate across divisions to meet accessibility needs for GMs and players</li>
+      <li>Coordinate with the hotel as needed to implement accessibility plans</li>
+    </ul>
+    
+    <h3 class="my-2"><a name='news'>Newsletter / Social Media Coordinator</a></h3>
+    <ul>
+      <li>Puts together communications to attendees based on input from other members of Intercon staff</li>
+      <li>Works with the con chair to determine the best media for each communication (newsletter post, facebook, twitter, etc)</li>
+      <li>Manages Intercon's social media presence</li>
+    </ul>
+
+    <h3 class="my-2"><a name='art'>Artwork</a></h3>
+    <ul>
+      <li>Designs the artwork for the convention: website, badges, patches, other items.</li>
+      <li>Works with Booklet on design/layout from an art perspective</li>
+    </ul>
+
+    <h3 class="my-2"><a name='hospitalitycoordinator'>Hospitality / Party Coordinator</a></h3>
+    <ul>
+      <li>Arranges the Friday night party</li>
+      <li>Arranges the Saturday night dance</li>
+      <li>Is the point of contact for people who want to run parties/meetups/etc in convention spaces</li>
+      <li>Works with the Scheduling team to schedule parties/meetups/etc and add them to the schedule</li>
+      <li>May have at-con responsibilities to run parties</li>
+    </ul>
+
+    <h3 class="my-2"><a name='irongmcoordinator'>Iron GM Coordinator</a></h3>
+    <ul>
+      <li>Appointed by the NEIL board; not an individual con position</li>
+      <li>Recruits Writing Teams and Readers for the Iron GM competition</li>
+      <li>Arranges for the writing weekend</li>
+      <li>Picks themes for the Iron GM competition</li>
+      <li>Runs the game judging, and announces the winners</li>
+    </ul>
+
+    <h3 class="my-2"><a name='raffle'>Raffle Coordinator</a></h3>
+    <ul>
+      <li>Reaches out to various people in advance of the convention to solicit raffle items</li>
+      <li>tracks donations, ensures they arrive at Ops and are properly labeled</li>
+      <li>Works with Advertising to track ads for the booklet</li>
+      <li>Coordinates with con chair to arrange membership exchanges with other cons</li>
+    </ul>
+
+    <h3 class="my-2"><a name='plugs'>Plugs Coordinator</a></h3>
+    <ul>
+      <li>Collects shameless plugs for the raffle plugs</li>
+      <li>Runs the plugs, manages the clock, etc.</li>
+      <li>Has at-con responsibilities - running plugs</li>
+    </ul>
+
+    <hr>
+
+    <h2 class="my-3"><a name='group'>Group Roles</a></h2>
+    <h3 class="my-2"><a name='propcom'>Proposal Committee</a></h3>
+    <ul>
+      <li>Gives feedback on each proposed proposal, helping set up the GMs to make their event as successful as possible </li>
+      <li>Does not reach out to the submitting GMs, except if asked to by the Proposal Chair.</li>
+    </ul>
+
+    <h3 class="my-2"><a name='safetystaff'>Safety Staff</a></h3>
+    <ul>
+      <li>Reports up to the Safety Coordinator</li>
+      <li>Provides at-large safety response for the convention.</li>
+      <li>Has at-con responsibilities</li>
+    </ul>
+
+    <h2 class="my-2"><a name='websiteteam'>Website Team</a></h2>
+    <ul>
+      <li>Dev side - Responsible for developing and maintaining the website</li>
+      <li>Ops side - Responsible for running the website and maintaining the email aliases </li>
+    </ul>
+
+    <h3 class="my-2"><a name='opsstaff'>Operations Volunteers</a></h3>
+    <ul>
+      <li>Helps out the Operations lead before or during the convention</li>
+      <li>Reports up to the Operations lead</li>
+      <li>Before - helps with item transport, ordering, etc</li>
+      <li>During - staffs the Ops desk and helps with check in, answers questions, and escalates issues appropriately </li>
+      <li>Has at-con responsibilities</li>
+    </ul>
+  </div>
+</div>

--- a/cms_content_sets/wanderlust/pages/root.liquid
+++ b/cms_content_sets/wanderlust/pages/root.liquid
@@ -1,0 +1,94 @@
+---
+name: Main Landing Page
+admin_notes: This is the root page of the website
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% include 'conintro' %}
+
+{% render 'vax_check', user_con_profile:user_con_profile, convention:convention %}
+
+{% render 'badgecheck', user_con_profile:user_con_profile, convention:convention %}
+
+{% capture sidebar_content %}
+  {% render 'user_resources', user_con_profile:user_con_profile %}
+  {% render 'user_signup_list', user_con_profile:user_con_profile, convention:convention %}
+  {% render 'user_team_member_events', user_con_profile:user_con_profile %}
+  {% render 'user_event_proposals', user_con_profile:user_con_profile %}
+  {% render 'discord_button', user_con_profile:user_con_profile, discord_invite:discord_invite, css_color_3:css_color_3 %}
+{% endcapture %}
+{% assign sidebar_content_stripped = (sidebar_content | strip) %}
+
+<div class="row my-2">
+  
+  {% if sidebar_content_stripped != '' %}
+    <div class="col-lg-6 order-lg-1">
+      {{ sidebar_content_stripped }}
+    </div>
+  {% endif %}
+  
+  <div class="{% if sidebar_content_stripped != '' %}col-lg-6{% else %}col-md-12{% endif %}">
+    <section class="my-4">
+      <ul class="nav nav-tabs" id="myTab" role="tablist">
+        {% if show_games_with_openings %}
+          <li class="nav-item">
+            <a class="nav-link active" id="games-with-openings-tab" data-bs-toggle="tab" href="#games-with-openings" role="tab" aria-controls="games-with-openings" aria-selected="true">
+              Larps with openings
+            </a>
+          </li>
+        {% endif %}
+        
+        {% if show_run_list == 'new' %}
+          <li class="nav-item">
+            <a class="nav-link {% unless show_games_with_openings %}active{% endunless%}" id="new-games-tab" data-bs-toggle="tab" href="#new-games" role="tab" aria-controls="new-games" aria-selected="{% unless show_games_with_openings %}true{%else%}false{% endunless%}">
+              New Events
+            </a>
+          </li>
+        {% else %}
+          <li class="nav-item">
+            <a class="nav-link {% unless show_games_with_openings %}active{% endunless%}" id="events-link-tab" data-bs-toggle="tab" href="#events-link" role="tab" aria-controls="events-link" aria-selected="{% unless show_games_with_openings %}true{%else%}false{% endunless%}">
+              All Events
+            </a>
+          </li>
+        {% endif %}
+        
+        {% if convention.show_schedule == 'yes' %}
+          <li class="nav-item">
+            <a class="nav-link" id="social-events-tab" data-bs-toggle="tab" href="#social-events" role="tab" aria-controls="social-events" aria-selected="false">
+              Social Events
+            </a>
+          </li>
+        {% endif %}
+      </ul>
+    <div class="tab-content my-3" id="myTabContent">
+      {% if show_games_with_openings' %}
+        <div class="tab-pane fade show active border-bottom" id="games-with-openings" role="tabpanel" aria-labelledby="games-with-openings-tab">
+          {% render 'runs_with_openings', convention:convention %}
+        </div>
+      {% endif %}
+      {% if show_run_list == 'new' %}
+        <div class="tab-pane fade{% unless show_games_with_openings %} show active{% endunless%}" id="new-games" role="tabpanel" aria-labelledby="new-games-tab">
+          {% render 'new_events_list', convention:convention %}
+        </div>
+      {% elsif convention.show_schedule == 'yes' %}
+      <div class="tab-pane fade{% unless show_games_with_openings %} show active{% endunless%} my-3 border-bottom" id="events-link" role="tabpanel" aria-labelledby="events-link-tab">
+          Check out <a href="/events/schedule">the convention schedule!</a>
+        </div>
+      {% else %}
+        <div class="tab-pane fade{% unless show_games_with_openings %} show active{% endunless%} my-3 border-bottom" id="events-link" role="tabpanel" aria-labelledby="events-link-tab">
+          Check out <a href="/events">the events list!</a>
+        </div>
+      {% endif %}
+      {% if convention.show_schedule == 'yes' %}
+      <div class="tab-pane fade my-3" id="social-events" role="tabpanel" aria-labelledby="social-events-tab">
+        {% render 'social_events', convention:convention %}
+      </div>
+      {% endif %}
+    </div>  
+    <div class="my-2 pt-2">
+      <h3>Convention News</h3>
+      {% render '0-news', convention:convention %}
+      <a href="{% page_url news %}">All News</a>
+    </div> 
+    </section>
+</div>

--- a/cms_content_sets/wanderlust/pages/rules.liquid
+++ b/cms_content_sets/wanderlust/pages/rules.liquid
@@ -1,0 +1,220 @@
+---
+name: Convention Rules
+admin_notes: ''
+skip_clickwrap_agreement: true
+hidden_from_search: false
+---
+{% assign con_chair = convention.staff_positions_by_name.con_chair %}
+{% assign ops_lead = convention.staff_positions_by_name.operations_coordinator %}
+{% assign safety = convention.staff_positions_by_name.safety_coordinator %}
+{% assign registrar = convention.staff_positions_by_name.registrar %}
+{% assign attendees = convention.staff_positions_by_name.attendee_coordinator %}
+{% assign vaccination = convention.staff_positions_by_name.covid_verification %}
+
+<h1 class="my-3">New England Intercon Rules and Code of Conduct</h1>
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Intercon Rules</h4>
+      </li>
+      <li class="toc-entry"><a href="#policies">Convention Policies</a>
+        <ul>
+          <li class="toc-entry"><a href="#policies-gameregistration">Game Registration</a></li>
+          <li class="toc-entry"><a href="#policies-communication">Player Communication Policy</a></li>
+          <li class="toc-entry"><a href="#policies-harassment">Harassment Policy</a>
+          <ul>
+            <li class="toc-entry"><a href="#policies-harassment-emergencynumbers">Emergency Numbers</a></li>
+          </ul></li>
+          <li class="toc-entry"><a href="#policies-covid">COVID Policy</a>
+          <li class="toc-entry"><a href="#policies-weapons">Weapons Policy</a></li>
+          <li class="toc-entry"><a href="#policies-violations">Policy Violations</a></li>
+          <li class="toc-entry"><a href="#policies-withdrawing">Withdrawing</a></li>
+          <li class="toc-entry"><a href="#policies-children">Children</a></li>
+          <li class="toc-entry"><a href="#policies-pets">Pet Policy</a></li>
+          <li class="toc-entry"><a href="#policies-photos">Photo Policy</a></li>
+          <li class="toc-entry"><a href="#policies-gm">GM Benefits and Policies</a></li>
+        </ul></li>
+      <li class="toc-entry"><a href="#hotel">Hotel Rules</a>
+      <ul>
+        <li class="toc-entry"><a href="#hotel-staying">Staying at the Hotel</a></li>
+        <li class="toc-entry"><a href="#hotel-smoking">Smoking</a></li>
+		<li class="toc-entry"><a href="#hotel-guests">Respect Non-Attendee Hotel Guests</a></li>
+        <li class="toc-entry"><a href="#hotel-alcohol">Alcohol</a></li>
+        <li class="toc-entry"><a href="#hotel-signs">Posting Signs</a></li>
+      </ul></li>
+      <li class="toc-entry"><a href="#contacting">Contacting Staff</a></li>
+      <li class="toc-entry"><a href="#fun">Have Fun</a></li>
+</ul>
+</div>
+<div class='col'>
+
+<h2 class="my-3"><a name='policies'>Convention Policies</a></h2>
+
+<h3 class="my-2"><a name='policies-gameregistration'>Game Registration Policy</a></h3>
+<p>Intercon follows a strict first come, first serve policy when it comes to game registrations.  We expect GMs to honor your signup bucket selection when it comes to casting.</p>
+
+<p>The only exceptions to this policy are age-related or legal restrictions.  Some games have age restrictions due to content or boffer combat, and the GMs have worked with the Convention staff to get approval for these restrictions.  In these cases, it will be clear from the game description.</p>
+
+<h3 class="my-2"><a name='policies-communication'>Player Communication Policy</a></h3>
+<p>
+  If you have questions about a game, for example content warnings or accessibility concerns, please reach out to the GMs or the {{attendees.name_with_email_link}} at your earliest convenience, in advance of signups if possible.
+</p>
+<p>
+  Many games are tightly plotted or depend on pre-convention communication from the players who have signed up for the game. In these cases, non-responsive players can make it harder to ensure that everyone in the game has a great time.  We recommend that GMs start early and reach out to players well before the convention.
+</p>
+  <p>
+If the GMs have made a good faith effort to contact a player and have not received any response for over two weeks, they can ask the GM Coordinator to attempt to get in touch with the player on their behalf. If at one month prior to the convention, the convention staff are not able to reach the player themselves, they will work with the GM to modify any game registrations as needed.
+ </p>
+ <p>
+If you know in advance that you cannot make a game, please let the GMs or Operations Staff know, so that the GMs can make proper arrangements.  If you are more than 10 minutes late for a game, you may be recast at the GMs' discretion.
+</p>
+
+
+<h3 class="my-2"><a name='policies-harassment'>Harassment Policy</a></h3>
+<p>
+Intercon is dedicated to providing a harassment-free convention experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion, or any other factor. We do not tolerate harassment of convention attendees in any form. Convention attendees violating these rules may be sanctioned or expelled from the convention without a refund at the discretion of the convention organizers.</p>
+<p>
+Harassment includes, but is not limited to, offensive verbal comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. It also includes display of sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of games or other events, inappropriate physical contact, unwelcome sexual attention, bathroom policing, and unwelcome simulated combat using realistic or non-realistic weapon props. Participants asked to stop any harassing behavior are expected to comply immediately.</p>
+<p>
+If a participant engages in harassing behavior, the convention organizers may take any action they deem appropriate, including warning the offender or expulsion from the convention with no refund. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the convention Safety Staff immediately. Convention Safety Staff can be identified by their convention badge, which will say "Safety Staff" under their name, and, if they are on duty, by an Intercon Safety Staff button.</p>
+<p>
+Convention Safety Staff will be happy to help participants contact Hotel security or local law enforcement if desired, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the convention. Safety Staff will never pressure anyone into making an official report.  We value your safety, privacy, and comfort while at Intercon.</p>
+<p>
+Questions about this policy should be directed to {{con_chair.email_link}}</a>. At con, you can contact convention staff by calling the Safety Staff 24-hour hotline number at 313-SAFETY-4, or by coming to the Operations desk during Ops hours, or emailing {{safety.email_link}}</a>.
+</p>
+
+<h4 class="my-2"><a name='policies-harassment-emergencynumbers'>Emergency Numbers</a></h4>
+<dl class="row">
+<dt class="col-md-7">Convention Safety 24-Hour Hotline</dt>
+  <dd class="col-md-5">313.SAFETY.4</dd>
+<dt class="col-md-7">Hotel Security/Front Desk</dt>
+  <dd class="col-md-5">Hotel Phone: Dial 0<br>or: 401.732.6000</dd>
+<dt class="col-md-7">Warwick Police</dt>
+  <dd class="col-md-5">401.468.4200</dd>
+<dt class="col-md-7">Rhode Island Domestic Violence Hotline</dt>
+  <dd class="col-md-5">800.494.8100</dd>
+<dt class="col-md-7">Boston Area Rape Crisis Center 24 hour hotline</dt>
+  <dd class="col-md-5">800.841.8371</dd>
+<dt class="col-md-7">Medical (or other) emergency</dt>
+  <dd class="col-md-5">911</dd>
+<dt class="col-md-7">Apponaug Cab Service</dt>
+  <dd class="col-md-5">401.249.0523</dd>
+<dt class="col-md-7">American Cab</dt>
+  <dd class="col-md-5">401.487.2111</dd>
+</dl>
+<h3 class="my-2"><a name='policies-covid'>COVID Policy</a></h3>
+<p>Intercon and NEIL require everyone attending {{ convention.name }} to provide proof of full vaccination against COVID-19 as defined by the CDC, including booster(s).  This proof can be given in advance, via email (to {{vaccination.email_link}}), zoom sessions, or similar, by January 1, {{convention.starts_at|date: "%Y"}}. No exemptions will be granted, including for medical or religious reasons, and this policy applies to everyone entering convention space as an attendee, the same as our Badge policy.</p>
+<p>Proof of full vaccination will be accepted in the form of:
+  <ul>
+    <li>Emailing a scanned or photographed vaccine card or letter to {{vaccination.email_link}}
+ - records will be deleted within 30 days of receipt</li>
+    <li>Holding up card on a video chat (schedule forthcoming)</li>
+    <li>Having provided the same level of proof to another NEIL event prior</li>
+    </li>
+  </ul>
+</p>
+<p>Please see the full COVID FAQ page for complete information on our policies and requirements. </p>
+
+
+
+<h3 class="my-2"><a name='policies-weapons'>Weapons Policy</a></h3>
+<p>
+Intercon understands that costumes sometimes include weapons, and some boffer games have simulated combat with boffer weapons, but the safety and comfort of our attendees and other occupants of the hotel must be paramount. In the context of this policy, "weapon prop" or "weapon-like prop" refers to any prop that looks like a weapon, including but not limited to swords, knives, guns, bats, clubs, claws, arrows, etc.</p>
+<p>
+Any realistic-looking weapon prop must be peace-bonded and not wieldable. Swords must be secured in their sheaths with string, zip-ties, or some other method that actually prevents them from being drawn. If you need help peace-bonding your weapon prop, you may bring it to Ops. If con staff concludes that your realistic-looking weapon prop cannot be peace-bonded, you will be asked to return the prop to your hotel room or vehicle and leave it there for the duration of the convention.</p>
+<p>
+Wieldable weapon props must be obviously fake and approved by the GMs. In games that use boffer combat, only props approved for boffer combat by the GMs may be used for this purpose. In other games, combat may be acted out as well as being simulated with non-physical methods ONLY with the explicit permission of all parties involved. Please note that explicit permission to act out a combat does not automatically imply permission to touch another player or to contact another player with your weapon prop.</p>
+<p>
+Outside of games, any non-realistic weapon props must either be peace-bonded or carried in a non-threatening manner (sheathed, pointed at the floor, or put away). (Realistic weapon props must be peace-bonded at all times, as detailed above).</p>
+<p>
+Non-prop weapons are not allowed at Intercon.</p>
+<p>
+No realistic-looking gun props without orange safety tips are allowed at con under any circumstances.</p>
+<p>
+Violation of any of these rules is grounds for immediate expulsion from the con, without refund. If you have any questions about acceptable weapon props, ask at the Operations desk or contact the Con Chair or the Operations coordinator.</p>
+
+<h3 class="my-2"><a name='policies-violations'>Violations</a></h3>
+<p>Anyone found violating any of these policies may be subject to ejection from Intercon without refund.  Intercon reserves the right to expel anyone for any reason, with or without warning.</p>
+
+<h3 class="my-2"><a name='policies-withdrawing'>Withdrawing from the Con</a></h3>
+<p>To withdraw from the Con, email the {{con_chair.name_with_email_link}} and {{registrar.name_with_email_link}}.</p>
+<p>If you withdraw from the Con before January 1st of the year of the convention, you are eligible for a full refund.  Withdrawals within 30 days of the Convention are eligible for a refund or membership in next year's Con at the discretion of the ConChair.</p>
+
+<h3 class="my-2"><a name='policies-children'>Children at Intercon</a></h3>
+<p>All attendees at the convention should be badged for security reasons.</p>
+<ul>
+  <li>Children under 5 are free to attend.</li>
+  <li>Children 5 - 14 who will not be playing games: $5 to cover costs.</li>
+  <li>Children under 14 who will be playing games : $20 to represent the limited selection of larps. ($10 at the door)</li>
+  <li>Children 14 and over: <a href="{% page_url pricing %}">normal price</a>.
+</ul>
+<p>We strongly recommend looking at the list of games for suitability before deciding to purchase a games badge.  The games available each year can vary quite a lot.  To arrange payment for child badges, please contact the {{registrar.name_with_email_link}}.</p>
+<p>Any child under 14 at Intercon must be accompanied by a responsible adult. Minors over 14 but under 18 must have a responsible adult present at the convention, but do not always need to be accompanied by them. Everyone under 18 must have contact information for their responsible adult on them or left at Ops. Intercon cannot be responsible for your children.</p>
+<h3 class="my-2"><a name='policies-pets'>Pets at Intercon</a></h3>
+ <p> While the hotel is pet-friendly, Intercon itself has a no-pet policy. Trained service animals are, of course, welcome in Intercon spaces. However, we ask, although this is not a requirement, that you give your GMs an advance note that you will be bringing your service dog into the gaming space so that they can inform all their players to expect the presence of the animal and behave accordingly.
+</p>
+  
+<h3 class="my-2"><a name='policies-photos'>Photography Policy</a></h3>
+<p>Prior to taking or sharing images or video of attendees taken during NEIL events,(such as {{convention.name}}) participants and organizers of NEIL events must get permission of the subjects or provide them explicit opt out opportunities.</p>
+
+<h3 class="my-2"><a name='policies-gm'>GM Benefits, Policies and Services</a></h3>
+<p><a href="{%page_url gmpolicies %}">The GM policies</a>, which cover running larps at Intercon, are available as a separate document.</p>
+<hr>
+<h2 class="my-3"><a name='hotel'>Hotel Rules</a></h2>
+
+<h3 class="my-2"><a name='hotel-staying'>Staying at the Crowne Plaza</a></h3>
+<p>
+Each hotel room should have no more than four occupants. Sleeping in public
+areas of the hotel or in the convention areas is forbidden by the hotel
+management.
+</p>
+
+<h3 class="my-2"><a name='hotel-smoking'>No Smoking in Hotel and Convention Area</a></h3>
+<p>
+Per the Board of Health, smoking is not allowed in any public area of the hotel.
+If you wish to smoke, please go to a designated public smoking area (outside).
+</p>
+
+<h3 class="my-2"><a name='hotel-guests'>Respect Non-Attendee Hotel Guests</a></h3>
+<p>
+Remember there are non convention-going guests staying at the hotel. All major game activity should take place in the conference area, not the hotel area, although quiet game activity may occur inside player rooms (not in the halls) during the day. The hotel area should be specifically considered quiet space after 10pm, and no game activity should take place there after that time, except in hotel suites designated by the convention for certain LARPs. Players in those LARPs are encouraged to be mindful of other hotel guests and keep activity within those hotel suites.
+</p>
+
+<h3 class="my-2"><a name='hotel-alcohol'>Alcohol Policy</a></h3>
+<p>Because of the hotel's liquor license and strict Rhode Island state law, alcohol in function spaces may only be served by a bartender from the hotel. Players and GMs may not bring their own alcohol into the function space.  If a GM would like to have a real bar for their game, we can make arrangements with the hotel in advance.</p>
+
+<p>Players, GMs, or Games found in violation of this policy will be asked to remove the alcohol from the function space immediately. If they do not comply, they will be asked to leave the hotel.  If the GMs opt to have a bartender, the bartender will validate that the players are of legal drinking age.</p>
+
+<h3 class="my-2"><a name='hotel-signs'>Posting Signs</a></h3>
+<p>
+You may only attach something to the walls, doors, columns, pillars, etc. if you use mounting putty, which will leave no residue and will not damage the paint or varnish. The convention has a limited amount of putty available which it can loan as needed.
+</p>
+<hr>
+<h2 class="my-3"><a name='contacting'>Contacting Staff</a></h2>
+<p>
+Please report to Safety Staff, Ops Staff or the Con Chair any incident in which a
+member of the convention ignores the rules of the convention stated
+above. New England Interactive Literature reserves the right to revoke,
+without refund, the membership of anyone for any just cause.
+</p>
+<p>Safety staff can be contacted via the 24-hour hotline at 313-SAFETY-4. An Ops
+Staff member can always be found at the Ops desk during regular Operations
+hours. If the hotel observes a guest violating any of the above rules,
+the hotel reserves the right to have that guest removed from the property
+without refund.
+</p>
+<p>
+  To find email addresses for all department heads at Intercon, please see the <a href="{% page_url contacts %}">Contacts page</a>.
+</p>
+<p>
+New England Interactive Literature is not responsible for any lost or
+stolen property.
+</p>
+<h2 class="my-3"><a name='fun'>Have Fun!</a></h2>
+<p>
+Have a good time! Have a great time! Have a grand time! Just have fun!
+</p>
+
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/signupfaq.liquid
+++ b/cms_content_sets/wanderlust/pages/signupfaq.liquid
@@ -1,0 +1,135 @@
+---
+name: Game Signup FAQ
+admin_notes: REVIEW
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign gm_coordinator = convention.staff_positions_by_name.gm_coordinator %}
+{% assign web_team = convention.staff_positions_by_name.web_team %}
+<h1 class="my-3">Game Signup FAQ</h1>
+
+<div class="row">
+  <div class="col-md-3">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Game Signup FAQ</h4>
+      </li>
+      <li class="toc-entry"><a href="#overview">Overview</a></li>
+      <li class="toc-entry"><a href="#dates">Signup Dates</a></li>
+      <li class="toc-entry"><a href="#tips">Tips for Signup</a>
+        <ul>
+          <li class="toc-entry"><a href="#pay">Pay in Advance</a></li>
+          <li class="toc-entry"><a href="#plan">Make a Plan</a></li>
+          <li class="toc-entry"><a href="#bucket">Know Which Bucket You Want</a>
+          <ul>
+            <li class="toc-entry"><a href="#bucket-flex">The Flex Bucket</a>
+            <li class="toc-entry"><a href="#bucket-np">No Preference</a>
+          
+          </ul>
+          </li>
+          <li class="toc-entry"><a href="#signin">Stay Signed In</a></li>
+          <li class="toc-entry"><a href="#norefresh">No Need to Refresh</a></li>
+          <li class="toc-entry"><a href="#stickaround">Stick Around</a></li>
+        </ul>
+      </li>
+      <li class="toc-entry"><a href="#problems">Having Problems?</a></li>
+    </ul>
+  </div>
+<div class='col'>
+<h2 class='my-3'><a name='overview'>Overview</a></h2>
+<p>
+  Intercon lets you sign up for games before the convention.  Since games have limited space, our goal with this process is to allow as many people as possible to play in the games they prefer.
+</p>
+
+<p>
+  Game signup is separate from convention registration. By registering and paying for Intercon, you are entitled to sign up for as many games as you like, provided they are not running concurrently.  Furthermore, you <strong>do not</strong> need to have provided Intercon with proof of up-to-date vaccination to sign up for games - we check vaccination status closer to the con.
+</p>
+
+<p>
+  Individual game signups usually begin in November, but will be announced in an email newsletter, which is sent to everyone who has registered. You must be paid up in order to sign up for games.
+</p>
+
+<p>There are four rounds of signups. Signups usually open at 7pm Eastern; each round is six days later than the last.</p>
+<div class="alert text-bg-warning">As of October 2024, this is under review, but a new fourth round has been added for {{convention.name}}</div>
+<ul>
+	<li>In the first round, you may sign up for one game</li>
+	<li>In the second round, you may sign up for a second game</li>
+	<li>In the third round, you may sign up for a third game</li>
+    <li>In the fourth round, you may sign up for a fourth game</li>
+	<li>In the final round, you may sign up for as many games as you like</li>
+</ul>
+<hr>
+<h2 class='my-3'><a name='dates'>Signup Dates</a></h2>
+<p>
+  For {{convention.name}}, these are the likely signup dates:
+</p>
+{% include 'signup_schedule'%}
+<hr>
+<h2 class='my-3'><a name='tips'>Tips for Signup</a></h2>
+
+<h3 class="my-2"><a name='pay'>Pay In Advance</a></h3>
+
+<p>Have you paid for Intercon?  If not, you won't be able to sign up for games, so please make sure to log in and pay for the con before signups open!  (Or if you're a GM, make sure you've set yourself up to be comped for your game.  You can email the {{gm_coordinator.name_with_email_link}} if you're not sure how.)</p>
+
+
+<h3 class="my-2"><a name='plan'>Make a Plan</a></h3>
+
+<p>Signups tend to go pretty fast once we open the floodgates!  It pays to plan ahead, not only for which game you'd like to sign up for, but for one or two backup options in case your first choice fills too fast.</p>
+
+<h3 class="my-2"><a name='bucket'>Know Which Bucket You Want</a></h3>
+
+<p>
+  Intercon allows games to split up their signups into "buckets" of character types.  Many games divide their buckets by character gender (e.g. "Female Role" and "Male Role" buckets).  Other games use "Cast" and "Horde", or anything else the game's GMs decide.
+</p>
+<p>
+  On the web page for a game, you'll see a button for each bucket in the game.  For example, if the game has buckets for "PC" and "NPC", you'll see buttons for "Sign up - PC" and "Sign up - NPC".  Click on whichever one you'd like to sign up for.
+</p>
+<p>
+  Some games don't use buckets, and instead either choose roles for players later in the process or have players create their own characters.  This type of game will just have a single "Sign up" button on its page.
+</p>
+<p>
+We expect GMs to honor your signup bucket selection when it comes to casting.  If you have any questions or concerns, please email the {{convention.staff_positions_by_name.attendee_coordinator.name_with_email_link}}.
+</p>
+  
+<h4 class="my-2"><a name='bucket-flex'>The Flex Bucket</a></h4>
+<p>
+  Some games may have a "Flex" bucket, which shows up in the list of buckets of character types. The Flex bucket represents characters which can be <strong>any one of the other buckets above it</strong>.  For example, a larp might have 6 robot characters, 3 human characters, and 7 characters that could be played as either a robot or a human.  Those 7 characters would make up the flex bucket.
+ </p>
+<p>
+  Games that have a flex bucket don't have a signup button <strong>specifically</strong> for the flex bucket (in other words, there is no "Sign up - Flex" button).  That's because ultimately, all the characters in the flex bucket will end up as one of the other buckets.  In the example above, all 7 characters in the flex bucket are either robots or humans - we just don't know which each one of them is yet.
+</p>
+<p>
+  Because of that, we still ask you about your preference between the different buckets when you sign up.  We keep a record of what button you clicked on, even if you end up in the flex bucket.  We show the GMs which button you clicked, and we expect them to honor your stated bucket preferences.
+</p>
+
+<p>One important thing to note is that, because of this, if a game has every slot of the specific bucket you want showing as filled, but there's still empty space in the flex bucket, you can go ahead and sign up directly for the bucket you want, and that will assign your signup to that bucket, using a character from the flex bucket.
+</p>
+  
+<h4 class="my-2"><a name='bucket-np'>No Preference</a></h4>
+<p>
+  Many games offer a "Sign up - No preference" button in addition to the other signup buttons.  If you don't have a preference between the buckets in the game, this button is for you.  In our above example, let's say you're fine playing a human or a robot and you don't really care which you play as long as you get to be in the game.  If that's the case, click this button, and we'll record that you didn't have a preference and show that to the GMs.
+</p>
+<p>
+  If a game has a flex bucket (see the section above), clicking "Sign up - No preference" <strong>does not guarantee you a spot in the flex bucket.</strong>  Clicking that button means that you have no preference about which bucket you're in.  You might even be moved between buckets to make room for players who clicked buttons to sign up for specific buckets.  (We'll never drop you from the game, but if you clicked "Sign up - No preference" we might move you around within the buckets.)
+</p>
+<p>
+  One exception is games that have NPCs.  If a game has NPCs, "Sign up - No preference" usually means "I want to be a PC, but I don't care which type of PC."  If that's the case, the game page will indicate that by placing the ‘Sign up - NPC’ button below the ‘Sign up - No Preference’ button and  visually separating it from other "Sign up" buttons.  If you click "Sign up - No preference" for a game like this, you won't be slotted into an NPC role, but might be slotted into any of the other buckets.
+</p>
+  
+<h3 class="my-2"><a name='signin'>Stay Signed In</a></h3>
+
+<p>Years ago, you had to sign out of the web site and sign back in once signups opened.  Those days are long gone!  You can just stay signed in on any page of the site you like.</p>
+
+<h3 class="my-2"><a name='norefresh'>No Need to Refresh</a></h3>
+
+<p>There's no need to refresh the game page for the game you want to sign up for when signups begin, you can simply click on the signup button, and the site will process the request appropriately.</p>
+
+<h3 class="my-2"><a name='stickaround'>Stick around</a></h3>
+
+<p>The best place to be on the Intercon site when signups open is on the page of your first choice game.  When it gets close to signup round opening time, start clicking on the button for the signup bucket you want.  If you click too early, you'll get an error saying that registration isn't open yet &mdash; that's fine, just keep hitting the button until signups open.  (It's ok, our mighty web server can handle it.)</p>
+<hr>
+<h2 class="my-3"><a name='problems'>Having Problems?</a></h2>
+
+<p>If you have any trouble signing up, please email the {{ web_team.name_with_email_link }}.  We'll be on the lookout for emails during the signup rush and will try to get things fixed up as quickly as possible.</p>
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/social.liquid
+++ b/cms_content_sets/wanderlust/pages/social.liquid
@@ -1,0 +1,74 @@
+---
+name: Social Events at Intercon
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+{% assign hospitality = convention.staff_positions_by_name.social_coordinator %}
+{% assign all_categories = convention.event_categories %}
+{% assign social_event = (all_categories | where: "name", "Social event") %}
+{% assign meetup = (all_categories | where: "name", "Meetup") %}
+{% assign hospitality_categories = (social_event | concat: meetup) %}
+{% assign hospitality_category_ids_urlencoded = (hospitality_categories | map: "id" | join: "%2C") %}
+
+<header class="mb-4">
+  <h1 class="mb-0">Social Events at {{ convention.name }}</h1>
+  <p class="lead">Intercon is more than just larps!  We also have a number of social events where you can meet and mingle with your fellow players and GMs.</p>
+</header>
+
+<div class="row mt-4">
+  <div class="col-md-8">
+    <section>    
+      <h3 class="mt-0">I'd like to host a social event or meetup!</h3>
+  
+      {% new_event_proposal_button "Propose an event" btn btn-outline-primary mb-2 %}
+
+      <p>Great!  Please click the button above to fill out the proposal form.  If you have more than one event you're interested in hosting, you'll need to fill out the form multiple times (similar to how larp proposals work).</p>
+
+      <p>Once you've filled out the form, we'll get back to you via email to let you know we've received it and give you some information on what you can expect.</p>
+      
+      <h2 class="mt-2"><a name="annual">Con-Sponsored Social Events</a></h2>
+
+      <h3 class="mt-2"><a name="friday">Thursday Welcome Party!</a></h3>
+<p>We are looking for people to join us for an adventure! We are now featuring a Thursday dinnertime Welcome Party to kick off the start of the con before evening games begin! Come join us for snacks and community!
+      
+      <h3 class="mt-2"><a name="friday">Friday Night Tavern Night! Saturday Night Lounge Party!</a></h3>
+      <p>Friday after most games wrap up at midnight, we host a party in con space, open and welcomed to all! The theme of this year's party is a Tavern Night with con-provided pizza, a bar setup (opening earlier), and bards are welcomed to bring their instruments! On Saturday, attendees (masks required) are welcomed to unwind in a cool lounge setting with board games and fun!
+      </p>
+
+      <h3 class="mt-2"><a name="saturday">Friday and Saturday Night Dances!</a></h3>
+      <p>After most games wrap up at midnight, on Friday and Saturday night, WE DANCE! Friday night's danced will be mask-required and Saturday night's will be mask-optional. Both nights will feature exceptional DJs!</p>
+
+      <h3 class="mt-2"><a name="friday">Lunch and Dinner Meetups!</a></h3>
+      <p>Feeling that Wanderlust and want to join fellow attendees for meals? Whether you know everyone already or are looking to make new friends, your lunch and dinner spot is saved! Come to the marked table in consuite with your lunch, meet friends, and enjoy the themed activities! There's a Druids Luncheon (Friday lunch), Rogues Dinner (Friday dinner), Warriors Luncheon (Saturday lunch), and Wizards Dinner (Saturday dinner)!
+      </p>
+
+      <h3 class="mt-2"><a name="friday">Sundae Night Social!</a></h3>
+      <p>Every year, we close the convention with one more social! Join us Sunday (sundae) night for our anual ice cream party, in the con suite!
+      </p>
+
+      There are many more, attendee-run social events too! Check out the full list! Propose your own to add to it! HYPE!
+    </section>
+    
+  </div>
+  
+  <div class="col-md-4">
+    <div class="mb-4 d-flex flex-column justify-content-stretch">
+      {% new_event_proposal_button "Propose an event" btn btn-primary btn-lg mb-2 w-100 %}
+      <a href="/events/?filters.category={{ hospitality_category_ids_urlencoded }}" class="btn btn-outline-primary btn-lg">List of social events</a>
+    </div>
+    <div class="card bg-light">
+      <div class="card-header">Contact information</div>
+      <div class="card-body">
+        <strong>{{ hospitality.name }}</strong>
+        <ul class="list-unstyled">
+          {% for user_con_profile in hospitality.user_con_profiles %}
+            <li>{{ user_con_profile.name_without_nickname }}</li>
+          {% endfor %}
+        </ul>
+        
+        <p class="mb-0">{{ hospitality.email | email_link }}</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cms_content_sets/wanderlust/pages/social/request.liquid
+++ b/cms_content_sets/wanderlust/pages/social/request.liquid
@@ -1,0 +1,14 @@
+---
+name: Request a Social Event
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="{% page_url social %}">Social Events</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Request a Meetup or Party</li>
+  </ol>
+</nav>
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfNOVCKHUfWYS8-geYVSMj0I4csSDOqdmHRHrZ8pr166cJiUw/viewform?embedded=true" style="width: 100%; height: 720px; height: 80vh;" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>

--- a/cms_content_sets/wanderlust/pages/statements/challenging-content.liquid
+++ b/cms_content_sets/wanderlust/pages/statements/challenging-content.liquid
@@ -1,0 +1,53 @@
+---
+name: Statement of Intent - Challenging Content
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">NEIL / Intercon Statement of Intent</h1>
+<h2 class="my-3">Challenging content at Intercon</h2>
+<h4 class="my-2">Posted: April 12, 2019</h3>
+<h3 class="my-2">Introduction</h3>
+<p class='lead'>Over the past decade, the Intercon staff has made several changes to how Intercon runs. Many of these changes were made with the intent of improving safety.  We haven’t gone into the full details with all members of the community of why these changes were implemented.  To that end, we want to clarify the goals of these efforts and explain the  actions taken for them.</p>
+
+<p>Our primary goal in running Intercon is for it to be the best venue for larps that it can be, and all the decisions we make are to that end.  We actively want a wide variety of games at Intercon, including ones that explore complicated themes, dangerous ideas, and difficult topics.  The best way to support these kinds of games is to provide a support structure so that our attendees can safely choose to engage with them.  We ask GMs to provide content warnings on their games, to allow players to opt into or out of content that they know they will find hard, rather than having to avoid games because they don’t know what themes and content will be in them.  By providing a trained Safety team, we allow people to feel comfortable engaging with more difficult stories, and immersing themselves in character.  The Safety team provides people that players and GMs can talk to, if something goes in unexpected ways or affects them harder than anticipated.  We want GMs to be able to explore challenging content if they want to do so. Because we're all human, that comes with an inherent risk of making a mistake and presenting said content in a way that is likely to cause harm. By having the proposal team proactively review for potentially difficult content as part of their review, we allow space for GMs to make those mistakes in ways that don’t directly have a negative impact on players.</p>
+
+<p>We love games that are deeply emotional, carefully explore hard topics, and contain dangerous ideas.  We want those games to thrive at Intercon, alongside games that do not contain these elements.  It is important to remember that stories that explore topics that can cause real world pain have the potential to be cathartic and healing, but these stories also have the potential to inflict pain themselves. This is especially true when games address these items in an exploitative or trivializing manner. However, even if a game treats a difficult topic with care and sensitivity, there may still be some players who would be harmed by playing it.  We want there to be space for those games to run at Intercon, while also allowing players to make informed choices about whether they want to play in them.  These changes in policy are not to censor games, but to free them and players to explore difficult concepts and topics in a collaborative fashion. They allow for informed consent about a game’s topics so that everyone involved has a better idea of what the game they are playing is about.</p>
+
+<p>Below are more details on our views on Safety at Intercon, why it matters to us, and how we intend for Intercon to continue to be a place for lots of different types of games.</p>
+
+<h3 class="my-2">Statement</h3>
+<ol>
+  <li>We want larpers (both players and game runners) to be able to explore complicated themes, dangerous ideas, and difficult topics if they want to engage in those areas. We also want to allow larpers who do not, to be able to choose not to engage.</li>
+  <li>We want to provide space for attendees to play larps safely, and in ways that retain their agency.</li>
+  <li>Players:
+    <ol type='a'>
+      <li>Have a right to know what ideas and themes are present in the larps they're signing up for.</li>
+      <li>Have a right to know which themes they can avoid if they choose and which ones are unavoidable in any one particular game.</li>
+      <li>Have a right to know they can trust game runners to respect their choices to avoid certain ideas and themes.</li>
+      <li>Have a right to leave a space or game area if they do not feel safe for any reason</li>
+      <li>Have a responsibility to know their own limits and know which ideas and themes they should avoid.</li>
+      <li>Have a responsibility to respect the limits of their fellow players and of the games they sign up for.</li>
+    </ol>
+  </li>
+  <li>Game runners:
+    <ol type='a'>
+      <li>Have a right to create games that include hard topics and dangerous ideas.</li>
+      <li>Have a right to make mistakes.</li>
+      <li>Have a right to be in charge of the space that their game runs in during run time.  </li>
+      <li>Have a responsibility to own mistakes they make and address them appropriately. This may include being asked to not run a particular game at Intercon.</li>
+      <li>Have a responsibility to clearly communicate to potential players the ideas and themes their games explore or to explicitly and obviously opt out of doing so.</li>
+      <li>Have a responsibility to ensure that games have appropriate levels of control regarding safety, informed by the ideas and themes their games explore.</li>
+    </ol>
+  </li>
+  <li>Convention organizers:
+    <ol type='a'>
+      <li>Have a responsibility to protect our attendees (both players and game runners).</li>
+      <li>Have a responsibility to provide resources to game runners to help them create safer games.</li>
+    </ol>
+  </li>
+</ol>
+<p>
+  Dave Kapell, NEIL President, Conchair - Intercon S
+  <br>Jaelen Hartwin, Conchair - Intercon T
+</p>

--- a/cms_content_sets/wanderlust/pages/statements/queer-content.liquid
+++ b/cms_content_sets/wanderlust/pages/statements/queer-content.liquid
@@ -1,0 +1,14 @@
+---
+name: Statement of Intent - Queer/Polyamorous Content in Larps
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">NEIL Position Statement</h1>
+<h2 class="my-3">Queer and Polyamorous Content at NEIL Events</h2>
+<h4 class="my-2">Posted: October 16, 2019</h3>
+
+
+<p>It has come to the attention of the board of New England Interactive Literature that some GMs from previous years have gotten complaints from players for including non-explicit queer or polyamorous content in their games without a content warning (for example, "queer people exist in the game world").</p>
+<p>While we encourage GMs to publicize romantic content of any sort via game descriptions, the simple presence of characters who are queer and/or polyamorous, or themes of queerness or polyamory, in a family-friendly non-explicit game, does not require a content warning.</p>
+<p>Appropriate content warnings (or an explicit statement that the game writers are choosing to not use content warnings) are expected from games that include themes of oppression or harassment of queer or polyamorous people, or that include content inappropriate for people under 18.</p>
+<p>While NEIL events do not actively prioritize queer content, we are intentionally a community that is welcoming to queer and polyamorous larpers. As such, expecting warnings for those themes and characters is inappropriate and sends an inaccurate message that we don't want those larpers at our events.</p>

--- a/cms_content_sets/wanderlust/pages/store-old.liquid
+++ b/cms_content_sets/wanderlust/pages/store-old.liquid
@@ -1,0 +1,38 @@
+---
+name: Store (legacy version)
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: true
+---
+{% assign products = convention.available_products|sort: "name" %}
+<h1 class="my-3">{{convention.name}} Products</h1>
+
+<div class="alert alert-warning col-md-10 offset-md-1" role="alert">
+  <i class="bi-exclamation-triangle-fill" aria-hidden="true"></i> The deadline for all orders is {{shirt_order_deadline}}.
+</div>
+<div class="container mt-3">
+  <div class="row ">
+    <div class="card-deck d-flex align-items-stretch">
+      {% for product in products %}
+        {% unless product.name contains 'Staff' or product.provides_ticket_type %}
+          <div class="card mb-4" style="min-width: 18rem; ">
+            {% if product.image_url %}
+              <img class="card-img-top p-3" src="{{product.image_url}}" alt="{{product.name}}">
+            {% endif %}
+            <div class="card-body">
+              <h5 class="card-title">{{product.name}}</h5>
+              <p class="card-text">{{product.description}}</p>
+              </div>
+
+              <div class="card-footer">
+                <span class="align-middle" style="font-size:1.6em">{{product.price}}</span>
+                <a role="button" class="btn btn-primary float-end" href="{{product.url}}">Purchase</a>
+            </div>
+          </div>
+        {% endunless %}
+      {% endfor %}
+    </div>
+  </div>
+</div>
+
+ 

--- a/cms_content_sets/wanderlust/pages/store.liquid
+++ b/cms_content_sets/wanderlust/pages/store.liquid
@@ -1,0 +1,6 @@
+---
+name: Intercon V Store
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<iframe class='p-0 m-0 w-100' style="height: calc(100vh - 70px)" src="https://intercon-store.printify.me/products"></iframe>

--- a/cms_content_sets/wanderlust/pages/theme.liquid
+++ b/cms_content_sets/wanderlust/pages/theme.liquid
@@ -1,0 +1,21 @@
+---
+name: Intercon Theme
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<div class="con-logo-rounded float-end w-25 mx-4">
+ <img class="img-fluid rounded" src="{% file_url "Intercon w logo.png" %}" alt="{{ convention.name }}: {{ con_theme }}"> 
+</div>
+<h1 class='my-3'>{{convention.name}}: {{con_theme}}!</h1>
+<blockquote class="blockquote">
+  <p class="mb-3">He found himself wondering at times, especially in the autumn, about the wild lands, and strange visions of mountains that he had never seen came into his dreams.</p>
+ <footer class="blockquote-footer">J.R.R. Tolkein</footer>
+</blockquote>
+<p>
+  <strong>Wanderlust</strong> is a theme that speaks especially strongly to me after the past few years.  Larp gives us the chance to tell stories about other places, that may or may not exist, far reaches of the earth, or other worlds entirely.  We tell tales of travel, of doomed passages, of finding each other and ourselves along the road. 
+</p>
+<p>
+  Dave Kapell, Conchair, {{convention.name}}
+<br>So glad to have you along on this journey!
+</p>

--- a/cms_content_sets/wanderlust/pages/times-wanted.liquid
+++ b/cms_content_sets/wanderlust/pages/times-wanted.liquid
@@ -1,0 +1,52 @@
+---
+name: Room Availability
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">Desired times for new larps</h1>
+For all of the spaces below, we are looking for non-boffer games. Please note that boffer-safe space is very limited at this time, and we probably cannot accept any more boffer games at all.
+<h2 class="my-3">Friday</h2>
+<h3 class="my-2">Morning</h3>
+        <ul class="unstyled">
+          <li>1 &ndash; large room which can take 20-50 player game, and is boffer-safe</li>
+        </ul>
+<h3 class="my-2"> Afternoon</h3>
+        <ul class="unstyled">
+          <li>No space available</li>
+        </ul>
+<h3 class="my-2"> Evening</h3>
+        <ul class="unstyled">
+          <li>1 &ndash; Intercon rented hotel room (no one will be staying in this room)</li>
+          <li>1 &ndash; boardroom with a large table and chairs; set up for meetings etc.</li>
+        </ul>
+<h2 class="my-3">Saturday</h2>
+<h3 class="my-2">Morning</h3>
+        <ul class="unstyled">
+          <li>No space available</li>
+        </ul>
+<h3 class="my-2">Afternoon</h3>
+        <ul class="unstyled">
+          <li>No space available</li>
+        </ul>
+<h3 class="my-2">Evening</h3>
+        <ul class="unstyled">
+          <li>1 &ndash; rooms that can fit 10-15 players</li>
+          <li>2 &ndash; boardrooms with a large table and chairs; set up for meetings etc.</li>
+          <li>1 &ndash; Intercon rented hotel room (no one will be staying in this room)</li>
+        </ul>
+<h2 class="my-3">Sunday</h2>
+<h3 class="my-2">Morning</h3>
+        <ul class="unstyled">
+          <li>2 &ndash; parlor rooms available – come with sofas and some furnishings standard already 2 boardroom games - only for a 2 hour game starting at 9am</li>
+          <li>2 &ndash; boardrooms with a large table and chairs; set up for meetings etc - all morning</li>
+          <li>6 &ndash; rooms that each can fit 15-35 players - 2 all morning, 4 only for a 2 hour game starting at 9am</li>
+          <li>2 – rooms which can each fit a 10-20 player games - only for a 2 hour game starting at 9am</li>
+          <li>1 &ndash; Intercon rented hotel room (no one will be staying in this room) - only for a 2 hour game starting at 9am</li>
+        </ul>
+<h3 class="my-2">Afternoon</h3>
+        <ul class="unstyled">
+          <li>2 – parlor rooms – come with sofas and some furnishings standard already</li>
+          <li>2 &ndash; boardrooms with a large table and chairs; set up for meetings etc.</li>
+          <li>2 &ndash; rooms that each could take 15-35 player games</li>
+        </ul>
+      

--- a/cms_content_sets/wanderlust/pages/vending-at-intercon.liquid
+++ b/cms_content_sets/wanderlust/pages/vending-at-intercon.liquid
@@ -1,0 +1,134 @@
+---
+name: Vending at Intercon
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">Vending at Intercon</h1>
+<div class="row">
+  <div class="col-md-3 d-print-none">
+    <ul class="section-nav sticky-top" style="top:72px">
+      <li class="toc-entry menu-header" style='display:none'>
+        <h4>Vending</h4>
+      </li>
+      <li class="toc-entry"><a href="#overview">Overview</a></li>
+      <li class="toc-entry"><a href="#general">General Information</a></li>
+      <li class="toc-entry"><a href="#map">Vendor Map</a></li>
+      <li class="toc-entry"><a href="#schedule">Schedule</a>
+       <ul>
+        <li class="toc-entry"><a href="#schedule-loadin">Load In</a>
+        <li class="toc-entry"><a href="#schedule-loadout">Load Out</a>
+       </ul>
+      </li>
+        
+      <li class="toc-entry"><a href="#policies">Policies</a></li>
+      <li class="toc-entry"><a href="#apply">Applying to Vend</a>
+        <ul>
+          <li class="toc-entry"><a href="#apply-application">Applications</a>
+          <li class="toc-entry"><a href="#apply-cost">Costs</a>
+        </ul>
+      </li>
+      <li class="toc-entry"><a href="#questions">Vendor Coordinator</a></li>
+</ul>
+</div>
+<div class='col'>
+
+<h2 class="my-3"><a name='overview'>Overview</a></h2>
+  
+<p>{{convention.name}} is the premiere multi-genre Live Action Role Playing convention in the world. This year we expect to host over 400 LARPers from New England and beyond. {{convention.name}} will be the {{convention_number}} Intercon convention put on by NEIL, New England Interactive Literature. The convention website is at <a href="https://interconlarp.org/" target="_blank">https://interconlarp.org/</a></p>
+
+<p>{{convention.name}} will run from {{ convention.starts_at | date: "%A, %B %d" }} to {{convention.ends_at|date: "%A, %B %d, %Y"}} at the Crowne Plaza in Warwick, RI. The vendor area will be in the Plaza Foyer, which is public space, but behind doors that will likely only be traversed by convention attendees.</p> 
+
+  <div class='alert text-white bg-danger'>
+The Deadline for vendor applications and fees is midnight Eastern time on {{vendor_deadline}}.
+  </div>
+
+<p>In order to vend at Intercon, there are a number of things you need to know & do. We hope that you will find this page helpful!</p>
+<ol>
+  <li>Read the <a href="#general">General Information</a>.
+  <li>Be aware of the <a href="#schedule">schedule</a>.
+  <li>Vendors must abide by <a href="#policy">Intercon Policies</a>.
+  <li>Vendors must complete and submit <a href="#application">application paperwork</a> by the deadline.
+  <li>Vendors must <a href="#fees">pay the vending fees</a> to Intercon via Paypal by the deadline.
+</ol>
+
+<hr>
+<h2 class="my-3"><a name='general'>General Information</a></h2>
+
+<ul>
+  <li>Vendors will be selected such that the merchandise offered will be relatively non-competitive, for the mutual benefit of both vendors and the convention participants.</li>
+  <li>The vendor area will be available for load in on Thursday evening, but no vending will be allowed until Friday morning. This saves a day of fees.</li>
+  <li>We recommend that vendors pack out on Sunday morning instead of paying another day’s fee.</li>
+  <li>Each vendor gets three free vendor memberships to the convention. Check-in at the Intercon registration desk to get your badges.</li>
+  <li>If a vendor wishes to play games at the convention, they must buy a separate attendee badge by registering for the con.</li>
+  <li>Vendors <a href="/pages/hotel" target="_blank">may utilize the convention hotel room block</a> but must make their own reservations and pay for the room themselves.</li>
+  <li>Vendors may request that the Intercon hotel provide 1 or 2 tables which are 8X2 rectangles at an additional cost</li>
+  <li>Confirmed vendors for whom we have collected applications & fees will be <a href="/pages/vendors-at-intercon" target="_blank">listed on an Intercon web site.</a>.</li>
+  <li>Vendors will be located in the Plaza Foyer. <a href="/pages/hotel/layout" target="_blank">See this map of the hotel spaces.</a> and a picture is below</li>
+  <li>Each vendor will be allowed one approximately 10 X10 dimensional space in the vendor area from which to vend your wares. There are a limited number of spaces available.</li>
+  <li>Folks not selling merch but only providing information may be assigned a smaller one-table space in the Atrium instead of the Plaza Foyer.</li>
+</ul>
+
+<hr> 
+<h2 class="my-3"><a name='map'>Vendor Space Map</a></h2>
+<p><img class="img-fluid" src="{% file_url Intercon V Vendor Spaces.png %}" alt="Plaza Foyer vendor space map"></p>
+<hr>
+<h2 class="my-3"><a name='schedule'>Schedule</a></h2>
+  <h3 class="my-2"><a name='schedule-loadin'>Arrival / Load In Options</a></h2>
+<ul>
+  <li>Thursday night 7:30 - 10:30 pm - no selling on Thursday night!
+  <li>Friday morning 8:30 - 10:00 am
+</ul>
+
+<p>Intercon strongly prefers that vendors arrive and set up during the Thursday night window as there will be games running in the rooms off the Foyer on Friday morning. This also allows the Vendor Coordinator to be available to assist with information and placement. It is also optimal for vendors as it will allow you to be open for business first thing Friday morning as the Con activities start.</p>
+
+  <h3 class="my-2"><a name='schedule-loadout'>Departure / Load Out</a></h2>
+<ul>
+  <li>Saturday night by 11:30 pm
+  <li>Sunday morning by by 10:00 am - no selling on Sunday
+  <li>Sunday by 6:30 pm - requires purchasing a 3rd day of permit from the town of Warwick to sell anything
+</ul>
+
+<p>Intercon prefers that vendors load out either Saturday night or Sunday by 10 am. The Iron GM games will be held in the rooms off the Foyer on Saturday afternoon and the Iron GM organizer tables will need to be set up in spaces which may otherwise be occupied by vendors.  If a vendor plans to stay until Sunday evening, they will be placed in a booth across from the game rooms to leave room for the Iron GM activities. All vendors must be out of the hotel by 6:30 pm on Sunday as the Intercon will be closing and our reservations of the hotel spaces will end.</p>
+
+<p>Thank you in advance for complying with this schedule!</p>
+<hr>
+<h2 class="my-3"><a name='policies'>Policies</a></h2>
+  
+<p>All vendors must abide by <a href="/pages/covid" target="_blank">Intercon’s COVID policies</a> including submitting proof of vaccination.  The vendor area is a mask optional space, vendors are welcome to mask if they choose to but attendees will not be required to mask in the Plaza Foyer vendor area.</p>
+<hr>
+<h2 class="my-3"><a name='apply'>Applying to Vend at Intercon</a></h2>
+<h3 class="my-2"><a name='apply-application'>Applications</a></h2>
+
+<p>Intercon must have all completed applications by the deadline above in order to send them to the town of Warwick before the convention.</p>
+
+<p><strong>There are two different forms that must be completed if you are selling anything:</strong></p>
+
+<p>1. Complete and submit the <a href="https://forms.gle/5ifi9pVqA3U2qPsz5" target="_blank">Intercon Vendor Registration Form</a><br>
+<em>(If you are only providing information and not selling anything, this is the only form needed.)</em></p>
+
+<p>AND EITHER</p>
+
+<p>2a. The <a href="https://www.warwickpd.org/pdfs/officialdocs/licenses/Daily%20Vendor%20Application.pdf" target="_blank">Warwick (Merchandise) Vendor application</a><br>
+OR<br>
+2b. The <a href="https://www.warwickpd.org/pdfs/officialdocs/licenses/Arts%20&%20Crafts%20Application.pdf" target="_blank">Warwick Arts & Crafts application</a> if you are vending only goods you made yourself.</p>
+
+<p>Once you have completed the appropriate Warwick Town application you can scan or take a picture of the form and email it to the {{convention.staff_positions_by_name.vendor_liaison.name_with_email_link }}. Some versions of the Adobe PDF viewer will allow you to complete and save the form online and then that can be emailed in. If you cannot create an electronic version of the form and email the Warwick town application form, please email the vendor coordinator and request a mailing address where you can send a printed version.</p>
+  
+<h3 class="my-2"><a name='apply-cost'>Costs</a></h2>
+<p>There are no vendor space fees for Intercon itself, but the town of Warwick requires a fee per day, per vendor be paid to them. The town of Warwick also requires Intercon to facilitate licensing of all our vendors, so we collect all the money and applications to send to them in a bundle.</p>
+
+<p>The town of Warwick <b>charges $50 per day for vendors selling merchandise OR $25 per day for people selling only crafts of their own making</b>. Intercon does not require payment of any kind, however we must to send the fees for the town as one large group, hence why vending feeds must be sent to the Intercon Registrar. Assuming that you vend on Friday and Saturday of the convention, that would be a total of either $100 (for merchandise) or $50 (for crafts) in fees.</p>
+
+<p>If you are setting up a booth for informational purposes only, you just need to fill out the Intercon form, there would be no payment or forms for the town of Warwick required. We only need to collect money and get permits if you are charging money for product.</p>
+
+<p>If you need Intercon to provide you with one or two tables, each table is $20 additional cost. Tables are 8X2 rectangles.</p>
+  
+<p>Fees need to be submitted by the deadline above or we will not be able to accept your application to vend.</p>
+
+<p>Please PayPal the fee to our registrar <a href="mailto:NEIL.registrar@gmail.com">NEIL.registrar@gmail.com</a> and indicate in a note or memo that it is for the vendor application fee and the name on your application for vending.</p>
+<hr>
+<h2 class="my-3"><a name='questions'>Vendor Coordinator</a></h2>
+<p>If after reading this page you have questions or concerns you can email the {{convention.staff_positions_by_name.vendor_liaison.name_with_email_link }}.
+</p>
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/vendors-at-intercon.liquid
+++ b/cms_content_sets/wanderlust/pages/vendors-at-intercon.liquid
@@ -1,0 +1,18 @@
+---
+name: Vendors at Intercon
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1>Vendors at Intercon</h1>
+
+<p>We will be listing vendors who will be at {{convention.name}} on this page as they are confirmed so that you can plan to come and patronize them!</p>
+
+<p>Vendors will be located in the Plaza Foyer. <a href="/pages/hotel/layout" target="_blank">See this map of the hotel spaces.</a>.<br>
+The Plaza Foyer will be a mask optional area.</p>
+
+<p><img class="img-fluid" src="{% file_url Intercon V Vendor Spaces.png %}"" alt="Plaza Foyer vendor space map"></p>
+
+<p>If you are interested in applying to vend at Intercon, <a href="/pages/vending-at-intercon#fees">see this information page</a>.</p>
+
+
+<p><b>Vendors coming soon!</b></p>

--- a/cms_content_sets/wanderlust/pages/volunteering.liquid
+++ b/cms_content_sets/wanderlust/pages/volunteering.liquid
@@ -1,0 +1,25 @@
+---
+name: Volunteering
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-3">Volunteering</h1>
+<p>Intercons are the result of the work of many people, all 
+pitching in. We welcome new people; there's no experience necessary. (After all, 
+many of us had never run a convention before we started.)
+</p>
+<p>
+Whether it's an hour or two at the con or an hour or two a month leading up 
+to the con, we welcome the help. You'll be working with a great group of people. 
+</p>
+<p>
+<!--<strong>Check our list of <a href="{% page_url open-roles %}">Open Roles</a> and see if any of them sound appealing!</strong>-->
+</p>
+{% if propcom_form %}
+<p>For {{convention.name}}, We have an <a href="{{propcom_form}}" target='_blank'>application form</a> for the Proposal Committee.
+</p>
+{% endif %}
+<p>
+Or send us a note to <a href="mailto:conchair@interactiveliterature.org?subject=%5BIntercon%5D%20Volunteer!">join the Intercon Con Committee</a>!
+</p>

--- a/cms_content_sets/wanderlust/pages/whats-new-gms.liquid
+++ b/cms_content_sets/wanderlust/pages/whats-new-gms.liquid
@@ -1,0 +1,12 @@
+---
+name: What's New Video - GM Edition
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-2">What's New - GM Overview</h1>
+<div class="row justify-content-center">
+<div class="embed-responsive embed-responsive-4by3 col-xl-10">
+  <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/HqI35RkGcZE?rel=0&showinfo=0" frameborder="1" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+</div>
+</div>

--- a/cms_content_sets/wanderlust/pages/whats-new-player.liquid
+++ b/cms_content_sets/wanderlust/pages/whats-new-player.liquid
@@ -1,0 +1,13 @@
+---
+name: What's New Video - Player Edition
+admin_notes: ''
+skip_clickwrap_agreement: false
+hidden_from_search: false
+---
+<h1 class="my-2">What's New - Player Overview</h1>
+<div class="row justify-content-center">
+  <div class="embed-responsive  embed-responsive-4by3 col-xl-10">
+    <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/h1UmBsADVxQ?rel=0&showinfo=0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+  </div>
+</div>
+

--- a/cms_content_sets/wanderlust/partials/0-news.liquid
+++ b/cms_content_sets/wanderlust/partials/0-news.liquid
@@ -1,0 +1,56 @@
+---
+admin_notes: Contains just news to be displayed on the front page
+invariant: false
+---
+<ul class="list-unstyled">
+<!--- NEWS ITEM -->
+<!--
+<li class="media d-flex align-items-start news-item">
+  <div class="media-body">
+    <h5 class="mt-0">Book a Hotel Room! <small class="text-muted">October 27, 2021</small></h5>
+     <p>
+       Remember to book your hotel room for Intercon U.  The correct room block code is <strong>LAR</strong> and you can find all the information you need on <a href="{% page_url hotel %}">our Hotel page!</a>
+   </p>
+  </div>
+</li>
+-->
+<!-- END NEWS ITEM --> 
+
+<!--- NEWS ITEM -->
+<!--
+  <li class="media d-flex align-items-start news-item">
+  <div class="media-body">
+    <h5 class="mt-0">COVID FAQ! <small class="text-muted">October 4, 2021</small></h5>
+     <p>
+       How is Intercon V handling COVID-19 safety? We've put together a FAQ to answer all your questions. <a href="{% page_url covid %}">Check it out here!</a>
+   </p>
+  </div>
+</li>
+-->
+<!-- END NEWS ITEM --> 
+  
+<!--- NEWS ITEM -->
+<li class="media d-flex align-items-start news-item">
+  <div class="media-body">
+    <h5 class="mt-0">Intercon Wants Your Games! <small class="text-muted">January 28, 2024</small></h5>
+     <p>
+       {{convention.name}} is ready to accept game proposals! New games, old games, your games! Time for the Hype! <a href="{% page_url new-proposal %}">Propose a larp!</a>
+   </p>
+  </div>
+</li>
+<!-- END NEWS ITEM --> 
+
+  <!--- NEWS ITEM -->
+<li class="media d-flex align-items-start news-item">
+  <div class="media-body">
+    <h5 class="mt-0">Intercon W Website is live! <small class="text-muted">January 27, 2024</small></h5>
+     <p>
+       We now have a web presence!  Please bear with us as we get the site fully updated and ready to go!  You may note a new 'Resources menu' above, which is meant to make some reference documents easier to find.
+   </p>
+  </div>
+</li>
+<!-- END NEWS ITEM --> 
+  
+ 
+  
+</ul>

--- a/cms_content_sets/wanderlust/partials/acceptingproposals.liquid
+++ b/cms_content_sets/wanderlust/partials/acceptingproposals.liquid
@@ -1,0 +1,12 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign proposal_chair = convention.staff_positions_by_name.game_proposals_chair %}
+<p>
+We're looking for a wide and varied slate of larps to fill this page. Do <em>you</em> have a game for us?  If so, please <a href="{% page_url new-proposal %}">propose your game</a>!
+</p>
+
+<p>
+If you're not sure, then take a look at our <a href="{% page_url proposalfaq %}">Proposal FAQ</a>, or contact the {{proposal_chair.name_with_email_link}}</a>.
+</p>

--- a/cms_content_sets/wanderlust/partials/all-news.liquid
+++ b/cms_content_sets/wanderlust/partials/all-news.liquid
@@ -1,0 +1,30 @@
+---
+admin_notes: This contains all news, vs 0-news, which is just current displayed news
+invariant: false
+---
+<ul class="list-unstyled">
+<!--- NEWS ITEM -->
+<li class="media d-flex align-items-start news-item">
+  <div class="media-body">
+    <h5 class="mt-0">Intercon Wants Your Games! <small class="text-muted">January 28, 2024</small></h5>
+     <p>
+       {{convention.name}} is ready to accept game proposals! New games, old games, your games! Time for the Hype! <a href="{% page_url new-proposal %}">Propose a larp!</a>
+   </p>
+  </div>
+</li>
+<!-- END NEWS ITEM --> 
+
+  <!--- NEWS ITEM -->
+<li class="media d-flex align-items-start news-item">
+  <div class="media-body">
+    <h5 class="mt-0">Intercon W Website is live! <small class="text-muted">January 27, 2024</small></h5>
+     <p>
+       We now have a web presense!  Please bear with us as we get the site fully updated and ready to go!  You may note a new 'Resources menu' above, which is meant to make some reference documents easier to find.
+   </p>
+  </div>
+</li>
+<!-- END NEWS ITEM --> 
+  
+
+
+</ul>

--- a/cms_content_sets/wanderlust/partials/attendee_count.liquid
+++ b/cms_content_sets/wanderlust/partials/attendee_count.liquid
@@ -1,0 +1,12 @@
+---
+invariant: false
+---
+{% if user_con_profile %}
+  {% assign concom = false %}
+  {% assign positions = user_con_profile.staff_positions |map: 'name'  %}
+  {% if positions contains 'Con Com' %}
+    <section class="my-2">
+      Total attending {{ convention.name}}: <strong>{{ convention.ticket_counts_by_type.total }}</strong>
+    </section>
+  {% endif %}
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/badgecheck.liquid
+++ b/cms_content_sets/wanderlust/partials/badgecheck.liquid
@@ -1,0 +1,30 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% if user_con_profile %}
+  {% if user_con_profile.ticket %}
+    {% if user_con_profile.ticket.allows_event_signups %}
+      <div class="alert alert-info" role="alert">
+        <p>You have a {{convention.ticket_name}} for {{convention.name}} and can sign up for games{% if convention.maximum_event_signups.current_value == 'not_yet' %} when signups open.{% else %}.{% endif %}
+        </p>
+        <p class='mb-0'>{% render 'signup_text', user_con_profile: user_con_profile, convention: convention%}</p>
+      </div>
+    {% else %}
+      <div class="alert alert-warning" role="alert">
+        <p>You have a {{convention.ticket_name}} for {{convention.name}} that does not allow event signups.  You will not be able to sign up for games until you have arranged for a full {{convention.ticket_name}}.</p>
+        <p class='mb-0'>{% render 'signup_text', user_con_profile: user_con_profile, convention: convention%}</p>
+      </div>
+    {% endif %}
+  {% else %}
+    <div class="alert alert-warning" role="alert">
+      <p>You do not have a {{convention.ticket_name}} for {{convention.name}}.  You will not be able to sign up for games until you have purchased a {{convention.ticket_name}}.</p>
+      <p>{% render 'signup_text', user_con_profile: user_con_profile, convention: convention%}</p>
+      <p class='mb-0'><a class="btn btn-warning" href="/ticket/new">Purchase your {{convention.ticket_name}} now!</a></p>
+    </div>
+  {% endif %}
+{% else %}
+  <div class="alert alert-info" role="alert">
+    <p class='mb-0'>{% render 'signup_text', user_con_profile: user_con_profile, convention: convention%}</p>
+  </div>
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/bio.liquid
+++ b/cms_content_sets/wanderlust/partials/bio.liquid
@@ -1,0 +1,42 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign positionslist = display_user_con_profile.staff_positions | map: "name" %}
+
+{% if display_user_con_profile.privileges contains 'Proposal Committee' %}
+  {% assign privslist = "Proposal Committee" |split: ", " %}
+  {% assign positionslist = positionslist | concat:privslist %}
+{% endif %}
+
+{% if display_user_con_profile.privileges contains 'Con Com' %}
+  {% assign privslist = "Con Com" |split: ", " %}
+  {% assign positionslist = positionslist | concat:privslist %}
+{% endif %}
+
+{% assign positions = positionslist |join: ', ' %}
+{% assign team_member_event_names = display_user_con_profile.team_members | map:'event' | map:'title' | join:', ' %}
+<hr>
+<div id="user-{{ display_user_con_profile.id }}">
+  <div class="media d-flex align-items-start mb-3">
+    {% include 'gravatar80' %}
+    <div class="media-body">
+      <h5 class="mt-0"><a>{{ display_user_con_profile.bio_name }}</a></h5>
+      <ul class="list-unstyled">
+        {% unless team_member_event_names == blank %}
+          <li>GM/Organizer for: {{ team_member_event_names }}</li>
+        {% endunless %}
+
+        {% unless positions == blank%}
+          <li>{{ positions }}</li>
+        {% endunless %}
+      </ul>
+
+      {{ display_user_con_profile.bio_html }}
+
+      {% if display_user_con_profile.id == user_con_profile.id %}
+        <div class="mt-2"><a href="/my_profile/edit_bio" class="btn btn-primary btn-sm">Edit bio</a></div>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/cms_content_sets/wanderlust/partials/boardgame_list.liquid
+++ b/cms_content_sets/wanderlust/partials/boardgame_list.liquid
@@ -1,0 +1,5 @@
+---
+admin_notes: fed from https://docs.google.com/spreadsheets/d/1xRKg6of806ciA1iydPUAhTP2tcWUTkyunXEzVzFpVHU/edit#gid=0
+invariant: true
+---
+<iframe width=600 height=600 src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRkzfBXeKpP6fL7k_sJeMEMKOQR6NFDCsbvfJsqF_lWTIjJdOJZOFB0BGkCzUNUpKTibdx9jTRf7FIR/pubhtml?gid=0&amp;single=true&amp;widget=true&amp;headers=false"></iframe>

--- a/cms_content_sets/wanderlust/partials/con_postponed_banner.liquid
+++ b/cms_content_sets/wanderlust/partials/con_postponed_banner.liquid
@@ -1,0 +1,18 @@
+---
+admin_notes: Not currently used, but if we have to postpone the con, put this in the
+  site layout
+invariant: true
+---
+<div class="bg-danger text-white text-center py-2 mb-4">
+  <strong>Intercon U is postponed, Extracon 2021 happening instead that weekend!</strong>
+  <p>
+    Due to the COVID-19 pandemic, Intercon U is postponed until 2022.  However, we're pleased to announce Extracon 2021, an online convention, on the weekend Intercon U was previously scheduled for.
+  </p>
+
+  <a href="https://2021.extraconlarp.org" class="btn btn-light me-4">
+    Go to the Extracon 2021 site
+  </a>
+  <a href="https://mailchi.mp/c40b44d55d84/intercon-u-announcement" class="btn btn-light">
+    Read the announcement for more details
+  </a>
+</div>

--- a/cms_content_sets/wanderlust/partials/conintro.liquid
+++ b/cms_content_sets/wanderlust/partials/conintro.liquid
@@ -1,0 +1,58 @@
+---
+admin_notes: ''
+invariant: false
+---
+<div class="row flex-column flex-lg-row align-items-center my-3" style="clear: both">
+  
+  <div class="col-lg pt-2 order-last">
+    <h1 class='display-4 d-none d-lg-block con-font'>
+      {{convention.name}}:  <span class="theme-title"><a class="text-secondary" href="{% page_url theme %}">{{con_theme}}</a></span>
+    </h1>
+    <h2 class='display-5 con-font'>
+      {% assign startMonth = convention.starts_at | date: "%m" %}
+      {% assign endMonth = convention.ends_at | date: "%m" %}
+ 
+      {% if startMonth == endMonth %}
+        <span class="d-lg-none">{{ convention.starts_at | date: "%b %d" }}-{{convention.ends_at|date: "%d, %Y"}}</span>
+        <span class="d-none d-lg-inline">{{ convention.starts_at | date: "%B %d" }}-{{convention.ends_at|date: "%d, %Y"}}</span>
+      {% else %}
+        <span class="d-xl-none">{{ convention.starts_at | date: "%b %d" }} to {{convention.ends_at|date: "%b %d, %Y"}}</span>
+        <span class="d-none d-xl-inline">{{ convention.starts_at | date: "%B %d" }} to {{convention.ends_at|date: "%B %d, %Y"}}</span>
+      {% endif %}
+    </h2>
+    <h2 class='display-5 con-font'>
+      <a class="text-secondary" href="{% page_url hotel %}">Warwick, RI</a>
+    </h2>
+
+    <p class="lead">
+      Welcome to {{convention.name}}, the premiere multi-genre <a href="{% page_url aboutlarp %}">Live Action Role Playing</a> (LARP) convention in the world.  
+    </p>
+    <p>  
+      {{convention.name}} is the  <a href="http://www.interactiveliterature.org/NEIL/interconConventions.html" rel="noopener" target="_blank">{{convention_number}}</a> Intercon in the greater Boston area, and we're so excited for this year! We can do or be anything with larp. If you love to larp, or you've always wanted to try Larping, then we welcome you to come join us at {{convention.name}}. Come join the Intercon Community!
+    </p>
+    <div class="row my-2">
+      <div class="col">
+      {% render 'attendee_count', user_con_profile:user_con_profile, convention:convention%}
+      </div>
+    </div>
+
+    {% unless user_con_profile %}
+      <p class="lead my-2">
+        <a class='btn btn-primary' href='/users/sign_in'>Log In or Sign Up</a>
+      </p>
+    {% endunless %}
+  </div>
+  
+   <div class="col-9 col-lg-4 text-center order-first">
+    <a href="{% page_url theme %}" class="con-logo-roundrect mb-4 mx-2">
+      <img 
+        srcset="{% file_url "Intercon-w-logo-480.png" %} 480w, {% file_url "Intercon-w-logo-800.png" %} 800w" 
+        sizes="(max-width: 640px) 480px, 800px"
+        src="{% file_url "Intercon-w-logo-800.png" %}"
+        alt="{{ convention.name }}: {{ con_theme }}"
+        class="rounded mx-auto d-block"
+      >
+    </a>
+    {% render 'countdown', convention:convention%} 
+  </div>
+</div>

--- a/cms_content_sets/wanderlust/partials/copyright.liquid
+++ b/cms_content_sets/wanderlust/partials/copyright.liquid
@@ -1,0 +1,13 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign current_date = "now" %}
+<div class="copyright text-center small">
+  Copyright © {{ current_date | date: "%Y" }} 
+  <a target="_blank" rel="noopener" href='http://www.interactiveliterature.org/NEIL'>New England Interactive Literature</a>
+  <br>
+  All Rights Reserved
+  &bull;
+  <a href="https://www.neilhosting.net/pages/cookies">Cookie policy</a>
+</div>

--- a/cms_content_sets/wanderlust/partials/countdown.liquid
+++ b/cms_content_sets/wanderlust/partials/countdown.liquid
@@ -1,0 +1,33 @@
+---
+invariant: false
+---
+{% assign nowTimestamp = 'now' | date: '%s' %}
+{% assign conventionStart = convention.starts_at | date: '%Y-%m-%d'| date: '%s' %}
+{% assign conventionStartTime = convention.starts_at| date: '%s' %}
+{% assign conventionEnd = convention.ends_at | date: '%s' %}
+{% assign diffSeconds = conventionStart | minus: nowTimestamp %}
+{% assign diffSecondsStart = conventionStartTime | minus: nowTimestamp %}
+{% assign diffSecondsEnd = conventionEnd | minus: nowTimestamp %}
+{% assign diffDays = diffSeconds | divided_by: 3600 | divided_by: 24 %}
+
+{% capture countdown_content %}
+  {% if diffDays > 0 %}
+    {{ diffDays }} days until {{convention.name}}!
+  {% elsif diffSecondsStart > 0 %}
+    {{convention.name}} is today!
+  {% elsif diffSecondsEnd > 0 %}
+    {{convention.name}} is happening now!
+  {% else %}
+    {{convention.name}} is over, see you next year!
+  {% endif %}
+{% endcapture %}
+
+<div id="countdown" class="card countdown text-white mt-2 mb-3 mt-lg-0 mb-lg-0 mx-1 d-none d-lg-block bg-purple" onload="showConf()">
+  <div class="card-body text-center py-2" >
+    {{countdown_content}}
+  </div>
+</div>
+<div class="d-lg-none text-center">
+   {{countdown_content}}
+</div>
+

--- a/cms_content_sets/wanderlust/partials/discord_button.liquid
+++ b/cms_content_sets/wanderlust/partials/discord_button.liquid
@@ -1,0 +1,10 @@
+---
+invariant: false
+---
+{% if user_con_profile %} 
+  <div class="border border-primary rounded text-bg-dark" style="padding: 1.25rem 0.75rem; padding-top: 0.6rem;">
+    <img src="{% file_url Discord-Logo+Wordmark-Color.svg %}" alt="Discord logo" style="max-width: 9rem">
+    <p class="small">Intercon has a Discord server so attendees can chat before, during, and after the con. <br>Please join us there!</p>
+    <a class="btn text-white" style="background-color:{{css_color_3}}" href="https://discord.gg/{{discord_invite}}" target="_blank">Join the Intercon Discord Server!</a>
+  </div>
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/event_list_entry.liquid
+++ b/cms_content_sets/wanderlust/partials/event_list_entry.liquid
@@ -1,0 +1,27 @@
+---
+invariant: false
+---
+<a class='list-group-item list-group-item-action flex-column align-items-start' href='/events/{{event.id}}'>
+  <div class="d-flex w-100 justify-content-between">
+    <h5 class="mb-1">{{event.title}}</h5>
+    <small>{{event.event_category.name | replace: "_", " " | humanize}}</small>
+  </div>
+  <div class="d-flex w-100 justify-content-between mb-1">
+    <span>
+      <strong>{{event.event_category.team_member_name|humanize}}(s):</strong>
+      {{hosts| join: ', '}}
+    </span>
+    {% if event.runs.size == 0 %}
+      <span> Not Scheduled Yet </span>
+    {% else %}      
+      {% assign runs = "" |split: ", " %}
+      {% for run in event.runs %}
+        {% assign runlist = run.starts_at | date: "%a %l:%M%P"|split: ", " %}
+        {% assign runs = runs | concat: runlist %}
+      {% endfor %}
+      <span>
+        {{runs | join: ', '}}      
+      </span>
+    {% endif %}
+  </div>
+</a>

--- a/cms_content_sets/wanderlust/partials/forum_registration_policy_instructions.liquid
+++ b/cms_content_sets/wanderlust/partials/forum_registration_policy_instructions.liquid
@@ -1,0 +1,6 @@
+---
+invariant: true
+---
+<p>How many people can sign up for your session?  If you want to limit the number, choose "limited participants" below and enter the count.  If you don't want to limit the number, choose "unlimited interested attendees" below.</p>
+
+<p>If you want to further divide the ways people can sign up, you can use the "custom registration policy" option below.  (Most events probably won't need to do this.)  This will let you set up custom buckets for your event.  You'll see a preview of the signup interface as you go.</p>

--- a/cms_content_sets/wanderlust/partials/gravatar80.liquid
+++ b/cms_content_sets/wanderlust/partials/gravatar80.liquid
@@ -1,0 +1,4 @@
+---
+invariant: false
+---
+<img class="me-3 rounded" src="{{ display_user_con_profile.gravatar_url }}?s=80&r=pg&d=mm" alt="{{ display_user_con_profile.bio_name}}'s Icon">

--- a/cms_content_sets/wanderlust/partials/nat_image_debug.liquid
+++ b/cms_content_sets/wanderlust/partials/nat_image_debug.liquid
@@ -1,0 +1,4 @@
+---
+invariant: false
+---
+{% file_url "interconu-web-480.png" %}

--- a/cms_content_sets/wanderlust/partials/new_events_list.liquid
+++ b/cms_content_sets/wanderlust/partials/new_events_list.liquid
@@ -1,0 +1,28 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign events = convention.events_created_since[convention.maximum_event_signups.current_value_change] | sort: "created_at" | reverse %}
+{% if events.size > 0 %}
+  {% capture newgames_content %}
+    {% for event in events %}
+      {% if event.runs.size == 0 %}
+        {% continue %}
+      {% endif %}
+      {% assign hosts = event.team_member_user_con_profiles |map: 'name_without_nickname' %}
+      {% render 'event_list_entry', event:event, hosts:hosts %}
+    {% endfor %}
+  {% endcapture %}
+
+  {% assign newgames_content_stripped = (newgames_content | strip) %}
+    {% if newgames_content_stripped != '' %}
+      <h3 class="my-h4">New Events added to the Schedule</h3>
+      <div class='list-group'>
+        {{ newgames_content_stripped }}
+      </div>
+  {% else %}
+      <p> No new events have been scheduled yet, stay tuned!</p>    
+  {% endif %}
+{% else %}
+  <p> No new events have been added yet, stay tuned!</p>    
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/new_events_list_for_email.liquid
+++ b/cms_content_sets/wanderlust/partials/new_events_list_for_email.liquid
@@ -1,0 +1,26 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign events = convention.events_created_since[convention.maximum_event_signups.current_value_change] | sort: "created_at" | reverse %}
+{% assign events = convention.events_created_since['2024-10-24'] | sort: "first_run_starts_at" %}
+{% if events.size > 0 %}
+  <section class="my-4">
+    <h3 class="my-h4">New Events added to the Schedule</h3>
+
+    <ul style='padding-left:10px'>
+      {% for event in events %}
+        <li >{{event.event_category.name | replace: "_", " " | humanize}}:&nbsp;
+          <a href="{{ event.url }}">{{ event.title }}</a> run by
+          {{event.team_member_user_con_profiles |map: 'name_without_nickname' |join: ', '}} - 
+          {% assign runs = "" |split: ", " %}
+          {% for run in event.runs %}
+            {% assign runlist = run.starts_at | date: "%a %l:%M%P"|split: ", " %}
+            {% assign runs = runs | concat: runlist %}
+          {% endfor %}
+          {{runs | join: ', '}}
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/pre_schedule_text.liquid
+++ b/cms_content_sets/wanderlust/partials/pre_schedule_text.liquid
@@ -1,0 +1,17 @@
+---
+admin_notes: This goes above the schedule grids
+invariant: false
+---
+{% unless convention.show_schedule == 'yes' %}
+<div class="alert alert-warning">
+  <div class="d-flex align-items-center">
+    <div class="h1 mb-0 me-3">
+      <i class="bi-exclamation-triangle-fill"></i>
+    </div>
+    <div class="flex-grow-1">
+      NOTE: This is not the final schedule. We expect to add more games and events before the convention. 
+      Games and events that are already on the schedule may change rooms to address conflicts.
+    </div>
+  </div>
+</div>
+{% endunless %}

--- a/cms_content_sets/wanderlust/partials/proposal_date_info.liquid
+++ b/cms_content_sets/wanderlust/partials/proposal_date_info.liquid
@@ -1,0 +1,17 @@
+---
+admin_notes: ''
+invariant: true
+---
+<p>Intercon solicits proposals for larps all through the year. It's our goal to have a great schedule
+of events up as early as possible!</p>
+
+<p>Larps with smaller numbers (less than 10 players) will be accepted on a 
+conditional basis due to space limitations during Friday night, Saturday 
+daytime and Saturday night time slots. Midnight, Sunday, and earlier in the 
+con will be easier to schedule for small games.  Also, if you are willing to 
+run your small game in part of a larger space alongside a second game, 
+please indicate on your form.</p>
+
+<p>
+Larp proposals will be evaluated in a timely manner.  Larps can still be submitted at any time, although we may have limited space remaining after the new year.  Please contact the proposal chair if you have any questions.
+</p>

--- a/cms_content_sets/wanderlust/partials/proposal_form_registration_policy_instructions.liquid
+++ b/cms_content_sets/wanderlust/partials/proposal_form_registration_policy_instructions.liquid
@@ -1,0 +1,26 @@
+---
+admin_notes: ''
+invariant: true
+---
+<p>As part of the game signup process, players can make one signup-time casting choice.  This section allows you to select what that choice will be, if anything.  For example, you can ask your characters what gender of character they would like to play, or if they would prefer to be Horde or Cast.</p>
+
+<p>First, select one of the pre-built bucket types, or select custom to design your own.</p>
+
+<p>Second, enter the minimum, preferred and maximum number of characters  in each bucket for your LARP. The character counts will be visible to users signing up to your LARP.</p>
+
+<ul>
+<li>Minimum - The minimum number of characters of this type required for your LARP. If there are fewer than the minimum number of characters signed up, you should talk with the GM Liaison about lowering the minimum number of characters or cancelling the LARP.</li>
+<li>Preferred - The number of characters of this type that you'd prefer to have in your LARP. If you're not sure, make this the same number as the Maximum.</li>
+<li>Maximum - The maximum number of characters of this type that your LARP can accommodate.</li>
+</ul>
+
+<p>
+You can also have a “Flex” bucket set with minimum / preferred / maximum number of characters. During registration, sign-ups will be counted against the Flex bucket only after the bucket that the player selected is filled. For example, in a game that allows for 3 Female, 3 Male, and 4 Flex characters, when signing up for the game, attendees will be presented with the option to request either a Male or Female character. The first three Female character signups will count against the Female bucket, and further Female signups will count against the Flex bucket. If 7 Female character signups are entered, both the Female and the Flex buckets will be full, leaving signups open only for 3 Male characters.  New Female signups will end up on the waitlist.
+</p>
+
+<p>Your total game size will be calculated as the maximum number of characters for each bucket, including the Flex bucket.  For example, if you have a max 3 Female, 3 Male characters, 2 Non-Binary characters and 2 Flex characters, your game will max out at 10 characters in total, and the 2 Flex characters will be mapped to the female/male/non-binary bucket based on player signup selection.</p>
+
+<p>At signup time, attendees will be presented with one button for each bucket available in your game.  The website will enforce your bucket limits, so when no roles in one bucket are available, any players that signup using that button will be put on the waitlist for that bucket. Once you've cast the game, you'll be able to "freeze" the bucket balance of the game; essentially converting all of your flex characters to the bucket they used when they signed up.  If a player drops out of your game, the website will pick the first player on the waitlist with a matching signup bucket selection, and you won't have to frantically rewrite the character sheet to match a different selection.
+</p>
+<p>If your selection includes a 'No Preference' option, attendees will also be presented with a 'No Preference' signup button, placed below the limited bucket options, which will allow them to sign up for your game without specifying a specific bucket.  This will put them in a bucket chosen to minimize conflicts, but also record that they signed up that way, so you know what was requested.
+</p>

--- a/cms_content_sets/wanderlust/partials/proposals_intro.liquid
+++ b/cms_content_sets/wanderlust/partials/proposals_intro.liquid
@@ -1,0 +1,13 @@
+---
+invariant: true
+---
+<p>Intercon is the premiere Live Action Role Playing convention in the
+world. We've gotten this way by seeking out a diverse selection of
+LARPs, in as many different styles and genres as we can find. Ask
+ten LARPers what LARP is about and you'll get thirteen different
+answers. We're trying to find interesting games that satisfy as
+many of those possibilities as we can. We encourage new authors to
+propose games as much as we recruit experienced authors. We also
+encourage authors who've never run at an Intercon before to propose.
+Whether it's a new game or one that's been run before, we're
+interested in what you have to propose.</p>

--- a/cms_content_sets/wanderlust/partials/propose_early.liquid
+++ b/cms_content_sets/wanderlust/partials/propose_early.liquid
@@ -1,0 +1,14 @@
+---
+admin_notes: ''
+invariant: false
+---
+<h3>Why Propose Early?</h3>
+
+<p>There are several great reasons to get your game proposal in early:</p>
+
+<ul class="mb-0">
+  <li>You're likelier to get the time slot you desire. As the schedule fills, the prime time slots fill up.</li>
+  <li>Your game gets more publicity and advertising. It's likelier to fill earlier, which will give you more time to cast and plan.</li>
+  <li>You get a better chance at attracting the players who know that it's smart to sign up early for games.</li>
+  <li>You might miss your chance to propose your game at all if you wait.  There are many GMs who know how much fun it is to run a game at {{ convention.name }}!</li>
+</ul>

--- a/cms_content_sets/wanderlust/partials/run_availability_grid.liquid
+++ b/cms_content_sets/wanderlust/partials/run_availability_grid.liquid
@@ -1,0 +1,71 @@
+---
+invariant: false
+---
+{% assign run_availabilities = convention.run_availabilities_with_any_slots %}
+{% assign larp_availability = run_availabilities | where: "event_category_name", "Larp" %}
+{% assign now_posix = "now" | date: "%s" | plus: 0 %}
+{% if larp_availability.size > 0 %}    
+  <div class="run-availability-grid">
+    {% for availability in larp_availability %}
+      {% assign ends_at_posix = availability.run.ends_at | date: "%s" | plus: 0 %}
+      {% if ends_at_posix > now_posix %}
+        {% assign displayed_any_larps = "yes" %}
+        {% assign day = availability.run.starts_at | date: "%s" | minus : 14400 | date: "%A" %}
+        {% if day != prev_day %}
+          <div class="run-availability-grid-header lead text-white">
+            {{ day }}
+          </div>
+        {% endif %}
+        {% assign prev_day = day %}
+
+        <div class="run-availability-grid-card p-2 rounded bg-light border">
+          <div class="col-4 col-lg ps-0 pe-2">
+            <a href="{{ availability.run.event.url }}" class="font-weight-bold">{{ availability.run.event.title }}</a> 
+            <small class="text-nowrap">({{ availability.run.starts_at | date: "%-l:%M%P" }}-{{ availability.run.ends_at | date: "%-l:%M%P" }})</small>
+          </div>
+          <div class="col-8 col-lg px-0">
+            {% for bucket_availability in availability.bucket_availabilities_with_counted_slots %}
+              <span class="rounded px-2 my-1 d-inline-block bg-info text-light">
+                <span class="d-flex align-items-center">
+                  <span class="me-1">
+                    {{ bucket_availability.bucket.name }}
+                  </span>
+                  <span class="badge badge-light">
+                    {% if bucket_availability.bucket.slots_limited %}
+                      {{ bucket_availability.available_slots }}
+                    {% else %}
+                      Unlimited
+                    {% endif %}
+                  </span>
+                </span>
+              </span>
+            {% endfor %}
+
+            {% for bucket_availability in availability.bucket_availabilities_with_not_counted_slots %}
+              <span class="rounded px-2 my-1 d-inline-block bg-secondary text-light">
+                <span class="d-flex align-items-center">
+                  <span class="me-1">
+                    {{ bucket_availability.bucket.name }}
+                  </span>
+                  <span class="badge badge-light">
+                    {% if bucket_availability.bucket.slots_limited %}
+                      {{ bucket_availability.available_slots }}
+                    {% else %}
+                      Unlimited
+                    {% endif %}
+                  </span>
+                </span>
+              </span>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+
+    {% unless displayed_any_larps %}
+      <p><em>Sorry, all the games with available slots have already ended.  We hope to see you at next year's con.</em></p>
+    {% endunless %}
+  </div>
+{% else %}
+  <p><em>Sorry, there are no games with available slots.</em></p>
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/runs_with_npc_slots.liquid
+++ b/cms_content_sets/wanderlust/partials/runs_with_npc_slots.liquid
@@ -1,0 +1,15 @@
+---
+invariant: false
+---
+{% assign run_availabilities = convention.run_availabilities_with_not_counted_slots %}
+{% assign larp_availability = run_availabilities | where: "event_category_name", "Larp" | sort: "starts_at" %}
+{% if larp_availability.size > 0 %}
+  <section class="my-4">
+    <h4 class="my-h4">There's still room for NPCs or unlimited signups in all these great games!</h4>
+    <ul>
+      {% for availability in larp_availability %}
+        <li><a href="{{ availability.run.event.url }}">{{ availability.run.event.title }}</a>: {{ availability.run.starts_at | date: "%a %l:%M%P" }} - {{ availability.bucket_availabilities_with_any_slots | map: "bucket" | map: "name" | to_sentence }}</li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/runs_with_openings.liquid
+++ b/cms_content_sets/wanderlust/partials/runs_with_openings.liquid
@@ -1,0 +1,53 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign run_availabilities = convention.run_availabilities_with_counted_slots %}
+{% assign larp_availability = run_availabilities | where: "event_category_name", "Larp" | sort: "starts_at" %}
+{% assign npc_availabilities = convention.run_availabilities_with_not_counted_slots %}
+{% assign npclarp_availability = npc_availabilities | where: "event_category_name", "Larp" | sort: "starts_at" %}
+{% assign now_posix = "now" | date: "%s" | plus: 0 %}
+
+
+{% if larp_availability.size > 0 || npclarp_availability.size > 0 %}
+  <section class="my-4">
+    <h4 class="my-h4">There's still openings in all these great games!</h4>
+    {% if larp_availability.size > 0 %}
+      <h5>Player Character Signups</h5>
+      <ul>
+        {% assign displayed_any_larps = false %}
+        {% for availability in larp_availability %}
+          {% assign ends_at_posix = availability.run.ends_at | date: "%s" | plus: 0 %}
+          {% assign starts_at_plus_30_min_posix = availability.run.starts_at | date: "%s" | plus: 1800 %}
+          {% if starts_at_plus_30_min_posix > now_posix and ends_at_posix > now_posix %}
+            {% assign displayed_any_larps = true %}
+            <li><a href="{{ availability.run.event.url }}">{{ availability.run.event.title }}</a>: {{ availability.run.starts_at | date: "%a %l:%M%P" }} - {{ availability.bucket_availabilities_with_counted_slots | map: "bucket" | map: "name" | to_sentence }}</li>
+          {% endif %}
+        {% endfor %}
+     {% unless displayed_any_larps %}
+      <li><em>Sorry, all the games with available slots have already ended.</em></li>
+    {% endunless %}
+      </ul>
+    {% endif %}
+
+    {% if npclarp_availability.size > 0 %}
+      <h5>NPC or Unlimited Signups</h5>
+      <ul>
+        {% assign displayed_any_larps = false %}
+        {% for availability in npclarp_availability %}
+          {% assign ends_at_posix = availability.run.ends_at | date: "%s" | plus: 0 %}
+          {% assign starts_at_plus_30_min_posix = availability.run.starts_at | date: "%s" | plus: 1800 %}
+          {% if starts_at_plus_30_min_posix > now_posix and ends_at_posix > now_posix %}
+            {% assign displayed_any_larps = true %}
+            <li><a href="{{ availability.run.event.url }}">{{ availability.run.event.title }}</a>: {{ availability.run.starts_at | date: "%a %l:%M%P" }} - {{ availability.bucket_availabilities_with_not_counted_slots | map: "bucket" | map: "name" | to_sentence }}</li>
+          {% endif %}
+        {% endfor %}
+     {% unless displayed_any_larps %}
+      <li><em>Sorry, all the games with available slots have already ended.</em></li>
+    {% endunless %}
+        
+      </ul>
+    {% endif %}
+
+  </section>
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/signup_schedule.liquid
+++ b/cms_content_sets/wanderlust/partials/signup_schedule.liquid
@@ -1,0 +1,32 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign con_end_date = convention.ends_at | date: '%s' %}
+<div class='table-responsive'>
+<table class='table table-striped'>
+  <thead>
+    <tr>
+     <th>Date</th>
+     <th>Maximum Signups</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for timespan in convention.maximum_event_signups.timespans %}
+      {% assign ts_date = timespan.start | date: '%s' %}
+      {% unless timespan.value == 'not_yet'  or ts_date >= con_end_date%}
+        <tr>
+          <td>{{timespan.short_description_without_value}}</td>
+          {% if timespan.value == 'not_now' %}
+            <td>Site Frozen, No Signups Allowed</td>
+          {% elsif timespan.value == 'unlimited' %}
+            <td>Unlimited Signups</td>
+          {% else %}
+            <td>{{timespan.value}}</td>
+          {% endif %}
+        </tr>
+      {% endunless %}
+    {% endfor %}
+  </tbody>
+</table>
+</div>

--- a/cms_content_sets/wanderlust/partials/signup_text.liquid
+++ b/cms_content_sets/wanderlust/partials/signup_text.liquid
@@ -1,0 +1,66 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign next_val = convention.maximum_event_signups.next_value | plus: 0 %}
+{% if convention.maximum_event_signups.next_value == 'unlimited' %}
+  {% assign next_val = 'unlimited' %}
+{% endif %}
+{% assign current_val = convention.maximum_event_signups.current_value | plus: 0 %}
+{% if convention.maximum_event_signups.current_value == 'unlimited' %}
+  {% assign current_val = 'unlimited' %}
+{% endif %}
+
+{% assign show_next = false %}
+{% if next_val and convention.maximum_event_signups.current_value != 'unlimited' and convention.maximum_event_signups.current_value != 'not_now' %}
+  {% assign show_next = true %}
+{% endif %}
+
+{% unless convention.maximum_event_signups.current_value == 'not_yet' %}
+  {% if convention.maximum_event_signups.current_value == 'unlimited' %}
+    {% if user_con_profile.ticket %} 
+      {% if user_con_profile.ticket.allows_event_signups %}
+        Signups are open. You may <b>sign up</b> for as many games as you like.{% if show_next %}<br><br>{% endif %}
+      {% else %}
+      Signups are open. If you had a full {{convention.ticket_name}}, you would be able to <b>sign up</b> for as many games as you like.{% if show_next %}<br><br>{% endif %}
+      {% endif %}
+    {% else %}
+      Signups are open. If you had a {{convention.ticket_name}}, you would be able to <b>sign up</b> for as many games as you like.{% if show_next %}<br><br>{% endif %}
+    {% endif %}
+  {% elsif convention.maximum_event_signups.current_value == 'not_now' %}
+    The site is now frozen, and you may no longer sign up or drop larps.
+  {% else %}
+    {% assign signup_count = 0 %}
+    {% for signup in user_con_profile.signups %}
+      {% if signup.counted or signup.state == 'waitlisted' %}
+        {% assign signup_count = signup_count | plus: 1 %}
+      {% endif %}
+    {% endfor %}
+    {% assign remaining = current_val | minus: signup_count %}
+    {% if user_con_profile.ticket %}
+      {% if user_con_profile.ticket.allows_event_signups %}
+        Signups are open. You are allowed to be <b>signed up</b> for <strong>{{ current_val }}</strong> game{% unless current_val == 1 %}s{% endunless %} in total.
+        You have <strong>{{ remaining }}</strong> signup{% unless remaining == 1 %}s{% endunless %} remaining.
+      {% else %}. 
+        Signups are open.  If you had a full {{convention.ticket_name}}, you would be able to <b>sign up</b> for <strong>{{ current_val }}</strong> game{% unless current_val == 1 %}s{% endunless %}.
+      {% endif %}
+    {% else %}
+      Signups are open.  If you had a {{convention.ticket_name}}, you would be able to <b>sign up</b> for <strong>{{ current_val }}</strong> game{% unless current_val == 1 %}s{% endunless %}.
+    {% endif %}
+    {% if show_next %}<br><br>{% endif %}
+  {% endif %}
+{% endunless %}
+
+{% if show_next %}
+    The next round of signups will be on {{ convention.maximum_event_signups.next_value_change  | date: "%b %d, %Y at %l:%M %p %Z" }}.
+      {% if user_con_profile.ticket %}
+        {% if user_con_profile.ticket.allows_event_signups %}
+          You will be able to <b>sign up</b> for
+        {% else %}
+          If you had a full {{convention.ticket_name}}, you would be able to <b>sign up</b> for
+        {% endif %}
+      {% else %}
+        If you had a {{convention.ticket_name}}, you would be able to <b>sign up</b> for
+      {% endif %}
+      <strong>{{ next_val }}</strong> game{% unless next_val == 1 %}s{% endunless %} in total, including games you had previously signed up for, at that time.
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/site-css.liquid
+++ b/cms_content_sets/wanderlust/partials/site-css.liquid
@@ -1,0 +1,205 @@
+---
+admin_notes: ''
+invariant: true
+---
+ <style type="text/css">
+      body {
+        background: linear-gradient(90deg, {{css_background_color}} 0%, {{css_background_color_2}} 50%, {{css_background_color}} 100%);
+        background-image: 
+          linear-gradient(90deg, {{css_background_color}} 0%, {{css_background_color_2}} 25%,{{css_background_color_2}} 75%, {{css_background_color}} 100%),
+          url("{% file_url intercon-w-leaf-background-3.jpg %}");
+        background-attachment: fixed;
+        background-position: -40px 72px;
+
+      }
+     #mainContent, .footer{
+         
+        box-shadow: 0 0 10px 5px rgba(0,0,0,0.4);
+        clip-path: inset(0px -750px 0px -750px);
+     }
+
+      .navbar-dark .nav-link {
+        color: hsla(0,0%, 100%, 1)
+      }
+      .navbar-dark .btn-primary, .navbar-dark .btn-primary:hover, .navbar-dark .btn-primary:active {
+        background-color: {{css_color_3}};
+        border-color: {{css_color_3}};
+      }
+      .navbar-dark .btn-primary:hover {
+        text-decoration:underline;
+      }
+      
+      body, .popover {
+        font-family: 'Lato', sans-serif;
+      }
+   
+      .navbar-brand, .con-font{
+        font-family:  'Poiret One', sans-serif;
+        letter-spacing: .05rem;
+      }
+      
+      h1, h2, h3, h4, .blockquote, .font-heading {
+        font-family:  'Poiret One', sans-serif;
+      }
+   
+      h1 {
+        font-weight:700;
+        font-size: 3rem;
+      }
+   
+      h2 {
+        font-size: 2.5rem;
+        font-weight:700;
+      }
+
+      .bg-purple {
+        background-color: {{css_color_3}};
+        --bs-bg-opacity:1 ;
+      }
+      .border-purple {
+        --bs-border-opacity: 1;
+        border-color: {{css_color_3}};
+      }
+      
+      .intercon-menubar {
+        font-family: 'Lato', sans-serif;
+        background:  {{css_color_2}};
+        background: -webkit-linear-gradient(to right, {{css_color_1}}, {{css_color_2}});
+        background: linear-gradient(to bottom right, {{css_color_1}}, {{css_color_2}});
+        -webkit-box-shadow: 0px 3px 7px 0px rgba(0,0,0,0.4);
+        -moz-box-shadow: 0px 3px 7px 0px rgba(0,0,0,0.4);
+        box-shadow: 0px 3px 7px 0px rgba(0,0,0,0.4);
+      }
+   .intercon-menubar .nav-link, .intercon-menubar .navbar-brand, .intercon-menubar .navbar-toggler{
+        color: {{css_header_text_color}};
+   }
+   .intercon-menubar a.btn{
+     background-color: {{css_color_3}};
+     border-color: {{css_color_3}};
+   }
+   
+      .countdown {
+        font-family: 'Lato', sans-serif;
+        background:  {{css_color_3}};
+        -webkit-box-shadow: 0px 3px 7px 0px rgba(0,0,0,0.4);
+        -moz-box-shadow: 0px 3px 7px 0px rgba(0,0,0,0.4);
+        box-shadow: 0px 3px 7px 0px rgba(0,0,0,0.4);
+      }
+   
+      .con-logo-circle {
+        display: inline-block; 
+        border-radius: 50%; 
+        background: linear-gradient(rgb(67, 51, 91) 45%, rgba(67, 51, 91, 0.647) 100%); 
+        padding: 20px; 
+        overflow: hidden;
+        transition: box-shadow 0.2s ease-in-out .05s;
+      }
+
+       .con-logo-roundrect {
+            display: inline-block;
+       }
+      
+      a.con-logo-circle:hover, .con-logo-roundrect:hover {
+        box-shadow: 0 0 6px {{css_color_3}}; 
+      }
+   
+      .con-logo-circle img {
+        width: 100%;
+        max-width: 300px;
+        aspect-ratio: 1 / 1;
+      }
+
+      .con-logo-roundrect img {
+        width: 100%;
+        max-width: 480px;
+      }
+   
+      .background-content {
+        position: fixed;
+        width: 100%;
+        height: 100vh;
+        z-index: -1000;
+        display: flex;
+      }
+   
+      /* CSS hax so that hash-targeted elements don't get hidden under the fixed navbar.  First line of defense: scroll-margin-top.  This doens't always work (c.f. Safari and scrollIntoView) */
+      *[id], a[name] {
+        scroll-snap-margin-top: 82px;
+        scroll-margin-top: 82px;
+      }
+   
+      /* For other browsers, undo the scroll-margin-top thing and use a ::before hack to put in some margin.  This doesn't work for elements rendered in React components that are hash-targeted on navigation changes, but for anything else it works. */
+      :target::before {
+        scroll-snap-margin-top: 0;
+        scroll-margin-top: 0;
+        content: "";
+        display: block;
+        height: 82px; /* fixed header height*/
+        margin: -82px 0 0; /* negative fixed header height */
+      }
+      
+      .theme-title {
+        font-weight:300;
+        font-size:80;
+      }
+      
+      .bg-medium-gray {
+        background-color:#eee;
+      }
+      .section-nav {
+        padding-left: 0;
+        font-size:90%;
+      }
+      .toc-entry {
+        display: block;
+      }
+      .section-nav ul {
+        padding-left: 1rem;
+      }
+      .toc-entry a {
+        display: block;
+        padding: .125rem 1.5rem;
+        color: #99979c;
+      }
+       .toc-entry h4 {
+        display: block;
+        padding: .125rem 1.5rem;
+        color: #99979c;
+      }
+      .news-item:not(:first-child){
+        border-top:1px solid #eee
+      }
+    @media only screen and (min-width: 576px){
+        .overall {
+          min-height:100vh
+        }
+        .section-nav {
+          border-right: 1px solid #eee;
+          max-height: 90vh; 
+          overflow-y: auto;
+          border-bottom: none;
+        }
+     }
+    @media only screen and (min-width: 992px){
+        #user_signups_inner {
+          max-height:5499px;  
+          overflow-y:auto;
+        }
+      }
+      
+      @media only screen and (max-width: 575px){
+        .section-nav {
+          border-bottom: 1px solid #eee;
+        }
+        
+        .section-nav li a{
+          margin-bottom:10px;
+        }
+        .theme-title {
+          font-size:60%;
+        }
+        
+      }
+   
+   
+</style>

--- a/cms_content_sets/wanderlust/partials/social_event_registration_policy_instructions.liquid
+++ b/cms_content_sets/wanderlust/partials/social_event_registration_policy_instructions.liquid
@@ -1,0 +1,6 @@
+---
+invariant: true
+---
+<p>How many people can sign up for your social event?  If you want to limit the number, choose "limited capacity" below and enter the count.  If you don't want to limit the number, choose "unlimited capacity" below.</p>
+
+<p>If you want to further divide the ways people can sign up, you can use the "custom registration policy" option below.  (Most social events probably won't need to do this.)  This will let you set up custom buckets for your event.  You'll see a preview of the signup interface as you go.</p>

--- a/cms_content_sets/wanderlust/partials/social_events.liquid
+++ b/cms_content_sets/wanderlust/partials/social_events.liquid
@@ -1,0 +1,19 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign_graphql_result result = getMeetups()  %}
+{% assign meetups =  result.convention.events_paginated.entries %}
+<h3 class="my-h4">Meetups and Parties at {{convention.name}}</h3>
+<div class=list-group>
+{% for meetup in meetups %}
+  {% assign hosts = '' | split: ' ' %}
+  {% for host in meetup.team_members %}
+    {% assign name = host.user_con_profile.name_without_nickname | split: '_' %}
+    {% assign hosts = hosts | concat: name %}
+  {% endfor %}
+  {% render 'event_list_entry', event:meetup, hosts:hosts %}
+{% endfor %}
+</div>
+
+

--- a/cms_content_sets/wanderlust/partials/user_event_proposals.liquid
+++ b/cms_content_sets/wanderlust/partials/user_event_proposals.liquid
@@ -1,0 +1,62 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign event_proposals = user_con_profile.event_proposals | sort: "created_at" %}
+
+{% assign event_proposals_count = 0 %}
+{% for event_proposal in event_proposals %}
+  {% if event_proposal.status != 'accepted' or show_all_proposals == true %}
+    {% assign event_proposals_count = event_proposals_count| plus: 1 %}
+  {% endif %}
+{% endfor %}
+
+{% unless event_proposals_count == 0 %}
+  <div class="card bg-purple text-white mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <div>
+        My Event Proposals
+      </div>
+      {% new_event_proposal_button "Propose another event" btn btn-outline-light btn-sm %}
+    </div>
+    <ul class="list-group list-group-flush text-dark">
+      {% for event_proposal in event_proposals %}
+        {% if event_proposal.status != 'accepted' or show_all_proposals == true%}
+          <li class="list-group-item d-flex justify-content-between align-items-baseline">
+            <div>
+              <strong>
+                {% if event_proposal.title %}
+                  {{ event_proposal.title }}
+                {% else %}
+                  Untitled
+                {% endif %}
+              </strong>
+
+              ({{ event_proposal.status }})
+            </div>
+            {% if event_proposal.status == 'draft' %}
+              <a href="{{ event_proposal.edit_url }}" class="btn btn-primary btn-sm">
+                Continue
+              </a>
+
+            {% elsif event_proposal.status == 'proposed' or event_proposal.status == 'reviewing' %}
+              <a href="{{ event_proposal.edit_url }}" class="btn btn-secondary btn-sm">
+                Edit Proposal
+              </a>
+            {% elsif event_proposal.status == 'accepted' %}
+              <div class="btn-toolbar">
+                <a href="{{ event_proposal.event.url }}" class="btn btn-secondary btn-sm">
+                  View Event
+                </a>
+
+                <a href="{{ event_proposal.edit_url }}" class="btn btn-secondary btn-sm ms-2">
+                  Edit Event
+                </a>
+              </div>
+            {% endif %}
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </div>
+{% endunless %}

--- a/cms_content_sets/wanderlust/partials/user_resources.liquid
+++ b/cms_content_sets/wanderlust/partials/user_resources.liquid
@@ -1,0 +1,46 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign gm = false %}
+{% assign propcom = false %}
+{% assign concom = false %}
+
+{% if user_con_profile %}
+  {% assign positions = user_con_profile.staff_positions |map: 'name'  %}
+  {% if user_con_profile.event_proposals != empty or 
+      user_con_profile.team_member_events != empty or 
+      user_con_profile.privileges contains 'Con Com') %}
+    {% assign gm = true %}
+  {% endif %}
+
+  {% if positions contains 'Game Proposals Committee' or 
+      user_con_profile.privileges contains 'Staff' or
+      user_con_profile.privileges contains 'Site Admin' or
+      user_con_profile.privileges contains 'GM Liaison' %}
+    {% assign propcom = true %}
+  {% endif %}
+
+  {% if positions contains 'Con Com' %}
+    {% assign concom = true %}
+  {% endif %}
+{% endif %}
+
+{% if gm or propcom or concom %}
+  <div class="card border-purple my-4">
+    <div class="card-header bg-purple text-white">Convention Resources</div>
+    <div class='card-body'>
+      <ul class="list-unstyled mb-0">
+        {% if gm %}
+          <li><i class="bi-file-earmark-text-fill" aria-hidden="true"></i> <a href="{% page_url gmpolicies %}">GM Benefits, Policies and Services</a></li>
+        {% endif %}
+        {% if propcom %}
+          <li><i class="bi-file-earmark-text-fill" aria-hidden="true"></i> <a href="{% page_url propcom %}">Proposal Committee Procedures</a></li>
+        {% endif %}
+        {% if concom %}
+        <li><i class="bi-folder" aria-hidden="true"></i> <a href="https://drive.google.com/drive/folders/1cw0RHoDGbtoy2i0YtU1aD3U-ww3rOcNN?usp=sharing" target="_blank">NEIL Google Drive</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/user_signup.liquid
+++ b/cms_content_sets/wanderlust/partials/user_signup.liquid
@@ -50,18 +50,7 @@ invariant: false
       <strong>
         <a href="{{ signup.event_url }}">{{ signup.event.title }} </a>
       </strong>
-      {% if signup.state != 'confirmed' %}
-        &nbsp;[{{ signup.state | capitalize }}]
-      {% endif %}
-      {% if signup.team_member? %}
-        &nbsp;[{{ signup.event.team_member_name }}]
-      {% elsif signup.bucket.name %}
-        {% if signup.bucket.name != 'Signups' %}
-          {% if signup.bucket.name != 'Interested' %}
-            &nbsp;[{{ signup.bucket.name }}]
-          {% endif %}
-        {% endif %}
-      {% endif %}
+      {% render "signup_bucket_description" signup:signup %}
     </div>
   </div>
   <div>

--- a/cms_content_sets/wanderlust/partials/user_signup.liquid
+++ b/cms_content_sets/wanderlust/partials/user_signup.liquid
@@ -1,0 +1,74 @@
+---
+invariant: false
+---
+{% assign eventEnd = signup.ends_at | date: '%s' %}
+{% assign eventDiff = eventEnd | minus: nowTimestamp %}
+
+<li class="list-group-item d-flex align-items-center">
+  <div class="flex-grow-1">
+    <div>
+      <strong>
+        {{ signup.starts_at | date: "%a %l:%M%P" }} - {{ signup.ends_at | date: "%l:%M%P" }}:
+        {{ signup.run.room_names | join: ', ' }}
+      </strong>
+      <br>
+      <span>
+        {% if signup.state == 'waitlisted' %}
+          <i class="bi-hourglass-split" aria-hidden="true"></i>
+        {% elsif signup.team_member? %}
+          {% case signup.event.event_category.name %}
+            {% when "Con services" %}
+              <i class="bi-gear-fill" aria-hidden="true"></i>
+            {% when "Volunteer event" %}
+              <i class="bi-gear-fill" aria-hidden="true"></i>
+            {% when "Larp" %}
+              <i class="bi-megaphone-fill" aria-hidden="true"></i>
+            {% when "Moderated discussion" %}
+              <i class="bi-megaphone-fill" aria-hidden="true"></i>
+            {% when "Panel" %}
+              <i class="bi-megaphone-fill" aria-hidden="true"></i>
+            {% when "Presentation" %}
+              <i class="bi-megaphone-fill" aria-hidden="true"></i>
+            {% when "Town hall" %}
+              <i class="bi-megaphone-fill" aria-hidden="true"></i>
+            {% when "Workshop" %}
+              <i class="bi-megaphone-fill" aria-hidden="true"></i>
+            {% when "Party" %}
+              <i class="bi-chat-fill" aria-hidden="true"></i>
+            {% when "Social event" %}
+              <i class="bi-chat-fill" aria-hidden="true"></i>
+            {% when "Meetup" %}
+              <i class="bi-chat-fill" aria-hidden="true"></i>
+            {% else %}
+              <i class="bi-people-fill" aria-hidden="true"></i>
+          {% endcase%}
+        {% elsif signup.bucket.name %}
+          <i class="bi-person-circle" aria-hidden="true"></i>
+        {% endif %}
+      </span>
+      &nbsp;{{ signup.event.event_category.name | replace: "_", " " | humanize}}:&nbsp;
+      <strong>
+        <a href="{{ signup.event_url }}">{{ signup.event.title }} </a>
+      </strong>
+      {% if signup.state != 'confirmed' %}
+        &nbsp;[{{ signup.state | capitalize }}]
+      {% endif %}
+      {% if signup.team_member? %}
+        &nbsp;[{{ signup.event.team_member_name }}]
+      {% elsif signup.bucket.name %}
+        {% if signup.bucket.name != 'Signups' %}
+          {% if signup.bucket.name != 'Interested' %}
+            &nbsp;[{{ signup.bucket.name }}]
+          {% endif %}
+        {% endif %}
+      {% endif %}
+    </div>
+  </div>
+  <div>
+    {% if eventDiff > 0 %}
+      {% withdraw_user_signup_button signup "Withdraw" btn-outline-danger btn-sm %}
+    {% else %}
+    Past Event
+    {% endif %}
+  </div>
+</li>

--- a/cms_content_sets/wanderlust/partials/user_signup_list.liquid
+++ b/cms_content_sets/wanderlust/partials/user_signup_list.liquid
@@ -1,0 +1,57 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign nowTimestamp = 'now' | date: '%s' %}
+{% assign conventionStart = convention.starts_at| date: '%s' %}
+{% assign conventionEnd = convention.ends_at | date: '%s' %}
+{% assign diffSecondsStart = conventionStart | minus: nowTimestamp %}
+{% assign diffSecondsEnd = conventionEnd | minus: nowTimestamp %}
+{% assign signups = user_con_profile.signups | sort: "starts_at" %}
+
+{% if signups.size > 0 %}
+  <section class="card bg-purple text-white my-4">
+    <div class="card-header">My Schedule
+      <div class="float-end">
+        {% add_to_calendar_dropdown user_con_profile.ical_secret btn btn-outline-light %}
+      </div>
+    </div>
+    <div id="user_signups_inner">
+      <!--style='max-height:499px; overflow-y:auto' -->
+    <ul class="list-group list-group-flush text-dark">
+      {% if diffSecondsStart < 0 and diffSecondsEnd > 0 %}
+        {% assign has_old_events = false %}
+        {% capture old_events %}
+          {% for signup in signups %}
+            {% assign eventEnd = signup.ends_at | date: '%s' %}
+            {% assign eventDiff = eventEnd | minus: nowTimestamp %}
+            {% if eventDiff <= 0 %}
+              {% render 'user_signup', signup:signup %}
+              {% assign has_old_events = true %}
+            {% endif %}
+          {% endfor %}
+        {% endcapture %}
+      {% if has_old_events%}
+      <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#old-events" aria-expanded="false" aria-controls="pastEvents">
+    Show / Hide Past Events
+  </button>
+      <div id='old-events' class="collapse">
+        {{old_events}}
+      </div>
+      {% endif %}
+        {% for signup in signups %}
+          {% assign eventEnd = signup.ends_at | date: '%s' %}
+          {% assign eventDiff = eventEnd | minus: nowTimestamp %}
+          {% if eventDiff > 0 %}
+            {% render 'user_signup', signup:signup %}
+          {% endif %}
+        {% endfor %}
+      {% else %}
+        {% for signup in signups %}
+          {% render 'user_signup', signup:signup%}
+        {% endfor %}
+      {% endif %}
+      </div>
+    </ul>
+  </section>
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/user_team_member_events.liquid
+++ b/cms_content_sets/wanderlust/partials/user_team_member_events.liquid
@@ -1,0 +1,27 @@
+---
+admin_notes: ''
+invariant: false
+---
+{% assign team_member_events = user_con_profile.team_member_events %}
+
+{% if team_member_events.size > 0 %}
+  <section class="card bg-info text-white my-4">
+    <div class="card-header">Events I'm Running</div>
+
+    <ul class="list-group list-group-flush text-dark">
+      {% for event in team_member_events %}
+        <li class="list-group-item d-flex justify-content-between align-items-baseline">
+          <div>
+             {{ event.event_category.name | replace: "_", " " | humanize}}:&nbsp;
+            <a href="{{ event.url }}">{{ event.title }}</a>
+          </div>
+          <div>
+            <a href="{{ event.url }}/edit" class="btn btn-secondary btn-sm">
+              Edit
+            </a>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endif %}

--- a/cms_content_sets/wanderlust/partials/vax_check.liquid
+++ b/cms_content_sets/wanderlust/partials/vax_check.liquid
@@ -1,0 +1,30 @@
+---
+invariant: false
+---
+{% if user_con_profile %}
+  {% if user_con_profile.form_response.vaccination_status == nil or user_con_profile.form_response.vaccination_status.size == 0 %}
+    <div class="alert alert-danger" role="alert">
+      <div class="d-flex align-items-center">
+        <div class="d-none d-lg-block me-3">
+          <i class="bi-shield-fill-exclamation h4"></i>
+        </div>
+        <div>
+          <!--COVID-19 Vaccine verification is not yet live for {{convention.name}}.
+           When we know if there will be a fall 2024 booster, we will open verification at that time.  You can view the <a href="{% page_url covid %}">COVID FAQ</a> for additional information about the steps that {{convention.name}} is taking to keep everyone safe! -->
+          You have not yet verified your COVID-19 Vaccine status with {{convention.name}} and will not be able to <b>attend</b> until you do.  You can email us a photo of your Vaccine proof at {{convention.staff_positions_by_name.covid_verification.email_link }} or see <a href="{% page_url covid %}">our COVID FAQ</a> for more options.
+        </div>
+      </div>
+    </div>
+  {% else %}
+      <div class="alert alert-success" role="alert">
+        <div class="d-flex align-items-center">
+          <div class="d-none d-lg-block me-3">
+            <i class="bi-shield-fill-check h4"></i>
+          </div>
+          <div>
+            You have documented your COVID-19 Vaccine status with {{convention.name}} and will be able to <b>attend</b>.  We look forward to seeing you!
+          </div>
+        </div>
+      </div>
+    {% endif %}
+{% endif %}

--- a/db/migrate/20241111181051_update_signup_bucket_description_partials.rb
+++ b/db/migrate/20241111181051_update_signup_bucket_description_partials.rb
@@ -240,7 +240,18 @@ class UpdateSignupBucketDescriptionPartials < ActiveRecord::Migration[7.2]
       <strong>
         <a href="{{ signup.event_url | absolute_url }}">{{ signup.event.title }}</a>
       </strong>
-      {% render "signup_bucket_description" signup:signup %}
+      {% if signup.state != 'confirmed' %}
+        &nbsp;[{{ signup.state | capitalize }}]
+      {% endif %}
+      {% if signup.team_member? %}
+        &nbsp;[{{ signup.event.team_member_name }}]
+      {% elsif signup.bucket.name %}
+        {% if signup.bucket.name != 'Signups' %}
+          {% if signup.bucket.name != 'Interested' %}
+            &nbsp;[{{ signup.bucket.name }}]
+          {% endif %}
+        {% endif %}
+      {% endif %}
     </div>
   </li>
   LIQUID
@@ -265,19 +276,19 @@ class UpdateSignupBucketDescriptionPartials < ActiveRecord::Migration[7.2]
     },
     "notification_templates" => {
       "standard" => {
-        "signup_confirmation" => {
+        "signups/signup_confirmation" => {
           "body_html" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_HTML,
           "body_text" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_TEXT
         }
       },
       "smoke_and_mirrors" => {
-        "signup_confirmation" => {
+        "signups/signup_confirmation" => {
           "body_html" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_HTML,
           "body_text" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_TEXT
         }
       },
       "wanderlust" => {
-        "signup_confirmation" => {
+        "signups/signup_confirmation" => {
           "body_html" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_HTML,
           "body_text" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_TEXT
         }
@@ -331,7 +342,7 @@ class UpdateSignupBucketDescriptionPartials < ActiveRecord::Migration[7.2]
         CmsContentLoaders::NotificationTemplates.new(
           cms_parent: convention,
           content_set:,
-          content_identifiers: %w[signup_confirmation],
+          content_identifiers: %w[signups/signup_confirmation],
           conflict_policy: notification_template_conflict_policy
         )
       notification_template_loader.call!

--- a/db/migrate/20241111181051_update_signup_bucket_description_partials.rb
+++ b/db/migrate/20241111181051_update_signup_bucket_description_partials.rb
@@ -1,0 +1,346 @@
+class UpdateSignupBucketDescriptionPartials < ActiveRecord::Migration[7.2]
+  STANDARD_PREVIOUS_USER_SIGNUPS = <<~LIQUID
+  {% assign signups = user_con_profile.signups | sort: "starts_at" %}
+
+  {% if signups.size > 0 %}
+    <section class="card bg-info text-white my-4">
+      <div class="card-header">My Schedule</div>
+
+      <ul class="list-group list-group-flush text-dark">
+        {% for signup in signups %}
+          <li class="list-group-item d-flex align-items-center">
+            <div style="width: 11em">
+              {{ signup.starts_at | date: "%a %l:%M%P" }} - {{ signup.ends_at | date: "%l:%M%P" }}
+            </div>
+            <div class="col">
+              <a href="{{ signup.event_url }}">{{ signup.event.title }}</a>
+              {% if signup.state != 'confirmed' %}
+                [{{ signup.state | capitalize }}]
+              {% endif %}
+              {% if signup.team_member? %}
+                [{{ signup.event.team_member_name }}]
+              {% endif %}
+            </div>
+
+            <div>
+              {% withdraw_user_signup_button signup %}
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
+  LIQUID
+
+  SMOKE_AND_MIRRORS_PREVIOUS_USER_SIGNUPS = <<~LIQUID
+  {% assign signups = user_con_profile.signups | sort: "starts_at" %}
+
+  {% if signups.size > 0 %}
+    <section class="card bg-info text-white my-4">
+      <div class="card-header">My Schedule
+        <div class="float-end">
+            <a class="btn btn-outline-light" target="_blank" href="https://calendar.google.com/calendar/r?cid={{user_con_profile.schedule_calendar_url | url_encode}}" title='Add to Google Calendar' data-bs-toggle="tooltip" data-bs-placement="top"><i class="bi-calendar3" aria-hidden="true"></i></a>
+        </div>
+      </div>
+      <div style='max-height:499px; overflow-y:auto'>
+      <ul class="list-group list-group-flush text-dark">
+        {% for signup in signups %}
+          <li class="list-group-item d-flex align-items-center">
+            <div class="col">
+              <div class="row">
+                <strong>
+                  {{ signup.starts_at | date: "%a %l:%M%P" }} - {{ signup.ends_at | date: "%l:%M%P" }}:
+                  {{ signup.run.room_names | join: ', ' }}
+                </strong>
+              </div>
+              <div class="d-flex">
+                <span>
+                  {% if signup.state == 'waitlisted' %}
+                    <i class="bi-hourglass-split" aria-hidden="true"></i>
+                  {% elsif signup.team_member? %}
+                    {% case signup.event.event_category.name %}
+                      {% when "Con services" %}
+                        <i class="bi-gear-fill" aria-hidden="true"></i>
+                      {% when "Volunteer event" %}
+                        <i class="bi-gear-fill" aria-hidden="true"></i>
+                      {% when "Larp" %}
+                        <i class="bi-megaphone-fill" aria-hidden="true"></i>
+                      {% when "Moderated discussion" %}
+                        <i class="bi-megaphone-fill" aria-hidden="true"></i>
+                      {% when "Panel" %}
+                        <i class="bi-megaphone-fill" aria-hidden="true"></i>
+                      {% when "Presentation" %}
+                        <i class="bi-megaphone-fill" aria-hidden="true"></i>
+                      {% when "Town hall" %}
+                        <i class="bi-megaphone-fill" aria-hidden="true"></i>
+                      {% when "Workshop" %}
+                        <i class="bi-megaphone-fill" aria-hidden="true"></i>
+                      {% when "Party" %}
+                        <i class="bi-chat-fill" aria-hidden="true"></i>
+                      {% when "Social event" %}
+                        <i class="bi-chat-fill" aria-hidden="true"></i>
+                      {% when "Meetup" %}
+                        <i class="bi-chat-fill" aria-hidden="true"></i>
+                      {% else %}
+                        <i class="bi-people-fill" aria-hidden="true"></i>
+                    {% endcase%}
+                  {% elsif signup.bucket.name %}
+                    <i class="bi-person-circle" aria-hidden="true"></i>
+                  {% endif %}
+                </span>
+                &nbsp;{{ signup.event.event_category.name | replace: "_", " " | humanize}}:&nbsp;
+                <strong>
+                  <a href="{{ signup.event_url }}">{{ signup.event.title }} </a>
+                </strong>
+                {% if signup.state != 'confirmed' %}
+                  &nbsp;[{{ signup.state | capitalize }}]
+                {% endif %}
+                {% if signup.team_member? %}
+                  &nbsp;[{{ signup.event.team_member_name }}]
+                {% elsif signup.bucket.name %}
+                  {% if signup.bucket.name != 'Signups' %}
+                    {% if signup.bucket.name != 'Interested' %}
+                      &nbsp;[{{ signup.bucket.name }}]
+                    {% endif %}
+                  {% endif %}
+                {% endif %}
+              </div>
+            </div>
+
+            <div>
+              {% withdraw_user_signup_button signup %}
+            </div>
+          </li>
+        {% endfor %}
+        </div>
+      </ul>
+    </section>
+  {% endif %}
+  LIQUID
+
+  WANDERLUST_PREVIOUS_USER_SIGNUP = <<~LIQUID
+  {% assign eventEnd = signup.ends_at | date: '%s' %}
+  {% assign eventDiff = eventEnd | minus: nowTimestamp %}
+
+  <li class="list-group-item d-flex align-items-center">
+    <div class="flex-grow-1">
+      <div>
+        <strong>
+          {{ signup.starts_at | date: "%a %l:%M%P" }} - {{ signup.ends_at | date: "%l:%M%P" }}:
+          {{ signup.run.room_names | join: ', ' }}
+        </strong>
+        <br>
+        <span>
+          {% if signup.state == 'waitlisted' %}
+            <i class="bi-hourglass-split" aria-hidden="true"></i>
+          {% elsif signup.team_member? %}
+            {% case signup.event.event_category.name %}
+              {% when "Con services" %}
+                <i class="bi-gear-fill" aria-hidden="true"></i>
+              {% when "Volunteer event" %}
+                <i class="bi-gear-fill" aria-hidden="true"></i>
+              {% when "Larp" %}
+                <i class="bi-megaphone-fill" aria-hidden="true"></i>
+              {% when "Moderated discussion" %}
+                <i class="bi-megaphone-fill" aria-hidden="true"></i>
+              {% when "Panel" %}
+                <i class="bi-megaphone-fill" aria-hidden="true"></i>
+              {% when "Presentation" %}
+                <i class="bi-megaphone-fill" aria-hidden="true"></i>
+              {% when "Town hall" %}
+                <i class="bi-megaphone-fill" aria-hidden="true"></i>
+              {% when "Workshop" %}
+                <i class="bi-megaphone-fill" aria-hidden="true"></i>
+              {% when "Party" %}
+                <i class="bi-chat-fill" aria-hidden="true"></i>
+              {% when "Social event" %}
+                <i class="bi-chat-fill" aria-hidden="true"></i>
+              {% when "Meetup" %}
+                <i class="bi-chat-fill" aria-hidden="true"></i>
+              {% else %}
+                <i class="bi-people-fill" aria-hidden="true"></i>
+            {% endcase%}
+          {% elsif signup.bucket.name %}
+            <i class="bi-person-circle" aria-hidden="true"></i>
+          {% endif %}
+        </span>
+        &nbsp;{{ signup.event.event_category.name | replace: "_", " " | humanize}}:&nbsp;
+        <strong>
+          <a href="{{ signup.event_url }}">{{ signup.event.title }} </a>
+        </strong>
+        {% if signup.state != 'confirmed' %}
+          &nbsp;[{{ signup.state | capitalize }}]
+        {% endif %}
+        {% if signup.team_member? %}
+          &nbsp;[{{ signup.event.team_member_name }}]
+        {% elsif signup.bucket.name %}
+          {% if signup.bucket.name != 'Signups' %}
+            {% if signup.bucket.name != 'Interested' %}
+              &nbsp;[{{ signup.bucket.name }}]
+            {% endif %}
+          {% endif %}
+        {% endif %}
+      </div>
+    </div>
+    <div>
+      {% if eventDiff > 0 %}
+        {% withdraw_user_signup_button signup "Withdraw" btn-outline-danger btn-sm %}
+      {% else %}
+      Past Event
+      {% endif %}
+    </div>
+  </li>
+  LIQUID
+
+  STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_TEXT = <<~LIQUID
+  {%- assign run = signup.run -%}
+  {% if signup.state == "waitlisted"%}Waitlist{% else %}Signup{% endif %} confirmation for {% include 'run_description' %}
+
+  This message is to confirm that you've successfully
+  {%- if signup.state == "waitlisted" %} joined the waitlist for
+  {%- else %} signed up for
+  {%- endif %} {% include 'run_description' %}.
+
+  Your new signup:
+  {{ signup.starts_at | date: "%a %l:%M%P" }} - {{ signup.ends_at | date: "%l:%M%P" }}: {{ signup.run.room_names | join: ', ' }}
+  {{ signup.event.event_category.name | replace: "_", " " | humanize}}: {{ signup.event.title }}
+  {%- if signup.state != 'confirmed' %} [{{ signup.state | capitalize }}]{% endif -%}
+  {%- if signup.team_member? %} [{{ signup.event.team_member_name }}]
+  {%- elsif signup.bucket.name -%}
+    {%- if signup.bucket.name != 'Signups' -%}
+      {%- if signup.bucket.name != 'Interested' %} [{{ signup.bucket.name }}]{% endif -%}
+    {%- endif -%}
+  {%- endif %}
+  {{ signup.event_url | absolute_url }}
+  LIQUID
+
+  STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_HTML = <<~LIQUID
+  {% assign run = signup.run %}
+  <h1>{% if signup.state == "waitlisted"%}Waitlist{% else %}Signup{% endif %} confirmation for {% include 'run_description' %}</h1>
+
+  <p>
+    This message is to confirm that you've successfully
+    {%- if signup.state == "waitlisted" %} joined the waitlist for
+    {%- else %} signed up for
+    {%- endif %}
+    {% include 'run_description' %}.
+  </p>
+
+  <div style="border: 1px black solid; border-radius: 5px;">
+    <div style="background-color: black; padding: 10px; color: white; font-weight: bold;">
+      Your new signup
+    </div>
+    <div style="padding: 10px;">
+      <strong>
+        {{ signup.starts_at | date: "%a %l:%M%P" }} - {{ signup.ends_at | date: "%l:%M%P" }}:
+        {{ signup.run.room_names | join: ', ' }}
+      </strong>
+      <br>
+      {{ signup.event.event_category.name | replace: "_", " " | humanize}}:&nbsp;
+      <strong>
+        <a href="{{ signup.event_url | absolute_url }}">{{ signup.event.title }}</a>
+      </strong>
+      {% render "signup_bucket_description" signup:signup %}
+    </div>
+  </li>
+  LIQUID
+
+  PREVIOUS_CONTENT = {
+    "partials" => {
+      "standard" => {
+        "user_signups" => {
+          "content" => STANDARD_PREVIOUS_USER_SIGNUPS
+        }
+      },
+      "smoke_and_mirrors" => {
+        "user_signups" => {
+          "content" => SMOKE_AND_MIRRORS_PREVIOUS_USER_SIGNUPS
+        }
+      },
+      "wanderlust" => {
+        "user_signup" => {
+          "content" => WANDERLUST_PREVIOUS_USER_SIGNUP
+        }
+      }
+    },
+    "notification_templates" => {
+      "standard" => {
+        "signup_confirmation" => {
+          "body_html" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_HTML,
+          "body_text" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_TEXT
+        }
+      },
+      "smoke_and_mirrors" => {
+        "signup_confirmation" => {
+          "body_html" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_HTML,
+          "body_text" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_TEXT
+        }
+      },
+      "wanderlust" => {
+        "signup_confirmation" => {
+          "body_html" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_HTML,
+          "body_text" => STANDARD_PREVIOUS_SIGNUP_CONFIRMATION_BODY_TEXT
+        }
+      }
+    }
+  }
+
+  def up
+    standard = CmsContentSet.new(name: "standard")
+    smoke_and_mirrors = CmsContentSet.new(name: "smoke_and_mirrors")
+    wanderlust = CmsContentSet.new(name: "wanderlust")
+
+    Convention.find_each do |convention|
+      content_set =
+        if convention.name.start_with?("Intercon ")
+          if convention.cms_partials.where(name: "user_signup").any?
+            wanderlust
+          elsif convention.cms_partials.where(name: "badgecheck").any?
+            smoke_and_mirrors
+          else
+            standard
+          end
+        else
+          standard
+        end
+
+      cms_partial_identifiers =
+        if content_set.name == "wanderlust"
+          %w[signup_bucket_description user_signup]
+        else
+          %w[signup_bucket_description user_signups]
+        end
+
+      partial_conflict_policy =
+        CmsContentLoaders::ConflictPolicies::Update.new(PREVIOUS_CONTENT.fetch("partials").fetch(content_set.name))
+      partial_loader =
+        CmsContentLoaders::CmsPartials.new(
+          cms_parent: convention,
+          content_set:,
+          content_identifiers: cms_partial_identifiers,
+          conflict_policy: partial_conflict_policy
+        )
+      partial_loader.call!
+      partial_conflict_policy.skipped_items.each { |skipped_item| say "#{convention.name}: #{skipped_item.message}" }
+
+      notification_template_conflict_policy =
+        CmsContentLoaders::ConflictPolicies::Update.new(
+          PREVIOUS_CONTENT.fetch("notification_templates").fetch(content_set.name)
+        )
+      notification_template_loader =
+        CmsContentLoaders::NotificationTemplates.new(
+          cms_parent: convention,
+          content_set:,
+          content_identifiers: %w[signup_confirmation],
+          conflict_policy: notification_template_conflict_policy
+        )
+      notification_template_loader.call!
+      notification_template_conflict_policy.skipped_items.each do |skipped_item|
+        say "#{convention.name}: #{skipped_item.message}"
+      end
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20241111203124_update_event_updated_notification_headline.rb
+++ b/db/migrate/20241111203124_update_event_updated_notification_headline.rb
@@ -1,0 +1,61 @@
+class UpdateEventUpdatedNotificationHeadline < ActiveRecord::Migration[7.2]
+  PREVIOUS_EVENT_UPDATED_BODY_HTML = <<~LIQUID
+  <h1>Proposal updated</h1>
+
+  <p>
+    “{{ event.title }}” has been updated. To view the event, go
+    <a href="{{ event.url | absolute_url }}">here</a>.
+  <p>
+
+  <hr>
+
+  <h2>Change log</h2>
+
+  {{ changes_html }}
+  LIQUID
+
+  PREVIOUS_EVENT_UPDATED_BODY_TEXT = <<~LIQUID
+  “{{ event.title }}” has been updated. To view the event, go to: {{ event.url | absolute_url }}
+
+
+  A change log is available at: {{ event.history_url | absolute_url }}
+  LIQUID
+
+  PREVIOUS_CONTENT = {
+    "notification_templates" => {
+      "standard" => {
+        "events/event_updated" => {
+          "body_html" => PREVIOUS_EVENT_UPDATED_BODY_HTML,
+          "body_text" => PREVIOUS_EVENT_UPDATED_BODY_TEXT
+        }
+      }
+    }
+  }
+
+  def up
+    standard = CmsContentSet.new(name: "standard")
+
+    Convention.find_each do |convention|
+      content_set = standard
+
+      notification_template_conflict_policy =
+        CmsContentLoaders::ConflictPolicies::Update.new(
+          PREVIOUS_CONTENT.fetch("notification_templates").fetch(content_set.name)
+        )
+      notification_template_loader =
+        CmsContentLoaders::NotificationTemplates.new(
+          cms_parent: convention,
+          content_set:,
+          content_identifiers: %w[events/event_updated],
+          conflict_policy: notification_template_conflict_policy
+        )
+      notification_template_loader.call!
+      notification_template_conflict_policy.skipped_items.each do |skipped_item|
+        say "#{convention.name}: #{skipped_item.message}"
+      end
+    end
+  end
+
+  def down
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6120,6 +6120,7 @@ ALTER TABLE ONLY public.cms_files_pages
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241111181051'),
 ('20241031190016'),
 ('20240916155847'),
 ('20240807155222'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6120,6 +6120,7 @@ ALTER TABLE ONLY public.cms_files_pages
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20241111203124'),
 ('20241111181051'),
 ('20241031190016'),
 ('20240916155847'),

--- a/lib/intercode/liquid/tags/withdraw_user_signup_button.rb
+++ b/lib/intercode/liquid/tags/withdraw_user_signup_button.rb
@@ -30,17 +30,29 @@ module Intercode
         end
 
         def component_name(_context)
-          'WithdrawMySignupButton'
+          "WithdrawMySignupButton"
         end
 
-        def props(context)
+        def props(context) # rubocop:disable Metrics/MethodLength
+          signup = context[signup_variable_name]
+          signup_rounds = signup.event.convention.signup_rounds
+
           {
             event: {
-              title: context[signup_variable_name].event.title
+              title: signup.event.title
             },
             run: {
-              id: context[signup_variable_name].run.id
+              id: signup.run.id
             },
+            signup: {
+              id: signup.id,
+              state: signup.state,
+              counted: signup.counted
+            },
+            signupRounds:
+              signup_rounds.map do |round|
+                { start: round.start&.rfc3339, maximum_event_signups: round.maximum_event_signups }
+              end,
             buttonText: button_text,
             buttonClass: button_class,
             reloadOnSuccess: true
@@ -51,4 +63,4 @@ module Intercode
   end
 end
 
-Liquid::Template.register_tag('withdraw_user_signup_button', Intercode::Liquid::Tags::WithdrawUserSignupButton)
+Liquid::Template.register_tag("withdraw_user_signup_button", Intercode::Liquid::Tags::WithdrawUserSignupButton)

--- a/locales/en.json
+++ b/locales/en.json
@@ -810,11 +810,13 @@
       "ticketTypeHeader": "{{ ticketName }} type"
     },
     "withdrawPrompt": {
+      "checkboxLabel": "Yes, I’m sure I want to withdraw my <strong>confirmed</strong> signup from {{ eventTitle }}.",
       "duringLimitedRankedChoiceSignupRoundCounted": "Are you sure you want to withdraw from {{ eventTitle }}?  Once you do, you’ll have an available signup slot and will be able to immediately sign up for a different event.",
       "moderatedSignup": "<0><0>If you’re thinking of signing up for a different event instead, please go to that event’s page and request to sign up for it.</0> If the request is accepted, you’ll automatically be withdrawn from this event.</0><1>Are you sure you want to withdraw from {{eventTitle}}?</1>",
       "notCounted": "Are you sure you want to withdraw from {{ eventTitle }}?  This event does not count towards your signup totals and will not free up a signup slot.",
       "selfServiceSignup": "Are you sure you want to withdraw from {{ eventTitle }}?",
-      "signupRequest": "Are you sure you want to withdraw your request to sign up for {{ eventTitle }}?"
+      "signupRequest": "Are you sure you want to withdraw your request to sign up for {{ eventTitle }}?",
+      "title": "Are you sure?"
     }
   },
   "forms": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "punycode": "2.3.1",
     "qs": "^6.13.0",
     "react": "18.3.1",
-    "react-bootstrap4-modal": "3.0.6",
+    "react-bootstrap4-modal": "3.0.7",
     "react-color": "2.19.3",
     "react-cookie-consent": "9.0.0",
     "react-dom": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "punycode": "2.3.1",
     "qs": "^6.13.0",
     "react": "18.3.1",
-    "react-bootstrap4-modal": "2.0.0",
+    "react-bootstrap4-modal": "3.0.6",
     "react-color": "2.19.3",
     "react-cookie-consent": "9.0.0",
     "react-dom": "18.3.1",

--- a/workspaceConfiguration/LoadTerminal.json
+++ b/workspaceConfiguration/LoadTerminal.json
@@ -17,10 +17,10 @@
       ]
     },
     {
-      "name": "Webpack",
-      "description": "webpack-dev-server",
+      "name": "Vite",
+      "description": "Vite dev server",
       "enabled": true,
-      "terminals": [{ "name": "webpack", "path": ".", "cmd": ["yarn run start"], "num": 0 }]
+      "terminals": [{ "name": "vite", "path": ".", "cmd": ["yarn run start"], "num": 0 }]
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19173,14 +19173,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-bootstrap4-modal@npm:3.0.6":
-  version: 3.0.6
-  resolution: "react-bootstrap4-modal@npm:3.0.6"
+"react-bootstrap4-modal@npm:3.0.7":
+  version: 3.0.7
+  resolution: "react-bootstrap4-modal@npm:3.0.7"
   dependencies:
     classnames: "npm:^2.3.1"
   peerDependencies:
     react: ^18.0
-  checksum: 10c0/81ceb13c564a23565381e7120b92d0956390b1b3a06db5133ae525697b211357b6d37a0b9af405c7c997b115535e94bb590729abd1532103f200d75e38b55bc7
+  checksum: 10c0/ac8712230d0447f6d0b4fb879e1d8c806efc2c0d69dd62036c5ee2c9114a7dd5d1eca824b8635aba895e50ce5ea1219a35755bf8612db4d84c0b271538c642b6
   languageName: node
   linkType: hard
 
@@ -20559,7 +20559,7 @@ __metadata:
     punycode: "npm:2.3.1"
     qs: "npm:^6.13.0"
     react: "npm:18.3.1"
-    react-bootstrap4-modal: "npm:3.0.6"
+    react-bootstrap4-modal: "npm:3.0.7"
     react-color: "npm:2.19.3"
     react-cookie-consent: "npm:9.0.0"
     react-dom: "npm:18.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19173,7 +19173,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-bootstrap4-modal@npm:2.0.0, react-bootstrap4-modal@npm:^2.0.0":
+"react-bootstrap4-modal@npm:3.0.6":
+  version: 3.0.6
+  resolution: "react-bootstrap4-modal@npm:3.0.6"
+  dependencies:
+    classnames: "npm:^2.3.1"
+  peerDependencies:
+    react: ^18.0
+  checksum: 10c0/81ceb13c564a23565381e7120b92d0956390b1b3a06db5133ae525697b211357b6d37a0b9af405c7c997b115535e94bb590729abd1532103f200d75e38b55bc7
+  languageName: node
+  linkType: hard
+
+"react-bootstrap4-modal@npm:^2.0.0":
   version: 2.0.0
   resolution: "react-bootstrap4-modal@npm:2.0.0"
   dependencies:
@@ -20548,7 +20559,7 @@ __metadata:
     punycode: "npm:2.3.1"
     qs: "npm:^6.13.0"
     react: "npm:18.3.1"
-    react-bootstrap4-modal: "npm:2.0.0"
+    react-bootstrap4-modal: "npm:3.0.6"
     react-color: "npm:2.19.3"
     react-cookie-consent: "npm:9.0.0"
     react-dom: "npm:18.3.1"


### PR DESCRIPTION
* Prevent modal dialogs from being partially hidden behind navigation bar
* Add an additional confirmation for withdrawing confirmed signups  (checkbox on withdraw interface)
* Fix the wording where it’s telling people a signup doesn’t count during withdraw when actually it does
* Add (requested [bucket]) to player-facing wording when they’re in a flex bucket (email, website)
* Only show limited signups in the schedule page capacity graphs
* Fix “event proposal” wording in event updated email

