### PR TITLE
Add DATABASE_URL, SECRET_KEY_BASE, and OPENID_CONNECT_SIGNING_KEY to SSM

### DIFF
--- a/terraform/modules/intercode_aws_resources/main.tf
+++ b/terraform/modules/intercode_aws_resources/main.tf
@@ -4,6 +4,14 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
   }
 }
 

--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -33,3 +33,33 @@ resource "aws_ssm_parameter" "secrets" {
   type  = "SecureString"
   value = var.secrets[each.key]
 }
+
+resource "aws_ssm_parameter" "database_url" {
+  name  = "${local.ssm_path_prefix}/DATABASE_URL"
+  type  = "SecureString"
+  value = var.database_url
+}
+
+resource "random_password" "secret_key_base" {
+  count   = var.secret_key_base == null ? 1 : 0
+  length  = 128
+  special = false
+}
+
+resource "aws_ssm_parameter" "secret_key_base" {
+  name  = "${local.ssm_path_prefix}/SECRET_KEY_BASE"
+  type  = "SecureString"
+  value = var.secret_key_base != null ? var.secret_key_base : random_password.secret_key_base[0].result
+}
+
+resource "tls_private_key" "openid_connect_signing_key" {
+  count     = var.openid_connect_signing_key == null ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_ssm_parameter" "openid_connect_signing_key" {
+  name  = "${local.ssm_path_prefix}/OPENID_CONNECT_SIGNING_KEY"
+  type  = "SecureString"
+  value = var.openid_connect_signing_key != null ? var.openid_connect_signing_key : tls_private_key.openid_connect_signing_key[0].private_key_pem
+}

--- a/terraform/modules/intercode_aws_resources/variables.tf
+++ b/terraform/modules/intercode_aws_resources/variables.tf
@@ -15,8 +15,28 @@ variable "alarm_email_destinations" {
 }
 
 variable "secrets" {
-  description = "Map of secret name to value for manually-managed secrets (e.g. DATABASE_URL, SECRET_KEY_BASE). Written to SSM Parameter Store as SecureString and loaded by chamber at app boot."
+  description = "Map of secret name to value for manually-managed secrets. Written to SSM Parameter Store as SecureString and loaded by chamber at app boot."
   type        = map(string)
   sensitive   = true
   default     = {}
+}
+
+variable "database_url" {
+  description = "Full database connection URL (e.g. postgres://user:pass@host/db). Required — Intercode will not function without it."
+  type        = string
+  sensitive   = true
+}
+
+variable "secret_key_base" {
+  description = "Rails SECRET_KEY_BASE. If null, a random 128-character value is generated."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "openid_connect_signing_key" {
+  description = "RSA private key PEM for OpenID Connect token signing. If null, a 4096-bit key is generated."
+  type        = string
+  sensitive   = true
+  default     = null
 }


### PR DESCRIPTION
## Summary

Extends `intercode_aws_resources` to manage three more required secrets in SSM Parameter Store:

- **`DATABASE_URL`**: new required variable — Intercode won't function without it
- **`SECRET_KEY_BASE`**: optional variable; if not provided, a random 128-character value is generated via `random_password`
- **`OPENID_CONNECT_SIGNING_KEY`**: optional variable; if not provided, a 4096-bit RSA key is generated via `tls_private_key`

The generate-if-absent path only fires for new deployments. Existing deployments pass their current values as variables, so `count = 0` on the `random_password` and `tls_private_key` resources — no import needed.

Adds `hashicorp/random` and `hashicorp/tls` to the module's `required_providers`.

## Test plan

- [ ] `tofu init -upgrade` picks up the new providers
- [ ] `tofu plan` shows new SSM parameters to create for the existing deployment (no unexpected destroys)
- [ ] For a fresh deployment with no variables passed, plan shows `random_password` and `tls_private_key` resources being created

🤖 Generated with [Claude Code](https://claude.com/claude-code)