### PR TITLE
Move towards fully-static HTML page serving

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -75,9 +75,22 @@ Rails/RefuteMethods:
 # Offense count: 3
 # Configuration parameters: ForbiddenMethods, AllowedMethods.
 # ForbiddenMethods: decrement!, decrement_counter, increment!, increment_counter, insert, insert!, insert_all, insert_all!, toggle!, touch, touch_all, update_all, update_attribute, update_column, update_columns, update_counters, upsert, upsert_all
+Rails/HasAndBelongsToMany:
+  Exclude:
+    - 'app/models/page.rb'
+
+Rails/HasManyOrHasOneDependent:
+  Exclude:
+    - 'app/models/page.rb'
+
+Rails/HelperInstanceVariable:
+  Exclude:
+    - 'app/helpers/application_helper.rb'
+
 Rails/SkipsModelValidations:
   Exclude:
     - 'app/controllers/application_controller.rb'
+    - 'app/models/page.rb'
     - 'db/migrate/20251229184620_allow_null_redirect_uri_on_oauth_appliations.rb'
 
 # Offense count: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,13 @@ Intercode is a convention management system built with:
 - **TypeScript**: Run `yarn run tsc --noEmit` after making changes
 - **Ruby**: Run the relevant test suite before committing
 
+## Deployment Model
+
+Intercode is shipped as a Docker container with the frontend assets **pre-built at image build time**. Environment variables (including `ASSETS_HOST`, `SENTRY_FRONTEND_DSN`, `ROLLBAR_CLIENT_ACCESS_TOKEN`, etc.) are injected at **container runtime**, not at build time. This means:
+
+- Do not use Vite `define`, `import.meta.env`, or any other build-time constant substitution for runtime env vars.
+- Runtime configuration must be delivered to the browser via a server-rendered response (e.g. the `GET /client_configuration` endpoint) or a server-rendered HTML attribute, never baked into the JS bundle.
+
 ## Testing Requirements
 
 Whenever changing signup-related functionality (signup services, ranked choice, waitlists, etc.), always add or update tests in the relevant test file under `test/services/` or `test/models/`.

--- a/app/controllers/client_configuration_controller.rb
+++ b/app/controllers/client_configuration_controller.rb
@@ -16,7 +16,10 @@ class ClientConfigurationController < ApplicationController
              oidc_issuer_url: oidc_issuer_url,
              rails_default_active_storage_service_name: Rails.application.config.active_storage.service.to_s,
              rails_direct_uploads_url: rails_direct_uploads_url,
-             recaptcha_site_key: Recaptcha.configuration.site_key
+             recaptcha_site_key: Recaptcha.configuration.site_key,
+             assets_host: ENV["ASSETS_HOST"].presence,
+             sentry_frontend_dsn: ENV["SENTRY_FRONTEND_DSN"].presence,
+             rollbar_client_access_token: ENV["ROLLBAR_CLIENT_ACCESS_TOKEN"].presence
            }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,13 +18,7 @@ module ApplicationHelper
   end
 
   def open_graph_description_for_page(page)
-    return page.meta_description if page.meta_description.present?
-
-    Rails
-      .cache
-      .fetch(["open_graph_description", page], expires_in: 1.day) do
-        strip_tags(cms_rendering_context.render_page_content(@page)).gsub(/\s+/, " ").strip.truncate(160)
-      end
+    page.meta_description.presence || page.cached_og_description
   end
 
   def application_entry_path

--- a/app/javascript/@types/globals.d.ts
+++ b/app/javascript/@types/globals.d.ts
@@ -1,6 +1,4 @@
 interface Window {
   intercodeAssetsHost?: string;
-  sentryFrontendDSN?: string;
-  rollbarClientAccessToken?: string;
   __intercodeAssetURL: (filename: string) => string;
 }

