### PR TITLE
Fix registration_policy changes not captured in event changelog

### DIFF
--- a/app/graphql/mutations/update_event.rb
+++ b/app/graphql/mutations/update_event.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 class Mutations::UpdateEvent < Mutations::BaseMutation
-  field :event, Types::EventType, null: false
+  description "Update an event"
 
-  argument :event, Types::EventInputType, required: false
-  argument :id, ID, required: false
+  field :event, Types::EventType, null: false, description: "The updated event"
+
+  argument :event, Types::EventInputType, required: false, description: "The event attributes to update"
+  argument :id, ID, required: false, description: "The ID of the event to update"
 
   load_and_authorize_convention_associated_model :events, :id, :update
 
@@ -28,11 +30,12 @@ class Mutations::UpdateEvent < Mutations::BaseMutation
     new_registration_policy = RegistrationPolicy.new(registration_policy_attributes)
     return {} if event.registration_policy == new_registration_policy
 
+    old_registration_policy = event.registration_policy
     EventChangeRegistrationPolicyService.new(event, new_registration_policy, current_user).call!
 
     event.reload
 
-    { "registration_policy" => [event.registration_policy.as_json, new_registration_policy.as_json] }
+    { "registration_policy" => [old_registration_policy.as_json, new_registration_policy.as_json] }
   end
 
   def apply_form_response_attrs(event, form_response_attrs)

--- a/test/graphql/mutations/update_event_proposal_test.rb
+++ b/test/graphql/mutations/update_event_proposal_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+# rubocop:disable GraphQL/ObjectDescription
+require "test_helper"
+
+class Mutations::UpdateEventProposalTest < ActiveSupport::TestCase
+  let(:convention) { create(:convention) }
+  let(:admin_profile) { create(:user_con_profile, convention:, user: create(:site_admin)) }
+  let(:old_registration_policy) do
+    RegistrationPolicy.new(buckets: [{ key: "unlimited", slots_limited: false, anything: true }])
+  end
+  let(:new_registration_policy) do
+    RegistrationPolicy.new(
+      buckets: [
+        { key: "players", name: "Players", slots_limited: true, total_slots: 4 },
+        { key: "anything", name: "Anything", slots_limited: true, total_slots: 2, anything: true }
+      ]
+    )
+  end
+  let(:event_proposal) do
+    create(:event_proposal, convention:, status: "proposed", registration_policy: old_registration_policy)
+  end
+
+  # Add a registration_policy form item so it passes through filter_form_response_attributes_for_assignment
+  before do
+    form = event_proposal.event_category.event_proposal_form
+    section = form.form_sections.create!(title: "Section")
+    section.form_items.create!(
+      item_type: "registration_policy",
+      identifier: "registration_policy",
+      properties: {
+        "identifier" => "registration_policy",
+        "presets" => [],
+        "allow_custom" => true
+      }
+    )
+  end
+
+  UPDATE_EVENT_PROPOSAL_MUTATION = <<~GRAPHQL
+    mutation TestUpdateEventProposal($id: ID!, $formResponseAttrsJson: String!) {
+      updateEventProposal(input: { id: $id, event_proposal: { form_response_attrs_json: $formResponseAttrsJson } }) {
+        event_proposal { id }
+      }
+    }
+  GRAPHQL
+
+  describe "updating registration_policy" do
+    before do
+      execute_graphql_query(
+        UPDATE_EVENT_PROPOSAL_MUTATION,
+        user_con_profile: admin_profile,
+        variables: {
+          "id" => event_proposal.id.to_s,
+          "formResponseAttrsJson" => { "registration_policy" => new_registration_policy.as_json }.to_json
+        }
+      )
+    end
+
+    it "creates a FormResponseChange for registration_policy" do
+      assert FormResponseChange.exists?(response: event_proposal, field_identifier: "registration_policy")
+    end
+
+    it "records the old policy as previous_value" do
+      change = FormResponseChange.find_by!(response: event_proposal, field_identifier: "registration_policy")
+      assert_equal old_registration_policy.as_json, change.previous_value
+    end
+
+    it "records the new policy as new_value" do
+      change = FormResponseChange.find_by!(response: event_proposal, field_identifier: "registration_policy")
+      assert_equal new_registration_policy.as_json, change.new_value
+    end
+
+    it "stores different previous_value and new_value" do
+      change = FormResponseChange.find_by!(response: event_proposal, field_identifier: "registration_policy")
+      assert_not_equal change.previous_value, change.new_value
+    end
+  end
+
+  describe "updating with unchanged registration_policy" do
+    it "does not create a FormResponseChange" do
+      execute_graphql_query(
+        UPDATE_EVENT_PROPOSAL_MUTATION,
+        user_con_profile: admin_profile,
+        variables: {
+          "id" => event_proposal.id.to_s,
+          "formResponseAttrsJson" => { "registration_policy" => old_registration_policy.as_json }.to_json
+        }
+      )
+
+      assert_equal(0, FormResponseChange.where(response: event_proposal, field_identifier: "registration_policy").count)
+    end
+  end
+end

