### PR TITLE
Fix PG::UndefinedColumn: column orders.product_id does not exist

### DIFF
--- a/app/presenters/convention_reports_presenter.rb
+++ b/app/presenters/convention_reports_presenter.rb
@@ -26,14 +26,14 @@ class ConventionReportsPresenter
             .completed
             .left_joins(:order_entries)
             .group(
-              :product_id,
+              "order_entries.product_id",
               :status,
               "COALESCE(price_per_item_cents, 0)",
               "COALESCE(price_per_item_currency, #{ActiveRecord::Base.connection.quote(convention.default_currency_code_or_site_default)})"
             )
-            .where.not(product_id: nil)
+            .where.not(order_entries: { product_id: nil })
             .pluck(
-              :product_id,
+              "order_entries.product_id",
               :status,
               Arel.sql("COALESCE(price_per_item_cents, 0)"),
               Arel.sql(

--- a/test/presenters/convention_reports_presenter_test.rb
+++ b/test/presenters/convention_reports_presenter_test.rb
@@ -6,6 +6,21 @@ class ConventionReportsPresenterTest < ActiveSupport::TestCase
   let(:other_convention) { create(:convention, organization:, ticket_mode: "required_for_signup") }
   let(:presenter) { ConventionReportsPresenter.new(convention) }
 
+  describe "#sales_count_by_product_and_payment_amount" do
+    it "counts completed order entries grouped by product" do
+      profile = create(:user_con_profile, convention:)
+      product = create(:product, convention:)
+      order = create(:order, user_con_profile: profile, status: "paid")
+      create(:order_entry, order:, product:, quantity: 2, price_per_item_cents: 1000, price_per_item_currency: "USD")
+
+      result = presenter.sales_count_by_product_and_payment_amount
+
+      assert_equal 1, result.length
+      assert_equal product.id, result.first[:product_id]
+      assert_equal 2, result.first[:count]
+    end
+  end
+
   describe "#new_and_returning_attendees" do
     it "returns a new attendee who only has a ticket at this convention" do
       profile = create(:user_con_profile, convention:)


### PR DESCRIPTION
## Summary

- Fixes `PG::UndefinedColumn` crash in `ConventionReportsPresenter#sales_count_by_product_and_payment_amount`
- `product_id` lives on `order_entries`, not `orders` — the bare symbol references in `.group`, `.where.not`, and `.pluck` were being resolved against the primary `orders` table
- Qualified all three references as `"order_entries.product_id"` / `order_entries: { product_id: nil }`
- Added a regression test that reproduces the original error and passes after the fix

Fixes #11217

## Test plan

- [ ] Run `bundle exec ruby -Itest test/presenters/convention_reports_presenter_test.rb` — all 5 tests pass
- [ ] Visit the convention reports page on a convention with completed orders and verify the attendance by payment amount report loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)