### PR TITLE
Re-raise exceptions in Shoryuken ErrorReporter middleware

### DIFF
--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -74,6 +74,7 @@ class ErrorReporter
     yield
   rescue StandardError => e
     ErrorReporting.error(e, tags: { job: body["job_class"], queue: }, message: body)
+    raise e
   end
 end
 


### PR DESCRIPTION
Closes #11068.

## Summary
- Fix ErrorReporter middleware to re-raise exceptions after reporting them
- This enables proper retry behavior and dead-letter queue handling for failed background jobs

## Context
Previously, the ErrorReporter middleware would catch exceptions and report them to the error reporting service, but would not re-raise them. This caused Shoryuken to treat failed jobs as successful and delete the messages from SQS, preventing:
- Automatic retries based on SQS visibility timeout
- Movement to dead-letter queues after exceeding maxReceiveCount
- Proper failure handling in the background job system

## Changes
- Added `raise e` in the ErrorReporter middleware after error reporting (config/initializers/shoryuken.rb:77)

## Impact
With this change, failed background jobs will now:
- Be retried automatically according to SQS configuration
- Be moved to the dead-letter queue after too many failures
- Follow standard Shoryuken/SQS error handling patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)