### PR TITLE
Clear historic bucket_keys before adding null constraint

### DIFF
--- a/db/migrate/20260321193050_add_bucket_key_null_constraint_to_signups.rb
+++ b/db/migrate/20260321193050_add_bucket_key_null_constraint_to_signups.rb
@@ -1,5 +1,13 @@
 class AddBucketKeyNullConstraintToSignups < ActiveRecord::Migration[8.1]
   def up
+    # Clear bucket_key on withdrawn/waitlisted signups that predate the fix in EventWithdrawService
+    # (prior to March 2020, withdrawals did not null out bucket_key)
+    execute <<~SQL
+      UPDATE signups SET bucket_key = NULL
+        WHERE state NOT IN ('confirmed', 'ticket_purchase_hold')
+          AND bucket_key IS NOT NULL
+    SQL
+
     execute <<~SQL
       ALTER TABLE signups
         ADD CONSTRAINT bucket_key_null_for_non_slot_occupying_states


### PR DESCRIPTION
### Purpose

When we added the DB constraint that `bucket_key` must be null for non-slot-occupying signups, it turned out production had some old withdrawn signups with non-null `bucket_key` values. These dated back to before March 2020, when `EventWithdrawService` only set `state: 'withdrawn'` without also nulling out `bucket_key`. That was fixed in commit `f4ef1e3269`, but the old records were never cleaned up.

I ran the data fix manually on production before adding the constraint, but anyone else running the migration on a database with pre-2020 data would hit a `CheckViolation` error. This adds an `UPDATE` to the migration itself so it clears those stale values first.

### Changes

🗄 Database Migrations
- Before adding the `CHECK` constraint, null out `bucket_key` on any signup whose state is not `confirmed` or `ticket_purchase_hold`

### Release plan and notes

🚢

🤖 Generated with [Claude Code](https://claude.com/claude-code)