### PR TITLE
Use response_body instead of deprecated body in forwardemail_receiving

### DIFF
--- a/terraform/modules/forwardemail_receiving/main.tf
+++ b/terraform/modules/forwardemail_receiving/main.tf
@@ -18,7 +18,7 @@ data "http" "domains" {
 }
 
 locals {
-  pages = [for page in data.http.domains : jsondecode(page.body)]
+  pages = [for page in data.http.domains : jsondecode(page.response_body)]
   domains = toset(concat(local.pages...))
 
   # The API can occasionally return duplicate entries across pages; take the


### PR DESCRIPTION
## Summary

- The `hashicorp/http` provider deprecated the `body` attribute in favor of `response_body`
- `terraform/modules/forwardemail_receiving/main.tf` was still using `.body` when decoding the ForwardEmail API response, producing a deprecation warning during `tofu plan`

## Test plan

- [ ] Verify `tofu plan` no longer shows the "Value derived from a deprecated source" warning after `tofu init -upgrade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)