--- a/app/javascript/AppContexts.ts
+++ b/app/javascript/AppContexts.ts
@@ -13,6 +13,9 @@ export type ClientConfiguration = {
   rails_default_active_storage_service_name: string;
   rails_direct_uploads_url: string;
   recaptcha_site_key: string | null;
+  assets_host: string | null;
+  sentry_frontend_dsn: string | null;
+  rollbar_client_access_token: string | null;
 };
 
 export const authenticityTokensManagerContext = createContext<AuthenticityTokensManager>();

--- a/app/javascript/AppRoot.tsx
+++ b/app/javascript/AppRoot.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo, useState, useEffect, useRef } from 'react';
-import { useLocation, useLoaderData, Outlet, useNavigation } from 'react-router';
+import { useLocation, useLoaderData, useRouteLoaderData, Outlet, useNavigation } from 'react-router';
 import { Settings } from 'luxon';
 import { PageLoadingIndicator } from '@neinteractiveliterature/litform';
 
@@ -12,6 +12,7 @@ import { LazyStripeContext } from './LazyStripe';
 import { Stripe } from '@stripe/stripe-js';
 import { reloadOnAppEntrypointHeadersMismatch } from './checkAppEntrypointHeadersMatch';
 import { initErrorReporting } from 'ErrorReporting';
