### PR TITLE
Show "No" values on event pages

### DIFF
--- a/app/javascript/AppRouter.tsx
+++ b/app/javascript/AppRouter.tsx
@@ -549,6 +549,7 @@ const commonInConventionRoutes: RouteObject[] = [
     lazy: () => import('./FormAdmin'),
     children: [
       { path: ':id/edit_advanced', id: NamedRoute.FormJSONEditor, lazy: () => import('./FormAdmin/FormJSONEditor') },
+      { path: ':id', lazy: () => import('./FormAdmin/$id/route') },
       { index: true, id: NamedRoute.FormAdminIndex, lazy: () => import('./FormAdmin/FormAdminIndex') },
     ],
   },

--- a/app/javascript/EventsApp/EventPage/useSectionizedFormItems.ts
+++ b/app/javascript/EventsApp/EventPage/useSectionizedFormItems.ts
@@ -14,7 +14,7 @@ function getSectionizedFormItems(formData: EventPageForm, formResponse: Record<s
       item.identifier !== 'title' &&
       item.public_description != null &&
       item.public_description.trim().length > 0 &&
-      formResponse[item.identifier],
+      (formResponse[item.identifier] || formResponse[item.identifier] === false),
   );
   const shortFormItems: TypedFormItem[] = [];
   const secretFormItems: TypedFormItem[] = [];


### PR DESCRIPTION
"No" (i.e. a "false" response to a boolean form item) should be shown on an event page, since it's a valid, non-blank response to that question.  However, because it's falsy, it's being hidden right now. This fixes that.