### PR TITLE
Fix event rating favoriting (my_rating always null for JWT users)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,13 @@ jobs:
         with:
           name: minitest-system-reports
           path: test/html_reports/*
+      - name: Archive Capybara screenshots
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: minitest-system-screenshots
+          path: tmp/capybara/*
+          if-no-files-found: ignore
       - name: Archive coverage report
         uses: actions/upload-artifact@v7
         if: always()

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ gem "rails", "8.1.3"
 # benchmark was removed from Ruby's default gems in Ruby 4.0; required by mini_magick
 gem "benchmark"
 
+# prettyprint 0.2.0 was published to RubyGems without frozen_string_literal: true, but the
+# GitHub tag has it. Using the git source avoids constant warnings on Ruby 4.0.
+gem "prettyprint", github: "ruby/prettyprint", tag: "v0.2.0"
+
 # locking to connection_pool 2.x until ActiveSupport's memcachestore supports the v3 API
 # see https://github.com/mperham/connection_pool/issues/212
 gem "connection_pool", "< 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,13 @@ GIT
       rails (>= 5.2.0)
       shoryuken (>= 2.0)
 
+GIT
+  remote: https://github.com/ruby/prettyprint.git
+  revision: 9248e106c2ea8dbd5f98b18a15876cc96502fe86
+  tag: v0.2.0
+  specs:
+    prettyprint (0.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -452,7 +459,6 @@ GEM
       syntax_tree-haml (>= 2.0.0)
       syntax_tree-rbs (>= 0.2.0)
     prettier_print (1.2.1)
-    prettyprint (0.2.0)
     prism (1.9.0)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -771,6 +777,7 @@ DEPENDENCIES
   positioning
   prettier (= 4.0.4)
   prettier_print
+  prettyprint!
   prism
   pry-rails
   pry-remote

--- a/app/graphql/sources/event_rating.rb
+++ b/app/graphql/sources/event_rating.rb
@@ -3,12 +3,13 @@ class Sources::EventRating < GraphQL::Dataloader::Source
   attr_reader :user_con_profile
 
   def initialize(user_con_profile)
+    super()
     @user_con_profile = user_con_profile
   end
 
   def fetch(keys)
     event_ratings_by_event_id =
-      user_con_profile.event_ratings.where(event_id: keys.map(&:id)).pluck(:event_id, :rating).to_h
+      EventRating.where(user_con_profile:, event_id: keys.map(&:id)).pluck(:event_id, :rating).to_h
 
     keys.map { |event| event_ratings_by_event_id[event.id] }
   end

--- a/app/policies/event_rating_policy.rb
+++ b/app/policies/event_rating_policy.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 class EventRatingPolicy < ApplicationPolicy
   def read?
-    manage?
+    return false unless user
+    return false unless oauth_scope?(:read_signups)
+    record.user_con_profile.user_id == actual_user.id
   end
 
   def manage?
     return false unless user
-    return false if doorkeeper_token # cookie auth only
-
+    return false unless oauth_scope?(:manage_signups)
     record.user_con_profile.user_id == actual_user.id
   end
 
   class Scope < Scope
     def resolve
       return scope.none unless user
-      return scope.none if doorkeeper_token # cookie auth only
-
+      return scope.none unless oauth_scope?(:read_signups)
       scope.joins(:user_con_profile).where(user_con_profiles: { user_id: actual_user.id })
     end
   end

--- a/locales/en.json
+++ b/locales/en.json
@@ -1214,7 +1214,7 @@
       "manage_organizations": "Update privileged data about organizations on the site",
       "manage_profile": "Update your personal profile data",
       "manage_intercode": "Full site administration access",
-      "manage_signups": "Sign you up and withdraw you from events",
+      "manage_signups": "Sign you up and withdraw you from events, and update your favorites and queues",
       "openid": "Authenticate you using your account",
       "profile": "Access your personal profile data",
       "public": "Access your public data, and public data about conventions you are signed up for",
@@ -1223,7 +1223,7 @@
       "read_events": "Access data about the events and event proposals you manage",
       "read_organizations": "Access privileged data about organizations on the site",
       "read_profile": "Access your personal profile data",
-      "read_signups": "Access data about your signups"
+      "read_signups": "Access data about your signups, favorites, and queues"
     }
   },
   "payWhatYouWant": {

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -16,5 +16,14 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   self.use_transactional_tests = false
 
-  teardown { DatabaseCleaner.clean }
+  teardown do
+    if failures.any?
+      messages = page.driver.console_messages
+      if messages.any?
+        warn "\nBrowser console output:"
+        messages.each { |m| warn "  [#{m[:type]}] #{m[:text]}" }
+      end
+    end
+    DatabaseCleaner.clean
+  end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -18,10 +18,16 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   teardown do
     if failures.any?
+      warn "\nURL at failure: #{page.current_url}"
+      warn "Page title: #{page.title}"
+      body_snippet = page.html.to_s.gsub(/\s+/, " ").slice(0, 500)
+      warn "Page body (first 500 chars): #{body_snippet}"
       messages = page.driver.console_messages
       if messages.any?
         warn "\nBrowser console output:"
         messages.each { |m| warn "  [#{m[:type]}] #{m[:text]}" }
+      else
+        warn "No browser console messages captured."
       end
     end
     DatabaseCleaner.clean

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -11,7 +11,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
             options: {
               headless: %w[0 false].exclude?(ENV.fetch("HEADLESS", nil)),
               js_errors: true,
-              process_timeout: 30
+              process_timeout: 30,
+              timeout: 30
             }
 
   self.use_transactional_tests = false

--- a/test/graphql/mutations/rate_event_test.rb
+++ b/test/graphql/mutations/rate_event_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+# rubocop:disable GraphQL/ObjectDescription
+require "test_helper"
+
+class Mutations::RateEventTest < ActiveSupport::TestCase
+  let(:convention) { create(:convention) }
+  let(:user_con_profile) { create(:user_con_profile, convention:) }
+  let(:event) { create(:event, convention:) }
+
+  RATE_EVENT_MUTATION = <<~GRAPHQL
+    mutation TestRateEvent($eventId: ID!, $rating: Int!) {
+      rateEvent(input: { eventId: $eventId, rating: $rating }) {
+        event {
+          id
+          my_rating
+        }
+      }
+    }
+  GRAPHQL
+
+  describe "rating an event for the first time" do
+    it "returns the new rating in the mutation response" do
+      result =
+        execute_graphql_query(
+          RATE_EVENT_MUTATION,
+          user_con_profile:,
+          variables: {
+            "eventId" => event.id.to_s,
+            "rating" => 1
+          }
+        )
+
+      assert_equal 1, result.dig("data", "rateEvent", "event", "my_rating")
+    end
+
+    it "persists the rating to the database" do
+      execute_graphql_query(
+        RATE_EVENT_MUTATION,
+        user_con_profile:,
+        variables: {
+          "eventId" => event.id.to_s,
+          "rating" => 1
+        }
+      )
+
+      assert EventRating.exists?(user_con_profile:, event:, rating: 1)
+    end
+  end
+
+  describe "updating an existing rating" do
+    before { create(:event_rating, user_con_profile:, event:, rating: 1) }
+
+    it "returns the updated rating in the mutation response" do
+      result =
+        execute_graphql_query(
+          RATE_EVENT_MUTATION,
+          user_con_profile:,
+          variables: {
+            "eventId" => event.id.to_s,
+            "rating" => -1
+          }
+        )
+
+      assert_equal(-1, result.dig("data", "rateEvent", "event", "my_rating"))
+    end
+  end
+end
+# rubocop:enable GraphQL/ObjectDescription

--- a/test/javascript/EventRatings/EventCatalogRating.test.tsx
+++ b/test/javascript/EventRatings/EventCatalogRating.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../app/javascript/EventsApp/EventCatalog/EventList/queries.generated';
 import { RateEventDocument, RateEventMutationData } from '../../../app/javascript/EventRatings/mutations.generated';
 import { TimezoneMode } from '../../../app/javascript/graphqlTypes.generated';
-import { MockLink } from '@apollo/client/testing';
+import { MockedResponse } from '@apollo/client/testing';
 import { buildIntercodeApolloCache } from '../../../app/javascript/useIntercodeApolloClient';
 
 type EventEntry = EventListEventsQueryData['convention']['events_paginated']['entries'][number];
@@ -173,7 +173,7 @@ describe('Event catalog rating integration', () => {
   const queryVariables = { page: 1, pageSize: 10 };
 
   test('shows hollow star before favoriting', async () => {
-    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+    const queryMock: MockedResponse<EventListEventsQueryData> = {
       request: { query: EventListEventsQueryDocument, variables: queryVariables },
       result: { data: makeQueryData(makeEntry('1', null)) },
     };
@@ -192,13 +192,13 @@ describe('Event catalog rating integration', () => {
   // This test will fail if the Apollo cache update from the RateEvent mutation does not
   // propagate back to the useQuery(EventListEventsQueryDocument) that drives the display.
   test('updates to filled star after favoriting', async () => {
-    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+    const queryMock: MockedResponse<EventListEventsQueryData> = {
       request: { query: EventListEventsQueryDocument, variables: queryVariables },
       result: { data: makeQueryData(makeEntry('1', null)) },
     };
 
     const mutationCalled = vi.fn();
-    const mutationMock: MockLink.MockedResponse<RateEventMutationData> = {
+    const mutationMock: MockedResponse<RateEventMutationData> = {
       request: { query: RateEventDocument, variables: { eventId: '1', rating: 1 } },
       result: () => {
         mutationCalled();
@@ -240,12 +240,12 @@ describe('Event catalog rating integration', () => {
   // Reproduces issue #11614: once favorited, clicking the star should unfavorite (clear the rating).
   // This requires the UI to first show the selected state (filled star), which is a prerequisite.
   test('allows unfavoriting after favoriting', async () => {
-    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+    const queryMock: MockedResponse<EventListEventsQueryData> = {
       request: { query: EventListEventsQueryDocument, variables: queryVariables },
       result: { data: makeQueryData(makeEntry('1', null)) },
     };
 
-    const favoriteMock: MockLink.MockedResponse<RateEventMutationData> = {
+    const favoriteMock: MockedResponse<RateEventMutationData> = {
       request: { query: RateEventDocument, variables: { eventId: '1', rating: 1 } },
       result: {
         data: {
@@ -259,7 +259,7 @@ describe('Event catalog rating integration', () => {
     };
 
     const unfavoriteCalled = vi.fn();
-    const unfavoriteMock: MockLink.MockedResponse<RateEventMutationData> = {
+    const unfavoriteMock: MockedResponse<RateEventMutationData> = {
       request: { query: RateEventDocument, variables: { eventId: '1', rating: 0 } },
       result: () => {
         unfavoriteCalled();
@@ -311,13 +311,13 @@ describe('Event catalog rating integration (with production Apollo cache)', () =
   const queryVariables = { page: 1, pageSize: 10 };
 
   test('updates to filled star after favoriting', async () => {
-    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+    const queryMock: MockedResponse<EventListEventsQueryData> = {
       request: { query: EventListEventsQueryDocument, variables: queryVariables },
       result: { data: makeQueryData(makeEntry('1', null)) },
     };
 
     const mutationCalled = vi.fn();
-    const mutationMock: MockLink.MockedResponse<RateEventMutationData> = {
+    const mutationMock: MockedResponse<RateEventMutationData> = {
       request: { query: RateEventDocument, variables: { eventId: '1', rating: 1 } },
       result: () => {
         mutationCalled();
@@ -353,12 +353,12 @@ describe('Event catalog rating integration (with production Apollo cache)', () =
   });
 
   test('allows unfavoriting after favoriting', async () => {
-    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+    const queryMock: MockedResponse<EventListEventsQueryData> = {
       request: { query: EventListEventsQueryDocument, variables: queryVariables },
       result: { data: makeQueryData(makeEntry('1', null)) },
     };
 
-    const favoriteMock: MockLink.MockedResponse<RateEventMutationData> = {
+    const favoriteMock: MockedResponse<RateEventMutationData> = {
       request: { query: RateEventDocument, variables: { eventId: '1', rating: 1 } },
       result: {
         data: {
@@ -372,7 +372,7 @@ describe('Event catalog rating integration (with production Apollo cache)', () =
     };
 
     const unfavoriteCalled = vi.fn();
-    const unfavoriteMock: MockLink.MockedResponse<RateEventMutationData> = {
+    const unfavoriteMock: MockedResponse<RateEventMutationData> = {
       request: { query: RateEventDocument, variables: { eventId: '1', rating: 0 } },
       result: () => {
         unfavoriteCalled();
@@ -424,7 +424,7 @@ describe('EventList previousData fallback pattern', () => {
   const changedQueryVariables = { page: 1, pageSize: 10, fetchFormItemIdentifiers: ['new-identifier'] };
 
   test('maintains filled star even when useQuery variables change after favoriting', async () => {
-    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+    const queryMock: MockedResponse<EventListEventsQueryData> = {
       request: { query: EventListEventsQueryDocument, variables: baseQueryVariables },
       result: { data: makeQueryData(makeEntry('1', null)) },
     };
@@ -432,12 +432,12 @@ describe('EventList previousData fallback pattern', () => {
     // When variables change (fetchFormItemIdentifiers added), the mock for the new variables
     // returns the updated data with my_rating: 1 (as would happen with cache-first if the
     // cache was updated by the mutation)
-    const changedVarsQueryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+    const changedVarsQueryMock: MockedResponse<EventListEventsQueryData> = {
       request: { query: EventListEventsQueryDocument, variables: changedQueryVariables },
       result: { data: makeQueryData(makeEntry('1', 1)) },
     };
 
-    const mutationMock: MockLink.MockedResponse<RateEventMutationData> = {
+    const mutationMock: MockedResponse<RateEventMutationData> = {
       request: { query: RateEventDocument, variables: { eventId: '1', rating: 1 } },
       result: {
         data: {

--- a/test/javascript/EventRatings/EventCatalogRating.test.tsx
+++ b/test/javascript/EventRatings/EventCatalogRating.test.tsx
@@ -1,0 +1,479 @@
+import { useQuery } from '@apollo/client/react';
+import { useState } from 'react';
+import { vi } from 'vitest';
+import { render, fireEvent, waitFor } from '../testUtils';
+import RateEventControl from '../../../app/javascript/EventRatings/RateEventControl';
+import useRateEvent from '../../../app/javascript/EventRatings/useRateEvent';
+import {
+  EventListEventsQueryData,
+  EventListEventsQueryDocument,
+} from '../../../app/javascript/EventsApp/EventCatalog/EventList/queries.generated';
+import { RateEventDocument, RateEventMutationData } from '../../../app/javascript/EventRatings/mutations.generated';
+import { TimezoneMode } from '../../../app/javascript/graphqlTypes.generated';
+import { MockLink } from '@apollo/client/testing';
+import { buildIntercodeApolloCache } from '../../../app/javascript/useIntercodeApolloClient';
+
+type EventEntry = EventListEventsQueryData['convention']['events_paginated']['entries'][number];
+
+function makeEntry(id: string, my_rating: number | null = null): EventEntry {
+  return {
+    __typename: 'Event',
+    id,
+    title: `Event ${id}`,
+    created_at: null,
+    short_blurb_html: null,
+    form_response_attrs_json_with_rendered_markdown: null,
+    my_rating,
+    length_seconds: 3600,
+    event_category: { __typename: 'EventCategory', id: '1' },
+    runs: [],
+    team_members: [],
+    registration_policy: null,
+  };
+}
+
+function makeQueryData(entry: EventEntry): EventListEventsQueryData {
+  return {
+    __typename: 'Query',
+    currentAbility: { __typename: 'Ability', can_read_schedule: false },
+    convention: {
+      __typename: 'Convention',
+      id: '1',
+      timezone_mode: TimezoneMode.ConventionLocal,
+      events_paginated: {
+        __typename: 'EventsPagination',
+        total_entries: 1,
+        total_pages: 1,
+        current_page: 1,
+        per_page: 10,
+        entries: [entry],
+      },
+    },
+  };
+}
+
+// Mimics how EventList reads rating from Apollo cache via useQuery and passes it to RateEventControl.
+// This is the critical data flow: the rating display is controlled by Apollo cache, not local state.
+function EventRatingFromCache({ eventId }: { eventId: string }) {
+  const { data, loading } = useQuery(EventListEventsQueryDocument, {
+    variables: { page: 1, pageSize: 10 },
+  });
+  const rateEvent = useRateEvent();
+
+  if (loading || !data) {
+    return <div data-testid="loading" />;
+  }
+
+  const event = data.convention.events_paginated.entries.find((e) => e.id === eventId);
+  if (!event) {
+    return <div data-testid="not-found" />;
+  }
+
+  return <RateEventControl value={event.my_rating} onChange={(rating) => rateEvent(event.id, rating)} />;
+}
+
+// Mimics EventList's pattern more exactly: uses previousData as a fallback during loading.
+// This is important because EventList does: `const data = loading && previousData ? previousData : currentData`
+// If loading becomes true after the mutation (due to variable changes from revalidation),
+// and previousData still has the pre-mutation rating, the star would incorrectly revert to hollow.
+function EventRatingWithPreviousDataPattern({ eventId, extraVar }: { eventId: string; extraVar?: string }) {
+  const {
+    data: currentData,
+    previousData,
+    loading,
+  } = useQuery(EventListEventsQueryDocument, {
+    variables: { page: 1, pageSize: 10, ...(extraVar ? { fetchFormItemIdentifiers: [extraVar] } : {}) },
+  });
+  const rateEvent = useRateEvent();
+  // This is the same pattern as EventList
+  const data = loading && previousData ? previousData : currentData;
+
+  if (!data) {
+    return <div data-testid="loading" />;
+  }
+
+  const event = data.convention.events_paginated.entries.find((e) => e.id === eventId);
+  if (!event) {
+    return <div data-testid="not-found" />;
+  }
+
+  return <RateEventControl value={event.my_rating} onChange={(rating) => rateEvent(event.id, rating)} />;
+}
+
+// A wrapper that lets tests change variables to simulate what happens when
+// filterableFormItemIdentifiers changes after revalidation.
+function VariableChangingWrapper({ eventId }: { eventId: string }) {
+  const [extraVar, setExtraVar] = useState<string | undefined>(undefined);
+  return (
+    <>
+      <button data-testid="change-vars" onClick={() => setExtraVar('new-identifier')}>
+        Change variables
+      </button>
+      <EventRatingWithPreviousDataPattern eventId={eventId} extraVar={extraVar} />
+    </>
+  );
+}
+
+describe('RateEventControl', () => {
+  test('shows two buttons (favorite and hidden) when not rated', async () => {
+    const onChange = vi.fn();
+    const { getAllByRole } = await render(<RateEventControl value={null} onChange={onChange} />);
+    expect(getAllByRole('button')).toHaveLength(2);
+  });
+
+  test('shows hollow star icon when not rated', async () => {
+    const onChange = vi.fn();
+    const { container } = await render(<RateEventControl value={null} onChange={onChange} />);
+    expect(container.querySelector('.bi-star')).toBeTruthy();
+    expect(container.querySelector('.bi-star-fill')).toBeNull();
+  });
+
+  test('shows only one button when favorited', async () => {
+    const onChange = vi.fn();
+    const { getAllByRole } = await render(<RateEventControl value={1} onChange={onChange} />);
+    expect(getAllByRole('button')).toHaveLength(1);
+  });
+
+  test('shows filled star icon when favorited', async () => {
+    const onChange = vi.fn();
+    const { container } = await render(<RateEventControl value={1} onChange={onChange} />);
+    expect(container.querySelector('.bi-star-fill')).toBeTruthy();
+  });
+
+  test('shows only one button when hidden', async () => {
+    const onChange = vi.fn();
+    const { getAllByRole } = await render(<RateEventControl value={-1} onChange={onChange} />);
+    expect(getAllByRole('button')).toHaveLength(1);
+  });
+
+  test('calls onChange(1) when favorite button is clicked', async () => {
+    const onChange = vi.fn();
+    const { getByRole } = await render(<RateEventControl value={null} onChange={onChange} />);
+    fireEvent.click(getByRole('button', { name: 'Favorite' }));
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  test('calls onChange(0) when the selected button is clicked while favorited', async () => {
+    const onChange = vi.fn();
+    const { getByRole } = await render(<RateEventControl value={1} onChange={onChange} />);
+    // The single button when favorited has accessible name "Favorite" and acts as the clear button
+    fireEvent.click(getByRole('button', { name: 'Favorite' }));
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  test('calls onChange(-1) when hide button is clicked', async () => {
+    const onChange = vi.fn();
+    const { getByRole } = await render(<RateEventControl value={null} onChange={onChange} />);
+    fireEvent.click(getByRole('button', { name: 'Hidden' }));
+    expect(onChange).toHaveBeenCalledWith(-1);
+  });
+});
+
+describe('Event catalog rating integration', () => {
+  const queryVariables = { page: 1, pageSize: 10 };
+
+  test('shows hollow star before favoriting', async () => {
+    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+      request: { query: EventListEventsQueryDocument, variables: queryVariables },
+      result: { data: makeQueryData(makeEntry('1', null)) },
+    };
+
+    const { container, queryByTestId } = await render(<EventRatingFromCache eventId="1" />, {
+      apolloMocks: [queryMock],
+    });
+
+    await waitFor(() => expect(queryByTestId('loading')).toBeNull());
+    expect(container.querySelector('.bi-star')).toBeTruthy();
+    expect(container.querySelector('.bi-star-fill')).toBeNull();
+  });
+
+  // Reproduces issue #11614: after favoriting, the star should become filled and the
+  // component should switch to showing a single "clear" button instead of two buttons.
+  // This test will fail if the Apollo cache update from the RateEvent mutation does not
+  // propagate back to the useQuery(EventListEventsQueryDocument) that drives the display.
+  test('updates to filled star after favoriting', async () => {
+    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+      request: { query: EventListEventsQueryDocument, variables: queryVariables },
+      result: { data: makeQueryData(makeEntry('1', null)) },
+    };
+
+    const mutationCalled = vi.fn();
+    const mutationMock: MockLink.MockedResponse<RateEventMutationData> = {
+      request: { query: RateEventDocument, variables: { eventId: '1', rating: 1 } },
+      result: () => {
+        mutationCalled();
+        return {
+          data: {
+            __typename: 'Mutation',
+            rateEvent: {
+              __typename: 'RateEventPayload',
+              event: { __typename: 'Event', id: '1', my_rating: 1 },
+            },
+          },
+        };
+      },
+    };
+
+    const { container, getByRole, queryByTestId } = await render(<EventRatingFromCache eventId="1" />, {
+      apolloMocks: [queryMock, mutationMock],
+    });
+
+    await waitFor(() => expect(queryByTestId('loading')).toBeNull());
+
+    // Initially shows hollow star and two buttons
+    expect(container.querySelector('.bi-star')).toBeTruthy();
+    expect(container.querySelector('.bi-star-fill')).toBeNull();
+
+    // Click the favorite button
+    fireEvent.click(getByRole('button', { name: 'Favorite' }));
+
+    // Verify the mutation was called
+    await waitFor(() => expect(mutationCalled).toHaveBeenCalledTimes(1));
+
+    // After mutation, the Apollo cache should update Event:1.my_rating = 1, which should
+    // propagate to useQuery and cause the star to become filled
+    await waitFor(() => {
+      expect(container.querySelector('.bi-star-fill')).toBeTruthy();
+    });
+  });
+
+  // Reproduces issue #11614: once favorited, clicking the star should unfavorite (clear the rating).
+  // This requires the UI to first show the selected state (filled star), which is a prerequisite.
+  test('allows unfavoriting after favoriting', async () => {
+    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+      request: { query: EventListEventsQueryDocument, variables: queryVariables },
+      result: { data: makeQueryData(makeEntry('1', null)) },
+    };
+
+    const favoriteMock: MockLink.MockedResponse<RateEventMutationData> = {
+      request: { query: RateEventDocument, variables: { eventId: '1', rating: 1 } },
+      result: {
+        data: {
+          __typename: 'Mutation',
+          rateEvent: {
+            __typename: 'RateEventPayload',
+            event: { __typename: 'Event', id: '1', my_rating: 1 },
+          },
+        },
+      },
+    };
+
+    const unfavoriteCalled = vi.fn();
+    const unfavoriteMock: MockLink.MockedResponse<RateEventMutationData> = {
+      request: { query: RateEventDocument, variables: { eventId: '1', rating: 0 } },
+      result: () => {
+        unfavoriteCalled();
+        return {
+          data: {
+            __typename: 'Mutation',
+            rateEvent: {
+              __typename: 'RateEventPayload',
+              event: { __typename: 'Event', id: '1', my_rating: 0 },
+            },
+          },
+        };
+      },
+    };
+
+    const { container, getByRole, getAllByRole, queryByTestId } = await render(<EventRatingFromCache eventId="1" />, {
+      apolloMocks: [queryMock, favoriteMock, unfavoriteMock],
+    });
+
+    await waitFor(() => expect(queryByTestId('loading')).toBeNull());
+
+    // Favorite the event
+    fireEvent.click(getByRole('button', { name: 'Favorite' }));
+
+    // Wait for the UI to show the favorited state (filled star, single button)
+    await waitFor(() => {
+      expect(container.querySelector('.bi-star-fill')).toBeTruthy();
+    });
+
+    // Now unfavorite: click the single button (the clear button)
+    const clearButton = getByRole('button', { name: 'Favorite' });
+    fireEvent.click(clearButton);
+
+    // After unfavoriting, should return to two buttons with hollow star
+    await waitFor(() => {
+      expect(unfavoriteCalled).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(getAllByRole('button')).toHaveLength(2);
+      expect(container.querySelector('.bi-star-fill')).toBeNull();
+    });
+  });
+});
+
+// Re-run the key integration tests with the production Apollo cache (keyArgs: false + custom merge).
+// This catches bugs that only manifest with the real cache configuration used in production.
+describe('Event catalog rating integration (with production Apollo cache)', () => {
+  const queryVariables = { page: 1, pageSize: 10 };
+
+  test('updates to filled star after favoriting', async () => {
+    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+      request: { query: EventListEventsQueryDocument, variables: queryVariables },
+      result: { data: makeQueryData(makeEntry('1', null)) },
+    };
+
+    const mutationCalled = vi.fn();
+    const mutationMock: MockLink.MockedResponse<RateEventMutationData> = {
+      request: { query: RateEventDocument, variables: { eventId: '1', rating: 1 } },
+      result: () => {
+        mutationCalled();
+        return {
+          data: {
+            __typename: 'Mutation',
+            rateEvent: {
+              __typename: 'RateEventPayload',
+              event: { __typename: 'Event', id: '1', my_rating: 1 },
+            },
+          },
+        };
+      },
+    };
+
+    const { container, getByRole, queryByTestId } = await render(<EventRatingFromCache eventId="1" />, {
+      apolloMocks: [queryMock, mutationMock],
+      apolloCache: buildIntercodeApolloCache(),
+    });
+
+    await waitFor(() => expect(queryByTestId('loading')).toBeNull());
+
+    expect(container.querySelector('.bi-star')).toBeTruthy();
+    expect(container.querySelector('.bi-star-fill')).toBeNull();
+
+    fireEvent.click(getByRole('button', { name: 'Favorite' }));
+
+    await waitFor(() => expect(mutationCalled).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => {
+      expect(container.querySelector('.bi-star-fill')).toBeTruthy();
+    });
+  });
+
+  test('allows unfavoriting after favoriting', async () => {
+    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+      request: { query: EventListEventsQueryDocument, variables: queryVariables },
+      result: { data: makeQueryData(makeEntry('1', null)) },
+    };
+
+    const favoriteMock: MockLink.MockedResponse<RateEventMutationData> = {
+      request: { query: RateEventDocument, variables: { eventId: '1', rating: 1 } },
+      result: {
+        data: {
+          __typename: 'Mutation',
+          rateEvent: {
+            __typename: 'RateEventPayload',
+            event: { __typename: 'Event', id: '1', my_rating: 1 },
+          },
+        },
+      },
+    };
+
+    const unfavoriteCalled = vi.fn();
+    const unfavoriteMock: MockLink.MockedResponse<RateEventMutationData> = {
+      request: { query: RateEventDocument, variables: { eventId: '1', rating: 0 } },
+      result: () => {
+        unfavoriteCalled();
+        return {
+          data: {
+            __typename: 'Mutation',
+            rateEvent: {
+              __typename: 'RateEventPayload',
+              event: { __typename: 'Event', id: '1', my_rating: 0 },
+            },
+          },
+        };
+      },
+    };
+
+    const { container, getByRole, getAllByRole, queryByTestId } = await render(<EventRatingFromCache eventId="1" />, {
+      apolloMocks: [queryMock, favoriteMock, unfavoriteMock],
+      apolloCache: buildIntercodeApolloCache(),
+    });
+
+    await waitFor(() => expect(queryByTestId('loading')).toBeNull());
+
+    fireEvent.click(getByRole('button', { name: 'Favorite' }));
+
+    await waitFor(() => {
+      expect(container.querySelector('.bi-star-fill')).toBeTruthy();
+    });
+
+    fireEvent.click(getByRole('button', { name: 'Favorite' }));
+
+    await waitFor(() => {
+      expect(unfavoriteCalled).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(getAllByRole('button')).toHaveLength(2);
+      expect(container.querySelector('.bi-star-fill')).toBeNull();
+    });
+  });
+});
+
+// Tests the EventList previousData fallback pattern specifically.
+// EventList does: `const data = loading && previousData ? previousData : currentData`
+// If Apollo sets loading=true after a variable change (triggered by revalidation updating
+// filterableFormItemIdentifiers), and previousData still has my_rating: null, the star
+// would incorrectly revert to hollow even though the mutation already set my_rating: 1 in cache.
+describe('EventList previousData fallback pattern', () => {
+  const baseQueryVariables = { page: 1, pageSize: 10 };
+  const changedQueryVariables = { page: 1, pageSize: 10, fetchFormItemIdentifiers: ['new-identifier'] };
+
+  test('maintains filled star even when useQuery variables change after favoriting', async () => {
+    const queryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+      request: { query: EventListEventsQueryDocument, variables: baseQueryVariables },
+      result: { data: makeQueryData(makeEntry('1', null)) },
+    };
+
+    // When variables change (fetchFormItemIdentifiers added), the mock for the new variables
+    // returns the updated data with my_rating: 1 (as would happen with cache-first if the
+    // cache was updated by the mutation)
+    const changedVarsQueryMock: MockLink.MockedResponse<EventListEventsQueryData> = {
+      request: { query: EventListEventsQueryDocument, variables: changedQueryVariables },
+      result: { data: makeQueryData(makeEntry('1', 1)) },
+    };
+
+    const mutationMock: MockLink.MockedResponse<RateEventMutationData> = {
+      request: { query: RateEventDocument, variables: { eventId: '1', rating: 1 } },
+      result: {
+        data: {
+          __typename: 'Mutation',
+          rateEvent: {
+            __typename: 'RateEventPayload',
+            event: { __typename: 'Event', id: '1', my_rating: 1 },
+          },
+        },
+      },
+    };
+
+    const { container, getByRole, getByTestId } = await render(<VariableChangingWrapper eventId="1" />, {
+      apolloMocks: [queryMock, mutationMock, changedVarsQueryMock],
+      apolloCache: buildIntercodeApolloCache(),
+    });
+
+    // Wait for initial load
+    await waitFor(() => expect(container.querySelector('.bi-star')).toBeTruthy());
+
+    // Click favorite to trigger mutation
+    fireEvent.click(getByRole('button', { name: 'Favorite' }));
+
+    // Wait for mutation to complete and star to be filled
+    await waitFor(() => {
+      expect(container.querySelector('.bi-star-fill')).toBeTruthy();
+    });
+
+    // Simulate what happens after revalidation: variables change (new fetchFormItemIdentifiers)
+    fireEvent.click(getByTestId('change-vars'));
+
+    // Even after variables change, the star should REMAIN filled (not revert to hollow).
+    // This test will FAIL if the `loading && previousData` pattern causes a regression
+    // because previousData still holds the pre-mutation data.
+    await waitFor(() => {
+      expect(container.querySelector('.bi-star-fill')).toBeTruthy();
+    });
+  });
+});

--- a/test/javascript/testUtils.tsx
+++ b/test/javascript/testUtils.tsx
@@ -14,7 +14,7 @@ import AppRootContext, { appRootContextDefaultValue, AppRootContextValue } from 
 
 export type TestWrapperProps = {
   apolloMocks?: MockedProviderProps['mocks'];
-  apolloCache?: ApolloCache<unknown>;
+  apolloCache?: ApolloCache;
   children?: React.ReactNode;
   stripePublishableKey?: string;
   i18nInstance: i18n;

--- a/test/javascript/testUtils.tsx
+++ b/test/javascript/testUtils.tsx
@@ -6,6 +6,7 @@ import { i18n } from 'i18next';
 import { I18nextProvider } from 'react-i18next';
 import type { Stripe } from '@stripe/stripe-js';
 import { Confirm } from '@neinteractiveliterature/litform';
+import type { ApolloCache } from '@apollo/client';
 
 import getI18n from '../../app/javascript/setupI18Next';
 import { LazyStripeContext } from '../../app/javascript/LazyStripe';
@@ -13,6 +14,7 @@ import AppRootContext, { appRootContextDefaultValue, AppRootContextValue } from 
 
 export type TestWrapperProps = {
   apolloMocks?: MockedProviderProps['mocks'];
+  apolloCache?: ApolloCache<unknown>;
   children?: React.ReactNode;
   stripePublishableKey?: string;
   i18nInstance: i18n;
@@ -21,6 +23,7 @@ export type TestWrapperProps = {
 
 function TestWrapper({
   apolloMocks,
+  apolloCache,
   stripePublishableKey,
   i18nInstance,
   appRootContextValue,
@@ -51,7 +54,7 @@ function TestWrapper({
 
   return (
     <AppRootContext.Provider value={effectiveAppRootContextValue}>
-      <MockedProvider mocks={apolloMocks}>
+      <MockedProvider mocks={apolloMocks} cache={apolloCache}>
         <LazyStripeContext.Provider value={lazyStripeProviderValue}>
           <Confirm>
             <I18nextProvider i18n={i18nInstance}>
@@ -91,7 +94,14 @@ async function customRender<Q extends Queries = Queries>(
   ui: React.JSX.Element,
   options: Omit<TestWrapperProps, 'children' | 'i18nInstance'> & RenderOptions<Q> = {},
 ): Promise<RenderResult<typeof queries & Q & CustomQueries>> {
-  const { apolloMocks, stripePublishableKey, queries: providedQueries, appRootContextValue, ...otherOptions } = options;
+  const {
+    apolloMocks,
+    apolloCache,
+    stripePublishableKey,
+    queries: providedQueries,
+    appRootContextValue,
+    ...otherOptions
+  } = options;
   const combinedQueries: typeof queries & Q & CustomQueries = {
     ...queries,
     ...customQueries,
@@ -102,6 +112,7 @@ async function customRender<Q extends Queries = Queries>(
     wrapper: (wrapperProps) => (
       <TestWrapper
         apolloMocks={apolloMocks}
+        apolloCache={apolloCache}
         stripePublishableKey={stripePublishableKey}
         i18nInstance={i18nInstance}
         appRootContextValue={appRootContextValue}

--- a/test/javascript/useIntercodeApolloClient.test.ts
+++ b/test/javascript/useIntercodeApolloClient.test.ts
@@ -3,6 +3,7 @@ import {
   EventListEventsQueryDocument,
   EventListEventsQueryVariables,
 } from '../../app/javascript/EventsApp/EventCatalog/EventList/queries.generated';
+import { RateEventDocument } from '../../app/javascript/EventRatings/mutations.generated';
 import { buildIntercodeApolloCache } from '../../app/javascript/useIntercodeApolloClient';
 
 type EventEntry = EventListEventsQueryData['convention']['events_paginated']['entries'][number];
@@ -146,6 +147,88 @@ describe('buildIntercodeApolloCache', () => {
       // Reading with different variables should still return the merged data
       const result = cache.readQuery({ query: EventListEventsQueryDocument, variables: vars(2, 20) });
       expect(result?.convention.events_paginated.entries[0].id).toBe('event-1');
+    });
+  });
+
+  // Reproduces issue #11614: the RateEvent mutation returns event { id, my_rating }.
+  // Apollo normalizes this and updates the Event entity in the cache. The EventListEventsQuery
+  // reads events from convention.events_paginated.entries, which are entity references. So any
+  // query reading those events should reflect the updated my_rating.
+  describe('RateEvent mutation cache propagation', () => {
+    it('updates my_rating in EventListEventsQuery after RateEvent mutation result is written', () => {
+      const cache = buildIntercodeApolloCache();
+
+      // Write initial query data with event having no rating
+      cache.writeQuery({
+        query: EventListEventsQueryDocument,
+        variables: { page: 1, pageSize: 20 },
+        data: makeQueryData(1, 20, ['event-1']),
+      });
+
+      // Verify initial state
+      const initial = cache.readQuery({
+        query: EventListEventsQueryDocument,
+        variables: { page: 1, pageSize: 20 },
+      });
+      expect(initial?.convention.events_paginated.entries[0].my_rating).toBeNull();
+
+      // Simulate Apollo processing the RateEvent mutation response.
+      // Apollo writes normalized entity data from mutation results to the cache,
+      // so this is equivalent to what happens when client.mutate() completes.
+      cache.writeQuery({
+        query: RateEventDocument,
+        variables: { eventId: 'event-1', rating: 1 },
+        data: {
+          __typename: 'Mutation',
+          rateEvent: {
+            __typename: 'RateEventPayload',
+            event: { __typename: 'Event', id: 'event-1', my_rating: 1 },
+          },
+        },
+      });
+
+      // Read the query and verify the updated rating is reflected
+      const updated = cache.readQuery({
+        query: EventListEventsQueryDocument,
+        variables: { page: 1, pageSize: 20 },
+      });
+      expect(updated?.convention.events_paginated.entries[0].my_rating).toBe(1);
+    });
+
+    it('updates my_rating even when keyArgs: false causes all pages to share one cache slot', () => {
+      const cache = buildIntercodeApolloCache();
+
+      // Write two pages of events
+      cache.writeQuery({
+        query: EventListEventsQueryDocument,
+        variables: { page: 1, pageSize: 2 },
+        data: makeQueryData(1, 2, ['event-1', 'event-2'], 4),
+      });
+      cache.writeQuery({
+        query: EventListEventsQueryDocument,
+        variables: { page: 2, pageSize: 2 },
+        data: makeQueryData(2, 2, ['event-3', 'event-4'], 4),
+      });
+
+      // Favorite event-3 (which is on page 2 of the merged results)
+      cache.writeQuery({
+        query: RateEventDocument,
+        variables: { eventId: 'event-3', rating: 1 },
+        data: {
+          __typename: 'Mutation',
+          rateEvent: {
+            __typename: 'RateEventPayload',
+            event: { __typename: 'Event', id: 'event-3', my_rating: 1 },
+          },
+        },
+      });
+
+      // All queries share the same slot, so any variables should show the updated rating
+      const result = cache.readQuery({
+        query: EventListEventsQueryDocument,
+        variables: { page: 1, pageSize: 2 },
+      });
+      expect(result?.convention.events_paginated.entries[2].my_rating).toBe(1);
     });
   });
 });

--- a/test/policies/event_rating_policy_test.rb
+++ b/test/policies/event_rating_policy_test.rb
@@ -1,47 +1,48 @@
-require 'test_helper'
-require_relative 'convention_permissions_test_helper'
+# frozen_string_literal: true
+require "test_helper"
+require_relative "convention_permissions_test_helper"
 
 class EventRatingPolicyTest < ActiveSupport::TestCase
   include ConventionPermissionsTestHelper
 
+  FakeToken =
+    Struct.new(:scopes) do
+      def self.with_scopes(*scopes)
+        new(Doorkeeper::OAuth::Scopes.from_array(scopes.map(&:to_s)))
+      end
+    end
+
   let(:event_rating) { create(:event_rating) }
 
+  # rubocop:disable Metrics/BlockLength
   %w[read manage].each do |action|
     it "does not allow logged out users to #{action} event ratings" do
-      refute EventRatingPolicy.new(nil, event_rating).send("#{action}?")
+      assert_not EventRatingPolicy.new(nil, event_rating).send("#{action}?")
     end
 
     it "allows users to #{action} their own event ratings" do
       assert EventRatingPolicy.new(event_rating.user_con_profile.user, event_rating).send("#{action}?")
 
       # Event ratings are secret from identity assumers
-      refute EventRatingPolicy
-               .new(
-                 create_identity_assumer(event_rating.user_con_profile.user, event_rating.user_con_profile.convention),
-                 event_rating
-               )
-               .send("#{action}?")
-      refute EventRatingPolicy
-               .new(create_identity_assumer_from_other_convention(event_rating.user_con_profile.user), event_rating)
-               .send("#{action}?")
-    end
-
-    it "does not allow users to #{action} their own event ratings over OAuth" do
-      authorization_info = AuthorizationInfo.new(event_rating.user_con_profile.user, :fake_token)
-      refute EventRatingPolicy.new(authorization_info, event_rating).send("#{action}?")
-    end
-
-    it "does not allow users to #{action} their own event ratings over OAuth" do
-      authorization_info = AuthorizationInfo.new(event_rating.user_con_profile.user, :fake_token)
-      refute EventRatingPolicy.new(authorization_info, event_rating).send("#{action}?")
+      assert_not EventRatingPolicy.new(
+                   create_identity_assumer(
+                     event_rating.user_con_profile.user,
+                     event_rating.user_con_profile.convention
+                   ),
+                   event_rating
+                 ).send("#{action}?")
+      assert_not EventRatingPolicy.new(
+                   create_identity_assumer_from_other_convention(event_rating.user_con_profile.user),
+                   event_rating
+                 ).send("#{action}?")
     end
 
     it "does not allow users to #{action} other people's event ratings" do
-      refute EventRatingPolicy.new(create(:user), event_rating).send("#{action}?")
+      assert_not EventRatingPolicy.new(create(:user), event_rating).send("#{action}?")
     end
 
     it "does not allow site admins to #{action} other people's event ratings" do
-      refute EventRatingPolicy.new(create(:site_admin), event_rating).send("#{action}?")
+      assert_not EventRatingPolicy.new(create(:site_admin), event_rating).send("#{action}?")
     end
 
     it "does not allow site admins to #{action} other people's event ratings even under assumed identities" do
@@ -49,7 +50,29 @@ class EventRatingPolicyTest < ActiveSupport::TestCase
         create(:user_con_profile, convention: event_rating.user_con_profile.convention, user: create(:site_admin))
       authorization_info =
         AuthorizationInfo.new(event_rating.user_con_profile.user, nil, assumed_identity_from_profile: admin_profile)
-      refute EventRatingPolicy.new(authorization_info, event_rating).send("#{action}?")
+      assert_not EventRatingPolicy.new(authorization_info, event_rating).send("#{action}?")
     end
+  end
+  # rubocop:enable Metrics/BlockLength
+
+  it "allows users to read their own event ratings over OAuth with read_signups scope" do
+    authorization_info = AuthorizationInfo.new(event_rating.user_con_profile.user, FakeToken.with_scopes(:read_signups))
+    assert EventRatingPolicy.new(authorization_info, event_rating).read?
+  end
+
+  it "does not allow users to read their own event ratings over OAuth without read_signups scope" do
+    authorization_info = AuthorizationInfo.new(event_rating.user_con_profile.user, FakeToken.with_scopes(:public))
+    assert_not EventRatingPolicy.new(authorization_info, event_rating).read?
+  end
+
+  it "allows users to manage their own event ratings over OAuth with manage_signups scope" do
+    authorization_info =
+      AuthorizationInfo.new(event_rating.user_con_profile.user, FakeToken.with_scopes(:manage_signups))
+    assert EventRatingPolicy.new(authorization_info, event_rating).manage?
+  end
+
+  it "does not allow users to manage their own event ratings over OAuth without manage_signups scope" do
+    authorization_info = AuthorizationInfo.new(event_rating.user_con_profile.user, FakeToken.with_scopes(:public))
+    assert_not EventRatingPolicy.new(authorization_info, event_rating).manage?
   end
 end

--- a/test/system/page_weight_test.rb
+++ b/test/system/page_weight_test.rb
@@ -27,7 +27,7 @@ class PageWeightTest < ApplicationSystemTestCase
     visit "/"
 
     # Wait for the React app to finish bootstrapping before sampling resources.
-    assert page.has_css?("nav.navbar"), wait: 30
+    assert page.has_css?("nav.navbar", wait: 30)
 
     resources = JSON.parse(page.evaluate_script(<<~JS))
         JSON.stringify(

--- a/test/system/page_weight_test.rb
+++ b/test/system/page_weight_test.rb
@@ -26,6 +26,10 @@ class PageWeightTest < ApplicationSystemTestCase
   it "loads the home page within the initial JS/CSS payload budget" do
     visit "/"
 
+    # On CI the root CMS page lookup occasionally causes "/" to respond slowly enough
+    # that Ferrum's navigation times out, leaving Chrome at about:blank. Retry once.
+    visit "/" if page.current_url.start_with?("about:")
+
     # Wait for the React app to finish bootstrapping before sampling resources.
     assert page.has_css?("nav.navbar", wait: 30)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 ENV["RAILS_ENV"] = "test"
-module Warning
-  def warn(msg, category: nil, **)
-    super unless msg.include?("literal string will be frozen in the future")
-  end
-end
 require "simplecov"
 require "simplecov-cobertura"
 SimpleCov.start do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 ENV["RAILS_ENV"] = "test"
-Warning[:performance] = false
+module Warning
+  def warn(msg, category: nil, **)
+    super unless msg.include?("literal string will be frozen in the future")
+  end
+end
 require "simplecov"
 require "simplecov-cobertura"
 SimpleCov.start do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
 ENV["RAILS_ENV"] = "test"
+Warning[:performance] = false
 require "simplecov"
 require "simplecov-cobertura"
 SimpleCov.start do
@@ -13,7 +15,7 @@ end
 
 require "minitest/mock"
 
-require File.expand_path("../../config/environment", __FILE__)
+require File.expand_path("../config/environment", __dir__)
 require "rails/test_help"
 
 require "minitest/reporters"
@@ -111,7 +113,7 @@ class ActiveSupport::TestCase
   def execute_graphql_query(query, user_con_profile: nil, context_attrs: {}, **)
     context = TestGraphqlContext.with_user_con_profile(user_con_profile, **context_attrs)
     result = IntercodeSchema.execute(query, context:, **)
-    raise GraphqlTestExecutionError.new(result) if result["errors"].present?
+    raise GraphqlTestExecutionError, result if result["errors"].present?
     result
   end
 end


### PR DESCRIPTION
## Summary

- `EventRatingPolicy#read?` was delegating to `manage?`, which had a blanket `return false if doorkeeper_token` check. Since the SPA authenticates via JWT bearer tokens (which Doorkeeper treats as OAuth tokens), `my_rating` always returned `nil` for logged-in users. The rating was being saved correctly, but the mutation response contained `my_rating: null`, which Apollo wrote into its normalized cache — leaving the star unselected and the rating invisible until a hard reload (which still showed null for the same reason).
- Fixed `read?` to gate on `oauth_scope?(:read_signups)` and `manage?` to gate on `oauth_scope?(:manage_signups)`, consistent with how other personal-data policies in the codebase work. The SPA already requests both scopes at login, so no forced re-auth is needed.
- Also changed the `EventRating` dataloader source to query `EventRating.where(user_con_profile:, ...)` directly rather than through the AR association proxy, which is a cleaner pattern for dataloader sources.
- Updated `read_signups` and `manage_signups` scope descriptions in `en.json` to mention favorites and queues.

## Test plan

- [ ] Log in to a convention and click the favorite star on an event — star should turn gold immediately without a page reload
- [ ] Reload the page — star should remain gold
- [ ] Click the clear button — star should clear immediately
- [ ] Verify `bundle exec ruby -Itest test/policies/event_rating_policy_test.rb test/graphql/mutations/rate_event_test.rb` passes

Fixes #11614

🤖 Generated with [Claude Code](https://claude.com/claude-code)