### PR TITLE
Fix SES configuration set name regression

### DIFF
--- a/terraform/modules/ses_email_receiving/main.tf
+++ b/terraform/modules/ses_email_receiving/main.tf
@@ -189,7 +189,7 @@ resource "aws_ses_receipt_rule" "store_and_notify" {
 
 # SES configuration set with CloudWatch event tracking.
 resource "aws_ses_configuration_set" "default" {
-  name = "${var.name}-default"
+  name = var.configuration_set_name
 }
 
 resource "aws_ses_event_destination" "cloudwatch" {

--- a/terraform/modules/ses_email_receiving/variables.tf
+++ b/terraform/modules/ses_email_receiving/variables.tf
@@ -17,3 +17,9 @@ variable "iam_group_name" {
   description = "Name of the IAM group to attach the email-receiving policy to (from intercode_aws_resources.iam_group_name)."
   type        = string
 }
+
+variable "configuration_set_name" {
+  description = "Name of the SES configuration set. Defaults to 'default' to match the pre-existing account configuration."
+  type        = string
+  default     = "default"
+}


### PR DESCRIPTION
### Purpose

The `ses_email_receiving` module was naming the SES configuration set `"${var.name}-default"` (e.g. `"intercode_production-default"`). When neil-terraform applied the module, Terraform deleted the pre-existing `"default"` configuration set and created a new one with the new name.

The AWS account has `"default"` set as the account-level SES default configuration set, so all SES sends immediately started failing with `ConfigurationSetDoesNotExist`.

Fixes it by adding a `configuration_set_name` variable that defaults to `"default"`, preserving the existing resource name. The variable is there if someone ever needs to override it, but the default matches what was there before.

### Release plan and notes

Needs to be applied via neil-terraform immediately to restore the `"default"` configuration set. The Terraform plan should show a rename back from `"intercode_production-default"` → `"default"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)