### PR TITLE
Fix confirmation dialog hidden behind email editor modal

### DIFF
--- a/app/javascript/RootSiteEmailRoutesAdmin/EditEmailRouteModal.tsx
+++ b/app/javascript/RootSiteEmailRoutesAdmin/EditEmailRouteModal.tsx
@@ -65,7 +65,7 @@ function EditEmailRouteModal(): React.JSX.Element {
   }, [initialEmailRoute]);
 
   return (
-    <Modal visible dialogClassName="modal-lg">
+    <Modal visible={!confirm.visible} dialogClassName="modal-lg">
       <div className="modal-header">
         <div className="flex-grow-1">Edit email route</div>
         <button


### PR DESCRIPTION
Fixes #11227

The confirmation dialog shown when deleting an email route was appearing behind the email editor modal and couldn't be used. This is because the `Modal` component was always `visible`, so its backdrop covered the confirm dialog.

Fixed by setting `visible={!confirm.visible}` on the email editor modal, matching the pattern already used in `EditRunModal` and `EditOrderModal`.