### PR TITLE
Add optional stripe, recaptcha, and twilio SSM parameters

### DIFF
--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -33,6 +33,55 @@ resource "aws_ssm_parameter" "fly_api_token" {
   value = var.fly_api_token
 }
 
+resource "aws_ssm_parameter" "stripe_secret_key" {
+  count = var.stripe != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/STRIPE_SECRET_KEY"
+  type  = "SecureString"
+  value = var.stripe.secret_key
+}
+
+resource "aws_ssm_parameter" "stripe_publishable_key" {
+  count = var.stripe != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/STRIPE_PUBLISHABLE_KEY"
+  type  = "SecureString"
+  value = var.stripe.publishable_key
+}
+
+resource "aws_ssm_parameter" "stripe_connect_endpoint_secret" {
+  count = var.stripe != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/STRIPE_CONNECT_ENDPOINT_SECRET"
+  type  = "SecureString"
+  value = var.stripe.connect_endpoint_secret
+}
+
+resource "aws_ssm_parameter" "recaptcha_secret_key" {
+  count = var.recaptcha != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/RECAPTCHA_SECRET_KEY"
+  type  = "SecureString"
+  value = var.recaptcha.secret_key
+}
+
+resource "aws_ssm_parameter" "recaptcha_site_key" {
+  count = var.recaptcha != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/RECAPTCHA_SITE_KEY"
+  type  = "SecureString"
+  value = var.recaptcha.site_key
+}
+
+resource "aws_ssm_parameter" "twilio_account_sid" {
+  count = var.twilio != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/TWILIO_ACCOUNT_SID"
+  type  = "SecureString"
+  value = var.twilio.account_sid
+}
+
+resource "aws_ssm_parameter" "twilio_auth_token" {
+  count = var.twilio != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/TWILIO_AUTH_TOKEN"
+  type  = "SecureString"
+  value = var.twilio.auth_token
+}
+
 resource "aws_ssm_parameter" "secrets" {
   for_each = toset(nonsensitive(keys(var.secrets)))
 

--- a/terraform/modules/intercode_aws_resources/variables.tf
+++ b/terraform/modules/intercode_aws_resources/variables.tf
@@ -47,3 +47,34 @@ variable "fly_api_token" {
   sensitive   = true
   default     = null
 }
+
+variable "stripe" {
+  description = "Stripe API credentials. If null, no Stripe SSM parameters are written."
+  type = object({
+    secret_key              = string
+    publishable_key         = string
+    connect_endpoint_secret = string
+  })
+  sensitive = true
+  default   = null
+}
+
+variable "recaptcha" {
+  description = "Google reCAPTCHA credentials. If null, no reCAPTCHA SSM parameters are written."
+  type = object({
+    secret_key = string
+    site_key   = string
+  })
+  sensitive = true
+  default   = null
+}
+
+variable "twilio" {
+  description = "Twilio credentials. If null, no Twilio SSM parameters are written."
+  type = object({
+    account_sid = string
+    auth_token  = string
+  })
+  sensitive = true
+  default   = null
+}


### PR DESCRIPTION
## Summary

Adds three optional typed-object variables to `intercode_aws_resources`. When provided, each group writes its sub-keys to SSM as `SecureString`. When null (the default), nothing is written — so non-Intercode deployments aren't affected.

- **`stripe`**: `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_CONNECT_ENDPOINT_SECRET`
- **`recaptcha`**: `RECAPTCHA_SECRET_KEY`, `RECAPTCHA_SITE_KEY`
- **`twilio`**: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`

## Test plan

- [ ] `tofu plan` shows 7 new SSM parameters when all three objects are set
- [ ] `tofu plan` shows no changes for a deployment that passes `null` for all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)