### PR TITLE
Skip browser warning for CloudFront-proxied requests

### DIFF
--- a/app/controllers/oauth_sessions_controller.rb
+++ b/app/controllers/oauth_sessions_controller.rb
@@ -83,12 +83,6 @@ class OAuthSessionsController < ApplicationController
     end
 
     body = response.body
-    # Temporary diagnostic: log whether Doorkeeper returned a refresh_token so we
-    # can tell whether the missing Set-Cookie is a server-side or infra problem.
-    Rails.logger.info(
-      "[OAuthSessions] token body keys=#{body.keys.inspect} " \
-        "refresh_token_present=#{body["refresh_token"].present?}"
-    )
     set_refresh_cookie(body["refresh_token"]) if body["refresh_token"].present?
     render json: {
              access_token: body["access_token"],

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,10 @@ module ApplicationHelper
   end
 
   def browser_warning
+    # CloudFront strips all cookies before forwarding to the origin, so the
+    # suppressBrowserWarning cookie is never visible to Rails on proxied requests.
+    # The warning also can't be dismissed there. Skip it entirely.
+    return nil if request.headers["Via"].to_s.include?("CloudFront")
     return nil if request.cookies["suppressBrowserWarning"] == "true"
 
     presenter = BrowserWarningPresenter.new(request.user_agent)


### PR DESCRIPTION
### Purpose

The browser warning (shown to users on very old/unsupported browsers) fires unconditionally on CloudFront-fronted convention sites and can never be dismissed. The dismiss button works by setting a `suppressBrowserWarning` cookie via JavaScript, which the browser sends on subsequent requests — but CloudFront's origin request policy uses `cookie_behavior = "none"`, so that cookie is stripped before the request ever reaches Rails. The `request.cookies["suppressBrowserWarning"]` check always sees nil.

The fix is to bail out early when the request came through CloudFront, which we can detect reliably via the `Via` header. CloudFront adds itself to `Via` on every request it forwards to the origin, so `Via: ... cloudfront.net (CloudFront)` is always present on proxied requests. The cookie-based suppression stays in place for direct (non-CloudFront) access where it still works fine.

### Release plan and notes

🚢

🤖 Generated with [Claude Code](https://claude.com/claude-code)