### PR TITLE
Show sign-in errors inline instead of raw JSON

### DIFF
--- a/app/javascript/Authentication/DeviseSignInPage.tsx
+++ b/app/javascript/Authentication/DeviseSignInPage.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { AuthenticityTokensContext } from '../AuthenticityTokensContext';
@@ -10,12 +10,36 @@ function DeviseSignInPage() {
   const manager = useContext(AuthenticityTokensContext);
   const authenticityToken = manager.tokens?.signIn;
   const { conventionName, oauthAppName, siteName } = useSignInContext();
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
   const header = conventionName
     ? t('authentication.signInForm.headerWithConvention', { conventionName })
     : oauthAppName
       ? t('authentication.signInForm.headerWithOAuthApp', { appName: oauthAppName })
       : t('authentication.signInForm.header');
   usePageTitle(header);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      const response = await fetch('/users/sign_in', {
+        method: 'POST',
+        body: new FormData(event.currentTarget),
+      });
+      if (response.ok) {
+        window.location.href = response.url || '/';
+      } else {
+        const data = (await response.json()) as { error?: string };
+        setError(data.error ?? t('authentication.signInForm.genericError'));
+      }
+    } catch {
+      setError(t('authentication.signInForm.genericError'));
+    } finally {
+      setSubmitting(false);
+    }
+  }
 
   return (
     <div className="container mt-5">
@@ -39,8 +63,13 @@ function DeviseSignInPage() {
                   })}
                 </p>
               )}
-              <form action="/users/sign_in" method="post">
+              <form onSubmit={handleSubmit}>
                 <input type="hidden" name="authenticity_token" value={authenticityToken ?? ''} />
+                {error && (
+                  <div className="alert alert-danger mb-3" role="alert">
+                    {error}
+                  </div>
+                )}
                 <div className="mb-3">
                   <label htmlFor="user_email" className="form-label">
                     {t('authentication.signInForm.emailLabel')}
@@ -82,7 +111,7 @@ function DeviseSignInPage() {
                   </label>
                 </div>
                 <div className="d-grid">
-                  <button type="submit" className="btn btn-primary" disabled={!authenticityToken}>
+                  <button type="submit" className="btn btn-primary" disabled={!authenticityToken || submitting}>
                     {t('authentication.signInForm.logInButton')}
                   </button>
                 </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -656,6 +656,7 @@
       "headerWithConvention": "Log in to {{conventionName}}",
       "hostingExplanationWithConvention": "{{conventionName}} uses {{siteName}} to manage user accounts. You'll be directed back to the {{conventionName}} website after signing in.",
       "hostingExplanationWithOAuthApp": "{{appName}} uses {{siteName}} to manage user accounts. You'll be directed back to {{appName}} after signing in.",
+      "genericError": "An error occurred. Please try again.",
       "logInButton": "Log in",
       "passwordLabel": "Password",
       "rememberMeLabel": "Remember me",


### PR DESCRIPTION
### Purpose

User-reported bug: entering wrong credentials on the sign-in page shows a raw JSON object (`{"error": "Invalid email or password."}`) instead of a user-friendly error message.

The root cause is `JSONFailureApp`, which was written to always return JSON for API clients. When the sign-in page was converted to a React component, the form was left as a plain HTML `<form>` with `action` and `method` attributes. On a failed login, Devise hands off to `JSONFailureApp`, which sends back JSON — and the browser, receiving JSON in response to a form POST, just renders it as text.

The fix converts the form to submit via `fetch()`. On a 401 response, the component reads the `error` field from the JSON and displays it in a Bootstrap alert above the fields. On success, it navigates to `response.url` (wherever Devise redirected to). `JSONFailureApp` doesn't need to change — it's doing the right thing, the form just wasn't reading its response.

### Release plan and notes

🚢

🤖 Generated with [Claude Code](https://claude.com/claude-code)