### PR TITLE
Fix "An object of type EventProposal" error

### DIFF
--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 class Types::UserType < Types::BaseObject
+  description <<~MARKDOWN
+    A user on this instance of Intercode.  Users exist across all conventions.  For each convention a user has logged
+    into, they will have an attached UserConProfile.
+  MARKDOWN
+
   authorize_record
 
-  field :email, String, null: true
-  field :event_proposals, [Types::EventProposalType], null: false
-  field :first_name, String, null: true
-  field :id, ID, null: false
-  field :last_name, String, null: true
-  field :name, String, null: true
-  field :name_inverted, String, null: true
-  field :privileges, [String], null: true
-  field :user_con_profiles, [Types::UserConProfileType], null: false
+  field :email, String, null: true, description: "The user's email address"
+  field :event_proposals, [Types::EventProposalType], null: false, description: "The event proposals owned by this user"
+  field :first_name, String, null: true, description: "The user's first name"
+  field :id, ID, null: false, description: "The unique ID of this user"
+  field :last_name, String, null: true, description: "The user's last name"
+  field :name, String, null: true, description: "The user's full name"
+  field :name_inverted, String, null: true, description: "The user's full name in Last, First format"
+  field :privileges, [String], null: true, description: "The global privileges this user has across all conventions"
+  field :user_con_profiles, [Types::UserConProfileType], null: false do
+    description "All of the UserConProfiles owned by this user"
+  end
 
   association_loaders User, :user_con_profiles
 
@@ -20,6 +27,6 @@ class Types::UserType < Types::BaseObject
     # avoid n+1 in the policy check
     ::ActiveRecord::Associations::Preloader.new(records: event_proposals, associations: :owner).call
 
-    event_proposals
+    event_proposals.select { |p| policy(p).read? }
   end
 end

--- a/app/javascript/graphqlTypes.generated.ts
+++ b/app/javascript/graphqlTypes.generated.ts
@@ -6821,16 +6821,29 @@ export type UpdateUserConProfilePayload = {
   user_con_profile: UserConProfile;
 };
 
+/**
+ * A user on this instance of Intercode.  Users exist across all conventions.  For each convention a user has logged
+ * into, they will have an attached UserConProfile.
+ */
 export type User = {
   __typename: 'User';
+  /** The user's email address */
   email?: Maybe<Scalars['String']['output']>;
+  /** The event proposals owned by this user */
   event_proposals: Array<EventProposal>;
+  /** The user's first name */
   first_name?: Maybe<Scalars['String']['output']>;
+  /** The unique ID of this user */
   id: Scalars['ID']['output'];
+  /** The user's last name */
   last_name?: Maybe<Scalars['String']['output']>;
+  /** The user's full name */
   name?: Maybe<Scalars['String']['output']>;
+  /** The user's full name in Last, First format */
   name_inverted?: Maybe<Scalars['String']['output']>;
+  /** The global privileges this user has across all conventions */
   privileges?: Maybe<Array<Scalars['String']['output']>>;
+  /** All of the UserConProfiles owned by this user */
   user_con_profiles: Array<UserConProfile>;
 };
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -8888,15 +8888,54 @@ type UpdateUserConProfilePayload {
 
 scalar Upload
 
+"""
+A user on this instance of Intercode.  Users exist across all conventions.  For each convention a user has logged
+into, they will have an attached UserConProfile.
+"""
 type User {
+  """
+  The user's email address
+  """
   email: String
+
+  """
+  The event proposals owned by this user
+  """
   event_proposals: [EventProposal!]!
+
+  """
+  The user's first name
+  """
   first_name: String
+
+  """
+  The unique ID of this user
+  """
   id: ID!
+
+  """
+  The user's last name
+  """
   last_name: String
+
+  """
+  The user's full name
+  """
   name: String
+
+  """
+  The user's full name in Last, First format
+  """
   name_inverted: String
+
+  """
+  The global privileges this user has across all conventions
+  """
   privileges: [String!]
+
+  """
+  All of the UserConProfiles owned by this user
+  """
   user_con_profiles: [UserConProfile!]!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -39226,13 +39226,13 @@
         {
           "kind": "OBJECT",
           "name": "User",
-          "description": null,
+          "description": "A user on this instance of Intercode.  Users exist across all conventions.  For each convention a user has logged\ninto, they will have an attached UserConProfile.\n",
           "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
               "name": "email",
-              "description": null,
+              "description": "The user's email address",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -39244,7 +39244,7 @@
             },
             {
               "name": "event_proposals",
-              "description": null,
+              "description": "The event proposals owned by this user",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -39268,7 +39268,7 @@
             },
             {
               "name": "first_name",
-              "description": null,
+              "description": "The user's first name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -39280,7 +39280,7 @@
             },
             {
               "name": "id",
-              "description": null,
+              "description": "The unique ID of this user",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -39296,7 +39296,7 @@
             },
             {
               "name": "last_name",
-              "description": null,
+              "description": "The user's last name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -39308,7 +39308,7 @@
             },
             {
               "name": "name",
-              "description": null,
+              "description": "The user's full name",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -39320,7 +39320,7 @@
             },
             {
               "name": "name_inverted",
-              "description": null,
+              "description": "The user's full name in Last, First format",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -39332,7 +39332,7 @@
             },
             {
               "name": "privileges",
-              "description": null,
+              "description": "The global privileges this user has across all conventions",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -39352,7 +39352,7 @@
             },
             {
               "name": "user_con_profiles",
-              "description": null,
+              "description": "All of the UserConProfiles owned by this user",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,


### PR DESCRIPTION
When using the Become User feature, admins may encounter the error "An object of type EventProposal was hidden due to permissions".  This is because only the user themselves is allowed to view draft event proposals, even when using Become User.

This works around the issue by only returning event proposals that the current session has permissions to view.