### PR TITLE
Fix infinite redirect loop when signing in via third-party OAuth app

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,13 +2,29 @@
 class SessionsController < Devise::SessionsController
   include RedirectWithAuthentication
 
-  prepend_before_action :set_return_to, only: %i[new create]
+  prepend_before_action :set_return_to, only: [:new]
 
   def new
-    respond_to { |format| format.html { redirect_with_authentication('signIn') } }
+    respond_to do |format|
+      format.html do
+        if oauth_authorize_flow?
+          # Redirecting back to the OAuth URL would loop: Doorkeeper would
+          # again see no signed-in user and send us right back here.  Instead,
+          # open the sign-in modal on the root page; after sign-in Devise will
+          # redirect to session[:user_return_to] (the OAuth URL).
+          redirect_to root_url(show_authentication: "signIn")
+        else
+          redirect_with_authentication("signIn")
+        end
+      end
+    end
   end
 
   private
+
+  def oauth_authorize_flow?
+    session[:user_return_to]&.start_with?("/oauth/authorize")
+  end
 
   def set_return_to
     return if params[:user_return_to].blank?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,26 +5,10 @@ class SessionsController < Devise::SessionsController
   prepend_before_action :set_return_to, only: [:new]
 
   def new
-    respond_to do |format|
-      format.html do
-        if oauth_authorize_flow?
-          # Redirecting back to the OAuth URL would loop: Doorkeeper would
-          # again see no signed-in user and send us right back here.  Instead,
-          # open the sign-in modal on the root page; after sign-in Devise will
-          # redirect to session[:user_return_to] (the OAuth URL).
-          redirect_to root_url(show_authentication: "signIn")
-        else
-          redirect_with_authentication("signIn")
-        end
-      end
-    end
+    respond_to { |format| format.html { redirect_with_authentication("signIn") } }
   end
 
   private
-
-  def oauth_authorize_flow?
-    session[:user_return_to]&.start_with?("/oauth/authorize")
-  end
 
   def set_return_to
     return if params[:user_return_to].blank?

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -13,16 +13,7 @@ Doorkeeper.configure do
   orm :active_record
 
   # This block will be called to check whether the resource owner is authenticated or not.
-  resource_owner_authenticator do
-    if user_signed_in?
-      current_user
-    else
-      # Redirect to login page, preserving the OAuth parameters
-      session[:user_return_to] = request.fullpath
-      redirect_to new_user_session_url
-      nil
-    end
-  end
+  resource_owner_authenticator { user_signed_in? ? current_user : NullResourceOwner.new }
 
   # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
   # file then you need to declare this block in order to restrict access to the web interface for


### PR DESCRIPTION
### Purpose

Since v6.16.0, users trying to sign in via a third-party OAuth relying app (like survey.interconlarp.org) would hit an infinite redirect loop instead of being prompted to sign in.

The root cause was a change in `resource_owner_authenticator` in `doorkeeper.rb`: when an unauthenticated user hit `/oauth/authorize`, Doorkeeper was redirecting them to `/users/sign_in` and storing the OAuth authorize URL in `session[:user_return_to]`. Then `SessionsController#new` called `redirect_with_authentication`, which reads that stored URL and appends `show_authentication=signIn` — sending the user straight back to `/oauth/authorize`. Doorkeeper sees no signed-in user and bounces them back to `/users/sign_in`. Repeat indefinitely.

The fix is to revert `resource_owner_authenticator` to return `NullResourceOwner.new` for unauthenticated users, which was the original behavior. This lets Doorkeeper render the authorization page, and the `AuthorizationPrompt` React component already handles the unauthenticated case correctly: it detects `!data.currentUser`, opens the sign-in modal, and sets `afterSignInPath` to the OAuth URL so the user is returned to the consent page after signing in. The `NullResourceOwner` approach wasn't a hack — it was the correct design that let the React component do its job.

### Changes

- Revert `resource_owner_authenticator` to `NullResourceOwner.new`
- Drop `create` from `set_return_to`'s `only` list (it's redundant — `session[:user_return_to]` is already set during `new`, and RuboCop flags `create` as not being defined on the class)

### Testing

Reproduced the loop locally using the HAR from the bug report, then verified it no longer occurs with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)