### PR TITLE
Add missing cascade delete for signup_ranked_choice

### DIFF
--- a/app/models/signup.rb
+++ b/app/models/signup.rb
@@ -41,6 +41,7 @@ class Signup < ApplicationRecord
   has_one :event, through: :run
   has_one :convention, through: :event
   has_one :signup_request, foreign_key: "result_signup_id", dependent: :destroy
+  has_one :signup_ranked_choice, foreign_key: "result_signup_id", dependent: :destroy
   belongs_to :updated_by, class_name: "User", optional: true
   has_many :signup_changes, dependent: :destroy
 


### PR DESCRIPTION
## Summary
- Add `has_one :signup_ranked_choice` association with `dependent: :destroy` to the Signup model

This ensures that when a signup is deleted, any associated signup_ranked_choice record is also deleted, maintaining referential integrity.

## Test plan
- [ ] Verify that deleting a signup also deletes its associated signup_ranked_choice
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)