--- a/test/graphql/mutations/update_event_test.rb
+++ b/test/graphql/mutations/update_event_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+# rubocop:disable GraphQL/ObjectDescription
+require "test_helper"
+
+class Mutations::UpdateEventTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  let(:convention) { create(:convention) }
+  let(:admin_profile) { create(:user_con_profile, convention:, user: create(:site_admin)) }
+  let(:old_registration_policy) do
+    RegistrationPolicy.new(buckets: [{ key: "unlimited", slots_limited: false, anything: true }])
+  end
+  let(:new_registration_policy) do
+    RegistrationPolicy.new(
+      buckets: [
+        { key: "players", name: "Players", slots_limited: true, total_slots: 4 },
+        { key: "anything", name: "Anything", slots_limited: true, total_slots: 2, anything: true }
+      ]
+    )
+  end
+  let(:event) { create(:event, convention:, registration_policy: old_registration_policy) }
+
+  UPDATE_EVENT_MUTATION = <<~GRAPHQL
+    mutation TestUpdateEvent($id: ID!, $formResponseAttrsJson: String!) {
+      updateEvent(input: { id: $id, event: { form_response_attrs_json: $formResponseAttrsJson } }) {
+        event { id }
+      }
+    }
+  GRAPHQL
+
+  describe "updating registration_policy" do
+    before do
+      execute_graphql_query(
+        UPDATE_EVENT_MUTATION,
+        user_con_profile: admin_profile,
+        variables: {
+          "id" => event.id.to_s,
+          "formResponseAttrsJson" => { "registration_policy" => new_registration_policy.as_json }.to_json
+        }
+      )
+    end
+
+    it "creates a FormResponseChange for registration_policy" do
+      assert FormResponseChange.exists?(response: event, field_identifier: "registration_policy")
+    end
+
+    it "records the old policy as previous_value" do
+      change = FormResponseChange.find_by!(response: event, field_identifier: "registration_policy")
+      assert_equal old_registration_policy.as_json, change.previous_value
+    end
+
+    it "records the new policy as new_value" do
+      change = FormResponseChange.find_by!(response: event, field_identifier: "registration_policy")
+      assert_equal new_registration_policy.as_json, change.new_value
+    end
+
+    it "stores different previous_value and new_value" do
+      change = FormResponseChange.find_by!(response: event, field_identifier: "registration_policy")
+      assert_not_equal change.previous_value, change.new_value
+    end
+  end
+
+  describe "notification email for registration_policy changes" do
+    it "includes registration_policy changes when notifying" do
+      change_profile = create(:user_con_profile, convention:)
+      FormResponseChange.create!(
+        response: event,
+        user_con_profile: change_profile,
+        field_identifier: "registration_policy",
+        previous_value: old_registration_policy.as_json,
+        new_value: new_registration_policy.as_json,
+        compacted: true
+      )
+
+      sent_changes = nil
+      NotifyFormResponseChangesService.new(
+        scope: FormResponseChange.where(response_type: "Event"),
+        send_mail: ->(_event_id, compacted_changes) { sent_changes = compacted_changes }
+      ).call!
+
+      assert_not_nil sent_changes
+      assert_equal 1, sent_changes.size
+      assert_equal "registration_policy", sent_changes.first.field_identifier
+      assert_not_equal sent_changes.first.previous_value, sent_changes.first.new_value
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes a bug where updating an event's registration policy via the `UpdateEvent` mutation would record the **same value** for both `previous_value` and `new_value` in the `FormResponseChange` changelog entry
- The root cause: `apply_registration_policy` called `event.reload` after `EventChangeRegistrationPolicyService`, which overwrote the in-memory event with the saved new policy — so `event.registration_policy` was already the new policy when we tried to capture the old one
- Fix: capture `old_registration_policy = event.registration_policy` before calling the service and reload

## Test plan

- [ ] Added `test/graphql/mutations/update_event_test.rb` with tests that verify:
  - A `FormResponseChange` is created for `registration_policy` changes
  - `previous_value` is the old policy, not the new one
  - `new_value` is the new policy
  - `previous_value` and `new_value` are different
  - Registration policy changes flow through to `NotifyFormResponseChangesService`
- [ ] Added `test/graphql/mutations/update_event_proposal_test.rb` with tests that verify:
  - Proposal registration_policy changes are also captured correctly
  - Unchanged registration_policy does not create a spurious `FormResponseChange`

Fixes #10998

🤖 Generated with [Claude Code](https://claude.com/claude-code)