+import { RootLoaderData } from 'root';
 
 export function buildAppRootContextValue(
   data: AppRootQueryData | null | undefined,
@@ -81,10 +82,15 @@ function AppRoot(): React.JSX.Element {
   const navigationBarRef = useRef<HTMLElement>(null);
 
   const [stripePromise, setStripePromise] = useState<Promise<Stripe | null> | null>(null);
+  const rootLoaderData = useRouteLoaderData('root') as RootLoaderData | undefined;
 
   useEffect(() => {
-    initErrorReporting(data.currentUser?.id);
-  }, [data?.currentUser?.id]);
+    initErrorReporting(
+      data.currentUser?.id,
+      rootLoaderData?.clientConfiguration?.sentry_frontend_dsn,
+      rootLoaderData?.clientConfiguration?.rollbar_client_access_token,
+    );
+  }, [data?.currentUser?.id, rootLoaderData?.clientConfiguration]);
 
   useEffect(() => {
     reloadOnAppEntrypointHeadersMismatch();

--- a/app/javascript/ErrorReporting.ts
+++ b/app/javascript/ErrorReporting.ts
@@ -25,10 +25,10 @@ class ErrorReporting {
     return ErrorReporting.instance!;
   }
 
-  constructor(currentUserId: string | undefined) {
-    if (window.sentryFrontendDSN) {
+  constructor(currentUserId: string | undefined, sentryDsn?: string | null, rollbarToken?: string | null) {
+    if (sentryDsn) {
       import('@sentry/browser').then((Sentry) => {
-        const instance = Sentry.init({ dsn: window.sentryFrontendDSN });
+        const instance = Sentry.init({ dsn: sentryDsn });
         if (instance != null) {
           this.sentry = {
             instance,
@@ -42,10 +42,10 @@ class ErrorReporting {
       });
     }
 
-    if (window.rollbarClientAccessToken) {
+    if (rollbarToken) {
       import('rollbar').then((Rollbar) => {
         this.rollbar = Rollbar.default.init({
-          accessToken: window.rollbarClientAccessToken,
+          accessToken: rollbarToken,
           captureUncaught: true,
           captureUnhandledRejections: true,
           captureIp: 'anonymize',

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -62,6 +62,11 @@ const bootstrapPromise: Promise<Bootstrap> = (async () => {
     window.location.href = redirectUrl.toString();
   });
 
+  // Make the CDN host available for lazy chunk loading (renderBuiltUrl reads this at call time).
+  if (clientConfiguration.assets_host) {
+    window.intercodeAssetsHost = clientConfiguration.assets_host;
+  }
+
   return { clientConfiguration, authenticityTokensManager, authManager, client };
 })();
 
@@ -73,6 +78,7 @@ function DataModeApplicationEntry() {
       createBrowserRouter(
         [
           {
+            id: 'root',
             lazy: () => import('root'),
             children: appRootRoutes,
           },

--- a/app/javascript/root.tsx
+++ b/app/javascript/root.tsx
@@ -11,7 +11,7 @@ import AuthenticityTokensManager, { AuthenticityTokensContext } from 'Authentici
 import { StrictMode } from 'react';
 import { LoaderFunction, useLoaderData } from 'react-router';
 
-type RootLoaderData = {
+export type RootLoaderData = {
   clientConfiguration: ClientConfiguration;
   authenticityTokensManager: AuthenticityTokensManager;
   client: ApolloClient;

--- a/app/jobs/cache_page_og_description_job.rb
+++ b/app/jobs/cache_page_og_description_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CachePageOgDescriptionJob < ApplicationJob
+  def perform(page)
+    page.update_column(:cached_og_description, page.compute_og_description) # rubocop:disable Rails/SkipsModelValidations
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -11,6 +11,7 @@
 #  invariant                :boolean          default(FALSE), not null
 #  meta_description         :text
 #  name                     :text
+#  og_description           :text
 #  parent_type              :string
 #  skip_clickwrap_agreement :boolean          default(FALSE), not null
 #  slug                     :string
@@ -46,6 +47,7 @@ class Page < ApplicationRecord
 
   before_commit :set_performance_metadata, on: %i[create update]
   after_commit :touch_parent
+  after_commit :enqueue_cache_og_description_job, on: %i[create update]
 
   multisearchable(
     against: %i[name content_for_search],
@@ -84,6 +86,17 @@ class Page < ApplicationRecord
     ""
   end
 
+  def compute_og_description
+    convention = parent.is_a?(Convention) ? parent : nil
+    strip_tags(CmsContentFinder.new(convention).cms_rendering_context.render_page_content(self))
+      .gsub(/\s+/, " ")
+      .strip
+      .truncate(160)
+  rescue StandardError => e
+    Rails.logger.debug e
+    ""
+  end
+
   private
 
   def set_performance_metadata
@@ -94,5 +107,9 @@ class Page < ApplicationRecord
 
   def touch_parent
     parent.touch if parent&.persisted?
+  end
+
+  def enqueue_cache_og_description_job
+    CachePageOgDescriptionJob.perform_later(self)
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,12 +6,12 @@
 #
 #  id                       :bigint           not null, primary key
 #  admin_notes              :text
+#  cached_og_description    :text
 #  content                  :text
 #  hidden_from_search       :boolean          default(FALSE), not null
 #  invariant                :boolean          default(FALSE), not null
 #  meta_description         :text
 #  name                     :text
-#  og_description           :text
 #  parent_type              :string
 #  skip_clickwrap_agreement :boolean          default(FALSE), not null
 #  slug                     :string

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,16 +1,5 @@
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
 <title><%= page_title %></title>
-<script type="application/javascript">
-  <% if ENV['ASSETS_HOST'].present? -%>
-    window.intercodeAssetsHost = <%=raw ENV['ASSETS_HOST'].to_json %>;
-  <% end -%>
-  <% if ENV['SENTRY_FRONTEND_DSN'].present? -%>
-    window.sentryFrontendDSN = <%=raw ENV['SENTRY_FRONTEND_DSN'].to_json %>;
-  <% end -%>
-  <% if ENV["ROLLBAR_CLIENT_ACCESS_TOKEN"].present? -%>
-    window.rollbarClientAccessToken = <%=raw ENV['ROLLBAR_CLIENT_ACCESS_TOKEN'].to_json %>;
-  <% end -%>
-</script>
 <% if Rails.env.development? %>
   <script type="module">
     import RefreshRuntime from <%=raw url_with_possible_host("/@react-refresh", ENV['ASSETS_HOST']).to_json %>

--- a/db/migrate/20260601000000_add_og_description_to_pages.rb
+++ b/db/migrate/20260601000000_add_og_description_to_pages.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddOgDescriptionToPages < ActiveRecord::Migration[8.1]
+  def change
+    add_column :pages, :cached_og_description, :text
+    reversible { |dir| dir.up { Page.find_each { |page| CachePageOgDescriptionJob.perform_later(page) } } }
+  end
+end

--- a/db/migrate/20260601000000_add_og_description_to_pages.rb
+++ b/db/migrate/20260601000000_add_og_description_to_pages.rb
@@ -3,6 +3,13 @@
 class AddOgDescriptionToPages < ActiveRecord::Migration[8.1]
   def change
     add_column :pages, :cached_og_description, :text
-    reversible { |dir| dir.up { Page.find_each { |page| CachePageOgDescriptionJob.perform_later(page) } } }
+    reversible do |dir|
+      dir.up do
+        Page.find_each do |page|
+          say "Caching OpenGraph description for #{page.parent&.name || "root site"} #{page.name}"
+          CachePageOgDescriptionJob.perform_now(page)
+        end
+      end
+    end
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2136,7 +2136,8 @@ CREATE TABLE public.pages (
     invariant boolean DEFAULT false NOT NULL,
     skip_clickwrap_agreement boolean DEFAULT false NOT NULL,
     hidden_from_search boolean DEFAULT false NOT NULL,
-    meta_description text
+    meta_description text,
+    cached_og_description text
 );
 
 
@@ -6160,6 +6161,7 @@ ALTER TABLE ONLY public.cms_files_pages
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260601000000'),
 ('20260524175914'),
 ('20260519000000'),
 ('20260409003354'),

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include Devise::Test::IntegrationHelpers
+
+  Capybara.default_max_wait_time = 10
 
   driven_by :cuprite,
             screen_size: [1200, 800],

--- a/test/factories/pages.rb
+++ b/test/factories/pages.rb
@@ -6,12 +6,12 @@
 #
 #  id                       :bigint           not null, primary key
 #  admin_notes              :text
+#  cached_og_description    :text
 #  content                  :text
 #  hidden_from_search       :boolean          default(FALSE), not null
 #  invariant                :boolean          default(FALSE), not null
 #  meta_description         :text
 #  name                     :text
-#  og_description           :text
 #  parent_type              :string
 #  skip_clickwrap_agreement :boolean          default(FALSE), not null
 #  slug                     :string

--- a/test/factories/pages.rb
+++ b/test/factories/pages.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rubocop:disable Layout/LineLength, Lint/RedundantCopDisableDirective
 # == Schema Information
 #
@@ -10,6 +11,7 @@
 #  invariant                :boolean          default(FALSE), not null
 #  meta_description         :text
 #  name                     :text
+#  og_description           :text
 #  parent_type              :string
 #  skip_clickwrap_agreement :boolean          default(FALSE), not null
 #  slug                     :string

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -33,7 +33,37 @@
 require "test_helper"
 
 class PageTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  include ActiveJob::TestHelper
+
+  let(:convention) { create(:convention) }
+
+  describe "#compute_og_description" do
+    it "strips HTML tags and truncates to 160 characters" do
+      page = create(:page, parent: convention, content: "<p>#{"a" * 200}</p>")
+      result = page.compute_og_description
+      assert_equal 160, result.length
+      assert_no_match(%r{</?p>}, result)
+    end
+
+    it "returns the plain text content for short pages" do
+      page = create(:page, parent: convention, content: "Hello world")
+      assert_equal "Hello world", page.compute_og_description
+    end
+
+    it "returns an empty string if rendering raises" do
+      page = create(:page, parent: convention, content: "Hello world")
+      CmsContentFinder.stub(:new, ->(*) { raise "boom" }) { assert_equal "", page.compute_og_description }
+    end
+  end
+
+  describe "after save" do
+    it "enqueues CachePageOgDescriptionJob on create" do
+      assert_enqueued_with(job: CachePageOgDescriptionJob) { create(:page, parent: convention) }
+    end
+
+    it "enqueues CachePageOgDescriptionJob on update" do
+      page = create(:page, parent: convention)
+      assert_enqueued_with(job: CachePageOgDescriptionJob) { page.update!(name: "Updated") }
+    end
+  end
 end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -6,12 +6,12 @@
 #
 #  id                       :bigint           not null, primary key
 #  admin_notes              :text
+#  cached_og_description    :text
 #  content                  :text
 #  hidden_from_search       :boolean          default(FALSE), not null
 #  invariant                :boolean          default(FALSE), not null
 #  meta_description         :text
 #  name                     :text
-#  og_description           :text
 #  parent_type              :string
 #  skip_clickwrap_agreement :boolean          default(FALSE), not null
 #  slug                     :string

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # rubocop:disable Layout/LineLength, Lint/RedundantCopDisableDirective
 # == Schema Information
 #
@@ -10,6 +11,7 @@
 #  invariant                :boolean          default(FALSE), not null
 #  meta_description         :text
 #  name                     :text
+#  og_description           :text
 #  parent_type              :string
 #  skip_clickwrap_agreement :boolean          default(FALSE), not null
 #  slug                     :string


### PR DESCRIPTION
### Purpose

First step toward serving a fully static HTML shell for all SPA routes. The main blockers are runtime env vars injected as JS globals in `_head.html.erb` and Open Graph metadata generated from the DB. This PR tackles the env vars and lays the groundwork for static OG metadata.

### Changes

💻 **Move env var globals into `/client_configuration`**

`_head.html.erb` previously injected `intercodeAssetsHost`, `sentryFrontendDSN`, and `rollbarClientAccessToken` as `window.*` globals via an inline `<script>` block. All three now come from the `/client_configuration` JSON endpoint, which the SPA already fetches at boot.

- `GET /client_configuration` now returns `assets_host`, `sentry_frontend_dsn`, and `rollbar_client_access_token`
- `ErrorReporting` constructor accepts `sentryDsn` and `rollbarToken` as explicit params instead of reading from `window`
- `AppRoot` reads those values via `useRouteLoaderData('root')` and passes them to `initErrorReporting`
- After bootstrap resolves, `window.intercodeAssetsHost` is set from `clientConfiguration.assets_host` so lazy route chunks still use the CDN
- Inline `<script>` block removed from `_head.html.erb`

💻 **Cache OG description on the `pages` table**

Investigation of the SPA controller logs revealed that `open_graph_description_for_page` was doing a full Liquid render of the CMS page on every cold-cache request (70+ queries, ~150ms). Even with Rails.cache warmed, this was unnecessary complexity.

Adds a `cached_og_description` column to `pages`, populated by `CachePageOgDescriptionJob` on every page create/update. The job renders the page in a logged-out `CmsRenderingContext` (same pattern as `content_for_search`) and strips/truncates to 160 chars. `open_graph_description_for_page` now just reads the column — no more Rails.cache, no more on-demand Liquid rendering. A migration backfill enqueues the job for all existing pages.

💻 **Increase Capybara wait time for system tests**

Bumps `Capybara.default_max_wait_time` from 2s to 10s to reduce flaky failures on slow CI containers.

### Risks

On cold load, initial JS chunks fall back to loading from the origin server (`/packs/...`) rather than the CDN, since `window.intercodeAssetsHost` isn't set until after the bootstrap fetch. This is fine — the origin server serves `/packs` — and lazy-loaded route chunks after first render use the CDN as before. Verified against s.consequences.org.uk which uses the `Dockerfile.assets` setup.

Existing pages will have `cached_og_description: nil` until the backfill jobs run. During that window `open_graph_description_for_page` returns nil (blank OG description tag), same as the current cold-cache behaviour.

### Release plan and notes

🚢

🤖 Generated with [Claude Code](https://claude.com/claude-code)