### PR TITLE
Fix sentry provider version constraint to allow beta3

### DIFF
--- a/terraform/modules/sentry/main.tf
+++ b/terraform/modules/sentry/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     sentry = {
       source  = "jianyuan/sentry"
-      version = ">= 0.15.0"
+      version = ">= 0.15.0-beta3"
     }
   }
 }


### PR DESCRIPTION
## Summary

The `sentry` module specified `>= 0.15.0` but the installed version is `0.15.0-beta3`, which doesn't satisfy that constraint. Changed to `>= 0.15.0-beta3` to match the pin in neil-terraform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)