### PR TITLE
Use nonsensitive() for secrets for_each in SSM parameter resource

### DIFF
--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -27,7 +27,7 @@ resource "aws_ssm_parameter" "aws_region" {
 }
 
 resource "aws_ssm_parameter" "secrets" {
-  for_each = var.secrets
+  for_each = nonsensitive(var.secrets)
 
   name  = "${local.ssm_path_prefix}/${each.key}"
   type  = "SecureString"

--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -27,9 +27,9 @@ resource "aws_ssm_parameter" "aws_region" {
 }
 
 resource "aws_ssm_parameter" "secrets" {
-  for_each = nonsensitive(var.secrets)
+  for_each = toset(nonsensitive(keys(var.secrets)))
 
   name  = "${local.ssm_path_prefix}/${each.key}"
   type  = "SecureString"
-  value = each.value
+  value = var.secrets[each.key]
 }


### PR DESCRIPTION
## Summary

- `aws_ssm_parameter.secrets` iterated over `var.secrets` directly, but OpenTofu/Terraform forbids sensitive values as `for_each` keys (keys appear in state/plan output)
- Changed `for_each = var.secrets` → `for_each = nonsensitive(var.secrets)`
- Secret *values* are still written as `SecureString`; only the parameter *names* (map keys) are treated as non-sensitive, which is correct since parameter names are not secret

## Test plan

- [ ] Verify `tofu validate` passes in neil-terraform after `tofu init -upgrade` picks up this change
- [ ] Verify `tofu plan` no longer errors on the sensitive `for_each`

🤖 Generated with [Claude Code](https://claude.com/claude-code)