### PR TITLE
Add optional autoscale SSM parameters to intercode_aws_resources

### DIFF
--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -94,6 +94,20 @@ resource "aws_ssm_parameter" "twilio_auth_token" {
   value = var.twilio.auth_token
 }
 
+resource "aws_ssm_parameter" "autoscale_min_instances" {
+  count = var.autoscale != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/AUTOSCALE_MIN_INSTANCES"
+  type  = "String"
+  value = tostring(var.autoscale.min_instances)
+}
+
+resource "aws_ssm_parameter" "autoscale_max_instances" {
+  count = var.autoscale != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/AUTOSCALE_MAX_INSTANCES"
+  type  = "String"
+  value = tostring(var.autoscale.max_instances)
+}
+
 resource "aws_ssm_parameter" "secrets" {
   for_each = toset(nonsensitive(keys(var.secrets)))
 

--- a/terraform/modules/intercode_aws_resources/variables.tf
+++ b/terraform/modules/intercode_aws_resources/variables.tf
@@ -85,3 +85,12 @@ variable "twilio" {
   sensitive = true
   default   = null
 }
+
+variable "autoscale" {
+  description = "Fly.io auto-scaling configuration. If null, no autoscale SSM parameters are written."
+  type = object({
+    min_instances = number
+    max_instances = number
+  })
+  default = null
+}


### PR DESCRIPTION
## Summary

- Adds an optional `autoscale` variable to the `intercode_aws_resources` module (type `object({ min_instances, max_instances })`, default `null`)
- When non-null, writes `AUTOSCALE_MIN_INSTANCES` and `AUTOSCALE_MAX_INSTANCES` to SSM Parameter Store as plain strings
- Allows removing these values from `fly.toml`'s `[env]` section once chamber is wired up

## Test plan

- [ ] `tofu init -upgrade` in neil-terraform picks up the new module version
- [ ] `tofu plan` shows 2 new SSM parameters: `/intercode_production/AUTOSCALE_MIN_INSTANCES` and `/intercode_production/AUTOSCALE_MAX_INSTANCES`
- [ ] `tofu apply` creates them successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)