### PR TITLE
Set max_age on PKCE refresh cookie to fix mobile logout

### DIFF
--- a/app/controllers/oauth_sessions_controller.rb
+++ b/app/controllers/oauth_sessions_controller.rb
@@ -99,7 +99,7 @@ class OAuthSessionsController < ApplicationController
   # rubocop:enable Naming/AccessorMethodName
 
   def clear_refresh_cookie
-    cookies.delete(COOKIE_NAME, **cookie_attributes)
+    cookies.delete(COOKIE_NAME, **cookie_attributes.except(:max_age))
   end
 
   # `__Host-` prefix requires `Secure`, no `Domain`, and `Path=/`. Browsers

--- a/app/controllers/oauth_sessions_controller.rb
+++ b/app/controllers/oauth_sessions_controller.rb
@@ -105,7 +105,7 @@ class OAuthSessionsController < ApplicationController
   # `__Host-` prefix requires `Secure`, no `Domain`, and `Path=/`. Browsers
   # reject cookies with that prefix that don't meet these conditions.
   def cookie_attributes
-    { httponly: true, secure: true, same_site: :strict, path: "/" }
+    { httponly: true, secure: true, same_site: :strict, path: "/", max_age: 90.days.to_i }
   end
 
   def render_oauth_error(error_code, description = nil, status:)


### PR DESCRIPTION
### Purpose

Mobile users were being logged out whenever they closed their browser because the `__Host-intercode_refresh` cookie had no `max_age`, making it a session cookie. Browsers discard session cookies on close, which invalidates the PKCE refresh token and forces users to log in again.

This adds `max_age: 90.days.to_i` to `cookie_attributes` in `OAuthSessionsController`, giving the cookie a 90-day lifetime that survives browser restarts.

### Release plan and notes

🚢

🤖 Generated with [Claude Code](https://claude.com/claude-code)