### PR TITLE
Add EMAIL_FORWARDERS_API_TOKEN to intercode_aws_resources SSM

### DIFF
--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -26,6 +26,18 @@ resource "aws_ssm_parameter" "aws_region" {
   value = local.region
 }
 
+resource "random_password" "email_forwarders_api_token" {
+  count   = var.email_forwarders_api_token == null ? 1 : 0
+  length  = 128
+  special = false
+}
+
+resource "aws_ssm_parameter" "email_forwarders_api_token" {
+  name  = "${local.ssm_path_prefix}/EMAIL_FORWARDERS_API_TOKEN"
+  type  = "SecureString"
+  value = var.email_forwarders_api_token != null ? var.email_forwarders_api_token : random_password.email_forwarders_api_token[0].result
+}
+
 resource "aws_ssm_parameter" "fly_api_token" {
   count = var.fly_api_token != null ? 1 : 0
   name  = "${local.ssm_path_prefix}/FLY_API_TOKEN"

--- a/terraform/modules/intercode_aws_resources/variables.tf
+++ b/terraform/modules/intercode_aws_resources/variables.tf
@@ -41,6 +41,13 @@ variable "openid_connect_signing_key" {
   default     = null
 }
 
+variable "email_forwarders_api_token" {
+  description = "Secret key used to authenticate email forwarding requests. If null, a random value is generated."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
 variable "fly_api_token" {
   description = "Fly.io API token for runtime use (e.g. auto-scaling). Optional — not required for all deployments."
   type        = string


### PR DESCRIPTION
## Summary

Adds an optional `email_forwarders_api_token` variable to `intercode_aws_resources`. Follows the same pattern as `secret_key_base` — if null, a random 128-character value is generated via `random_password` and stored in SSM. Existing deployments can pass their current value to preserve it.

## Test plan

- [ ] `tofu plan` shows 1 new SSM parameter when the variable is set or null
- [ ] Passing the existing value preserves it; passing null generates a new random value

🤖 Generated with [Claude Code](https://claude.com/claude-code)