### PR TITLE
Set public Cache-Control on CDN SPA shell so CloudFront actually caches it

### DIFF
--- a/app/controllers/cdn_spa_shell_controller.rb
+++ b/app/controllers/cdn_spa_shell_controller.rb
@@ -9,6 +9,7 @@ class CdnSpaShellController < ApplicationController
   skip_before_action :ensure_clickwrap_agreement_accepted
 
   def show
+    expires_in 1.day, public: true
     render html: "".html_safe, layout: "cdn_spa_shell"
   end
 end


### PR DESCRIPTION
### Purpose

Every request to a CloudFront-fronted convention was a cache miss on the SPA shell, even on repeat visits. The `cdn_spa_shell` CloudFront cache policy is configured with a 24-hour TTL, but it was being completely ignored because `CdnSpaShellController#show` was letting Rails apply its default response headers: `Cache-Control: max-age=0, private, must-revalidate`. The `private` directive tells any shared/proxy cache — including CloudFront — not to store the response.

One line fix: `expires_in 1.day, public: true` sets `Cache-Control: public, max-age=86400`, which matches the default `cdn_spa_shell_ttl` in the Terraform module and lets CloudFront actually cache the shell per-convention as intended.

The tradeoff is that convention name/favicon/OG image changes in the shell will be stale in CloudFront for up to 24 hours (or until you invalidate). The React app fetches the actual convention data dynamically so users won't see stale content in the UI — just potentially in the `<title>` tag and OG metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)