### PR TITLE
Add missing dnsmasq setup instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,24 @@ domain intercode.test
 nameserver 127.0.0.1
 ```
 
+This tells macOS that for intercode.test and all its subdomains, it should use the DNS server running on your local machine to resolve them. Next, we'll need to put a DNS server on your local machine. Run this to install dnsmasq:
+
+```text
+brew install dnsmasq
+```
+
+Edit the file at /opt/homebrew/etc/dnsmasq.conf and add the following content:
+
+```text
+address=/intercode.test/127.0.0.1
+```
+
+Finally, run this to get dnsmasq started and configure it to automatically start whenever your computer starts:
+
+```text
+sudo brew services start dnsmasq
+```
+
 To test that this is working, try running `ping randomname.intercode.test`. It should start pinging your local machine on 127.0.0.1.
 
 </details>
@@ -195,7 +213,7 @@ To test that this is working, try running `ping randomname.intercode.test`. It s
 
 <summary>Linux</summary>
 
-On Linux, there's no built-in way to do wildcard domain resolution like there is with macOS's resolver. But, we can use dnsmasq as a DNS resolver proxy and configure it to resolve \*.intercode.test to 127.0.0.1. First, install dnsmasq:
+On Linux, there's no built-in way to do host-specific DNS resolution like there is with macOS's resolver. But, we can use dnsmasq as a DNS resolver proxy and configure it to resolve \*.intercode.test to 127.0.0.1. First, install dnsmasq:
 
 ```sh
 sudo apt install dnsmasq
@@ -245,7 +263,7 @@ To test that this is working, try running `ping randomname.intercode.test`. It s
 <details>
 <summary>Windows</summary>
 
-On Windows, there's no built-in way to do wildcard domain resolution like there is with macOS's resolver. But, we can use a DNS resolver proxy such as [Acrylic](https://mayakron.altervista.org/support/acrylic/Home.htm) and configure it to resolve \*.intercode.test to 127.0.0.1.
+On Windows, there's no built-in way to do host-specific DNS resolution like there is with macOS's resolver. But, we can use a DNS resolver proxy such as [Acrylic](https://mayakron.altervista.org/support/acrylic/Home.htm) and configure it to resolve \*.intercode.test to 127.0.0.1.
 
 I have not personally tried this, but if someone does and would like to contribute instructions to this README, I would be forever grateful!
 


### PR DESCRIPTION
### Purpose

The macOS section of the wildcard DNS setup instructions in README.md was missing the actual dnsmasq installation and configuration steps. It jumped straight from setting up the resolver file to testing with `ping`, leaving out the critical steps of installing dnsmasq and configuring it to resolve `*.intercode.test` to `127.0.0.1`. This would leave someone following the instructions confused about why the ping test doesn't work.

Also cleaned up a small inconsistency where Linux and Windows sections described the macOS resolver as supporting "wildcard domain resolution" — it actually does host-specific resolution via resolver files, not wildcards. macOS's resolver mechanism sends queries for a given domain to a specified nameserver, and dnsmasq is still the piece doing the wildcard matching.

### Testing

Verified the instructions are complete and accurate by reading through the full setup flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)