### PR TITLE
Add INTERCODE_HOST, INTERCODE_CERTS, TWILIO_SMS_NUMBER, and Sentry sample rate SSM params

### DIFF
--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -94,6 +94,27 @@ resource "aws_ssm_parameter" "twilio_auth_token" {
   value = var.twilio.auth_token
 }
 
+resource "aws_ssm_parameter" "twilio_sms_number" {
+  count = var.twilio != null && var.twilio.sms_number != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/TWILIO_SMS_NUMBER"
+  type  = "String"
+  value = var.twilio.sms_number
+}
+
+resource "aws_ssm_parameter" "intercode_host" {
+  count = var.intercode_host != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/INTERCODE_HOST"
+  type  = "String"
+  value = var.intercode_host
+}
+
+resource "aws_ssm_parameter" "intercode_certs_no_wildcard_domains" {
+  count = var.intercode_certs_no_wildcard_domains != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/INTERCODE_CERTS_NO_WILDCARD_DOMAINS"
+  type  = "String"
+  value = var.intercode_certs_no_wildcard_domains
+}
+
 resource "aws_ssm_parameter" "autoscale_min_instances" {
   count = var.autoscale != null ? 1 : 0
   name  = "${local.ssm_path_prefix}/AUTOSCALE_MIN_INSTANCES"

--- a/terraform/modules/intercode_aws_resources/variables.tf
+++ b/terraform/modules/intercode_aws_resources/variables.tf
@@ -81,6 +81,7 @@ variable "twilio" {
   type = object({
     account_sid = string
     auth_token  = string
+    sms_number  = optional(string)
   })
   sensitive = true
   default   = null
@@ -109,6 +110,18 @@ variable "uploads_host" {
 
 variable "cloudwatch_log_group" {
   description = "Name of the CloudWatch log group for the app. If null, no SSM parameter is written."
+  type        = string
+  default     = null
+}
+
+variable "intercode_host" {
+  description = "Primary hostname for the Intercode deployment (e.g. 'www.neilhosting.net'). If null, no SSM parameter is written."
+  type        = string
+  default     = null
+}
+
+variable "intercode_certs_no_wildcard_domains" {
+  description = "Space-separated list of domains that need individual TLS certs rather than wildcards. If null, no SSM parameter is written."
   type        = string
   default     = null
 }

--- a/terraform/modules/sentry/main.tf
+++ b/terraform/modules/sentry/main.tf
@@ -50,3 +50,17 @@ resource "aws_ssm_parameter" "sentry_release_token" {
   type  = "SecureString"
   value = var.release_token
 }
+
+resource "aws_ssm_parameter" "sentry_traces_sample_rate" {
+  count = var.traces_sample_rate != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/SENTRY_TRACES_SAMPLE_RATE"
+  type  = "String"
+  value = var.traces_sample_rate
+}
+
+resource "aws_ssm_parameter" "sentry_profiles_sample_rate" {
+  count = var.profiles_sample_rate != null ? 1 : 0
+  name  = "${local.ssm_path_prefix}/SENTRY_PROFILES_SAMPLE_RATE"
+  type  = "String"
+  value = var.profiles_sample_rate
+}

--- a/terraform/modules/sentry/variables.tf
+++ b/terraform/modules/sentry/variables.tf
@@ -18,3 +18,15 @@ variable "release_token" {
   type        = string
   sensitive   = true
 }
+
+variable "traces_sample_rate" {
+  description = "Sentry performance traces sample rate (0.0–1.0). If null, no SSM parameter is written."
+  type        = string
+  default     = null
+}
+
+variable "profiles_sample_rate" {
+  description = "Sentry profiling sample rate (0.0–1.0). If null, no SSM parameter is written."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary

- `intercode_aws_resources`: adds `intercode_host`, `intercode_certs_no_wildcard_domains`, and `twilio.sms_number` (optional field on existing object) with corresponding SSM parameters
- `sentry`: adds optional `traces_sample_rate` and `profiles_sample_rate` variables with corresponding SSM parameters
- All new parameters are plain `String` type (non-sensitive)

## Test plan

- [ ] `tofu init -upgrade` picks up the updated module
- [ ] `tofu plan` shows 5 new SSM parameters: `INTERCODE_HOST`, `INTERCODE_CERTS_NO_WILDCARD_DOMAINS`, `TWILIO_SMS_NUMBER`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_PROFILES_SAMPLE_RATE`
- [ ] `tofu apply` creates them successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)