### PR TITLE
Use medium-sized instances during high-scale time periods

### DIFF
--- a/app/services/autoscale_servers_service.rb
+++ b/app/services/autoscale_servers_service.rb
@@ -122,7 +122,7 @@ class AutoscaleServersService < CivilService::Service
 
     adapter.apply_instance_counts(
       [
-        { group: :web, type: :small, count: web_scaling_target },
+        { group: :web, type: web_scaling_target == MIN_INSTANCES ? :small : :medium, count: web_scaling_target },
         { group: :worker, type: worker_instance_type, count: worker_scaling_target }
       ]
     )

--- a/app/services/hosting_service_adapters/fly.rb
+++ b/app/services/hosting_service_adapters/fly.rb
@@ -1,5 +1,6 @@
 class HostingServiceAdapters::Fly < HostingServiceAdapters::Base
   SMALL_GUEST = { "cpu_kind" => "shared", "cpus" => 1, "memory_mb" => 512 }
+  MEDIUM_GUEST = { "cpu_kind" => "shared", "cpus" => 4, "memory_mb" => 1024 }
   LARGE_GUEST = { "cpu_kind" => "performance", "cpus" => 1, "memory_mb" => 2048 }
 
   class Machine < HostingServiceAdapters::Instance
@@ -62,6 +63,7 @@ class HostingServiceAdapters::Fly < HostingServiceAdapters::Base
         builder.request :json
         builder.response :json
         builder.response :raise_error
+        builder.response :logger, nil, { headers: true, bodies: true, errors: true }
       end
   end
 
@@ -93,6 +95,8 @@ class HostingServiceAdapters::Fly < HostingServiceAdapters::Base
         case guest
         when SMALL_GUEST
           :small
+        when MEDIUM_GUEST
+          :medium
         when LARGE_GUEST
           :large
         else
@@ -105,6 +109,8 @@ class HostingServiceAdapters::Fly < HostingServiceAdapters::Base
     case type
     when :small
       SMALL_GUEST
+    when :medium
+      MEDIUM_GUEST
     when :large
       LARGE_GUEST
     end

--- a/app/services/hosting_service_adapters/heroku.rb
+++ b/app/services/hosting_service_adapters/heroku.rb
@@ -21,8 +21,10 @@ class HostingServiceAdapters::Heroku < HostingServiceAdapters::Base
 
             type =
               case dyno_group["dyno_size"]["name"]
-              when "eco", "basic", "standard-1X"
+              when "eco", "basic"
                 :small
+              when "standard-1X"
+                :medium
               when "standard-2X"
                 :large
               else
@@ -46,9 +48,12 @@ class HostingServiceAdapters::Heroku < HostingServiceAdapters::Base
       end
 
     dyno_size =
-      if type == :small
+      case type
+      when :small
         count == 1 ? "basic" : "standard-1X"
-      elsif type == :large
+      when :medium
+        "standard-1X"
+      when :largerge
         "standard-2X"
       end
 


### PR DESCRIPTION
This will hopefully help avoid Fly's aggressive CPU throttling.