### PR TITLE
Add sentry module; add optional SSM writing to forwardemail_receiving

### DIFF
--- a/terraform/modules/forwardemail_receiving/main.tf
+++ b/terraform/modules/forwardemail_receiving/main.tf
@@ -1,10 +1,21 @@
 terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
     http = {
       source  = "hashicorp/http"
       version = ">= 3.0"
     }
   }
+}
+
+resource "aws_ssm_parameter" "forwardemail_api_key" {
+  count = var.ssm_name != null ? 1 : 0
+  name  = "/${var.ssm_name}/FORWARDEMAIL_API_KEY"
+  type  = "SecureString"
+  value = var.api_key
 }
 
 data "http" "domains" {

--- a/terraform/modules/forwardemail_receiving/variables.tf
+++ b/terraform/modules/forwardemail_receiving/variables.tf
@@ -9,3 +9,9 @@ variable "page_count" {
   type        = number
   default     = 2
 }
+
+variable "ssm_name" {
+  description = "If set, write FORWARDEMAIL_API_KEY to SSM at /{ssm_name}/FORWARDEMAIL_API_KEY."
+  type        = string
+  default     = null
+}

--- a/terraform/modules/sentry/main.tf
+++ b/terraform/modules/sentry/main.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    sentry = {
+      source  = "jianyuan/sentry"
+      version = ">= 0.15.0"
+    }
+  }
+}
+
+data "sentry_all_keys" "this" {
+  organization = var.organization
+  project      = var.project
+}
+
+locals {
+  ssm_path_prefix = "/${var.ssm_name}"
+  dsn             = data.sentry_all_keys.this.keys[0].dsn["public"]
+}
+
+resource "aws_ssm_parameter" "sentry_dsn" {
+  name  = "${local.ssm_path_prefix}/SENTRY_DSN"
+  type  = "SecureString"
+  value = local.dsn
+}
+
+resource "aws_ssm_parameter" "sentry_frontend_dsn" {
+  name  = "${local.ssm_path_prefix}/SENTRY_FRONTEND_DSN"
+  type  = "SecureString"
+  value = local.dsn
+}
+
+resource "aws_ssm_parameter" "sentry_organization_id" {
+  name  = "${local.ssm_path_prefix}/SENTRY_ORGANIZATION_ID"
+  type  = "String"
+  value = var.organization
+}
+
+resource "aws_ssm_parameter" "sentry_project_slugs" {
+  name  = "${local.ssm_path_prefix}/SENTRY_PROJECT_SLUGS"
+  type  = "String"
+  value = var.project
+}
+
+resource "aws_ssm_parameter" "sentry_release_token" {
+  name  = "${local.ssm_path_prefix}/SENTRY_RELEASE_TOKEN"
+  type  = "SecureString"
+  value = var.release_token
+}

--- a/terraform/modules/sentry/variables.tf
+++ b/terraform/modules/sentry/variables.tf
@@ -1,0 +1,20 @@
+variable "ssm_name" {
+  description = "SSM path prefix (e.g. 'intercode_production'). Parameters are written at /{ssm_name}/SENTRY_*."
+  type        = string
+}
+
+variable "organization" {
+  description = "Sentry organization slug."
+  type        = string
+}
+
+variable "project" {
+  description = "Sentry project slug."
+  type        = string
+}
+
+variable "release_token" {
+  description = "Sentry auth token used for creating releases (e.g. via sentry-cli)."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

- **New `terraform/modules/sentry`**: looks up the project's DSN via `data "sentry_all_keys"` and writes 5 SSM parameters — `SENTRY_DSN`, `SENTRY_FRONTEND_DSN`, `SENTRY_ORGANIZATION_ID`, `SENTRY_PROJECT_SLUGS`, `SENTRY_RELEASE_TOKEN` — at `/{ssm_name}/*`
- **`terraform/modules/forwardemail_receiving`**: adds optional `ssm_name` variable; when set, writes `FORWARDEMAIL_API_KEY` to `/{ssm_name}/FORWARDEMAIL_API_KEY`. Adds `hashicorp/aws` to required providers.

## Test plan

- [ ] `tofu init -upgrade` picks up the new `sentry` module and updated `forwardemail_receiving`
- [ ] `tofu plan` shows 6 new SSM parameters to create (5 Sentry + 1 ForwardEmail), no unexpected changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)