### PR TITLE
Add assets_host, uploads_host, cloudwatch_log_group SSM parameters

### DIFF
--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -108,6 +108,27 @@ resource "aws_ssm_parameter" "autoscale_max_instances" {
   value = tostring(var.autoscale.max_instances)
 }
 
+resource "aws_ssm_parameter" "assets_host" {
+  count = var.assets_host != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/ASSETS_HOST"
+  type  = "String"
+  value = var.assets_host
+}
+
+resource "aws_ssm_parameter" "uploads_host" {
+  count = var.uploads_host != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/UPLOADS_HOST"
+  type  = "String"
+  value = var.uploads_host
+}
+
+resource "aws_ssm_parameter" "cloudwatch_log_group" {
+  count = var.cloudwatch_log_group != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/CLOUDWATCH_LOG_GROUP"
+  type  = "String"
+  value = var.cloudwatch_log_group
+}
+
 resource "aws_ssm_parameter" "secrets" {
   for_each = toset(nonsensitive(keys(var.secrets)))
 

--- a/terraform/modules/intercode_aws_resources/variables.tf
+++ b/terraform/modules/intercode_aws_resources/variables.tf
@@ -94,3 +94,21 @@ variable "autoscale" {
   })
   default = null
 }
+
+variable "assets_host" {
+  description = "Hostname for the assets CDN (e.g. 'assets.neilhosting.net'). If null, no SSM parameter is written."
+  type        = string
+  default     = null
+}
+
+variable "uploads_host" {
+  description = "Full URL for the uploads CDN (e.g. 'https://uploads.neilhosting.net'). If null, no SSM parameter is written."
+  type        = string
+  default     = null
+}
+
+variable "cloudwatch_log_group" {
+  description = "Name of the CloudWatch log group for the app. If null, no SSM parameter is written."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary

- Adds optional `assets_host`, `uploads_host`, and `cloudwatch_log_group` variables to `intercode_aws_resources`
- When non-null, writes `ASSETS_HOST`, `UPLOADS_HOST`, and `CLOUDWATCH_LOG_GROUP` to SSM Parameter Store as plain strings
- Allows removing these from `fly.toml`'s `[env]` section once chamber is wired up

## Test plan

- [ ] `tofu init -upgrade` picks up the updated module
- [ ] `tofu plan` shows 3 new SSM parameters: `ASSETS_HOST`, `UPLOADS_HOST`, `CLOUDWATCH_LOG_GROUP`
- [ ] `tofu apply` creates them successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)