### PR TITLE
Add optional fly_api_token SSM parameter to intercode_aws_resources

### DIFF
--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -26,6 +26,13 @@ resource "aws_ssm_parameter" "aws_region" {
   value = local.region
 }
 
+resource "aws_ssm_parameter" "fly_api_token" {
+  count = var.fly_api_token != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/FLY_API_TOKEN"
+  type  = "SecureString"
+  value = var.fly_api_token
+}
+
 resource "aws_ssm_parameter" "secrets" {
   for_each = toset(nonsensitive(keys(var.secrets)))
 

--- a/terraform/modules/intercode_aws_resources/variables.tf
+++ b/terraform/modules/intercode_aws_resources/variables.tf
@@ -40,3 +40,10 @@ variable "openid_connect_signing_key" {
   sensitive   = true
   default     = null
 }
+
+variable "fly_api_token" {
+  description = "Fly.io API token for runtime use (e.g. auto-scaling). Optional — not required for all deployments."
+  type        = string
+  sensitive   = true
+  default     = null
+}


### PR DESCRIPTION
## Summary

Adds an optional `fly_api_token` variable to the `intercode_aws_resources` module. When provided, writes `FLY_API_TOKEN` to SSM at `/{name}/FLY_API_TOKEN` as a `SecureString`.

Not all Intercode deployments need this — it's only used by deployments that auto-scale using the Fly API.

## Test plan

- [ ] `tofu plan` shows one new SSM parameter when `fly_api_token` is set, no changes when it's null

🤖 Generated with [Claude Code](https://claude.com/claude-code)