### PR TITLE
Switch SES delivery to :ses_v2 with configurable configuration set

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,6 +47,7 @@ Lint/NoReturnInBeginEndBlocks:
 # AllowedMethods: refine
 Metrics/BlockLength:
   Exclude:
+    - 'config/environments/production.rb'
     - 'config/initializers/doorkeeper.rb'
 
 # Offense count: 4

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path("lib/intercode/disable_caching_for_specific_assets", Rails.root)
 
 Rails.application.configure do
@@ -61,14 +62,15 @@ Rails.application.configure do
     config.cache_store =
       :mem_cache_store,
       ENV["MEMCACHEDCLOUD_SERVERS"].split(","),
-      { username: ENV["MEMCACHEDCLOUD_USERNAME"], password: ENV["MEMCACHEDCLOUD_PASSWORD"] }
+      { username: ENV.fetch("MEMCACHEDCLOUD_USERNAME", nil), password: ENV.fetch("MEMCACHEDCLOUD_PASSWORD", nil) }
   end
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "intercode_#{Rails.env}"
 
-  config.action_mailer.delivery_method = :ses
+  config.action_mailer.delivery_method = :ses_v2
+  config.action_mailer.ses_v2_settings = { configuration_set_name: ENV["SES_CONFIGURATION_SET"].presence }.compact
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
@@ -101,14 +103,14 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new unless ENV["JSON_LOGGING"]
+  config.log_formatter = Logger::Formatter.new unless ENV["JSON_LOGGING"]
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger = (ENV["JSON_LOGGING"] ? logger : ActiveSupport::TaggedLogging.new(logger))
   end

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -11,7 +12,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are enabled and caching is turned on.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = true
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
@@ -22,7 +23,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = true if ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true if ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   # config.assets.js_compressor = :uglifier
@@ -64,8 +65,9 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.delivery_method = :ses
-  config.action_mailer.default_url_options = { host: 'stage.interconlarp.org' }
+  config.action_mailer.delivery_method = :ses_v2
+  config.action_mailer.ses_v2_settings = { configuration_set_name: ENV["SES_CONFIGURATION_SET"].presence }.compact
+  config.action_mailer.default_url_options = { host: "stage.interconlarp.org" }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -75,7 +77,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
### Purpose

Follow-up to the hotfix that restored the `"default"` SES configuration set name in Terraform. The v1 `:ses` mailer has no way to specify a configuration set name in its settings — it just fires `send_raw_email` with no `ConfigurationSetName` parameter, leaving the app implicitly dependent on the AWS account-level default.

The v1 gem's `:ses_v2` mailer supports `configuration_set_name` in `ses_v2_settings`, so switching lets us pass `SES_CONFIGURATION_SET` as a runtime env var and make the dependency explicit rather than hidden in account configuration.

When `SES_CONFIGURATION_SET` is unset, the setting is omitted and sends go through without an explicit configuration set (falling back to whatever the account default is).

### Release plan and notes

Set `SES_CONFIGURATION_SET=default` in the Fly.io config before or alongside deploying this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)