### PR TITLE
Add AppRoot body content to CDN SPA shell

### DIFF
--- a/app/views/layouts/cdn_spa_shell.html.erb
+++ b/app/views/layouts/cdn_spa_shell.html.erb
@@ -27,6 +27,8 @@
   <% end -%>
 </head>
 <body>
-  <%= yield %>
+  <%= browser_warning %>
+  <%= CmsRenderingContext::NOSCRIPT_WARNING %>
+  <div data-react-class="AppRoot"></div>
 </body>
 </html>


### PR DESCRIPTION
### Purpose

The CDN SPA shell layout (`cdn_spa_shell.html.erb`) was serving a completely empty `<body>`, which means the React app had no mount point to hydrate into when CloudFront served regular (non-crawler) requests. The app would load its JavaScript but then silently fail to render.

The fix is to render the same content that `CmsRenderingContext#render_app_root_content` puts in the body: the optional browser warning, the noscript warning, and the `<div data-react-class="AppRoot">` mount point.

### Release plan and notes

🚢

🤖 Generated with [Claude Code](https://claude.com/claude-code)