### PR TITLE
Lock connection_pool to 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ gem "rails", "8.1.1"
 # benchmark was removed from Ruby's default gems in Ruby 4.0; required by mini_magick
 gem "benchmark"
 
+# locking to connection_pool 2.x until ActiveSupport's memcachestore supports the v3 API
+# see https://github.com/mperham/connection_pool/issues/212
+gem "connection_pool", "< 3"
+
 gem "pg"
 gem "puma"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
     cgi (0.4.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crass (1.0.6)
     csv (3.3.5)
     cuprite (0.17)
@@ -720,6 +720,7 @@ DEPENDENCIES
   capybara
   civil_service!
   cloudwatch_scheduler!
+  connection_pool (< 3)
   csv
   cuprite
   dalli


### PR DESCRIPTION
### Purpose

`connection_pool` 3.x was recently released and got pulled in as a transitive dependency upgrade, but ActiveSupport's `MemCacheStore` doesn't support the new v3 API yet. This locks it back to 2.x until that compatibility lands.

See the upstream issue for details: https://github.com/mperham/connection_pool/issues/212

### Release plan and notes

🚢

🤖 Generated with [Claude Code](https://claude.com/claude-code)