### PR TITLE
Wire up Fly OIDC → AWS IAM role for chamber credential bootstrap

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -2,6 +2,19 @@
 set -e
 
 if [ -n "$CHAMBER_SERVICE" ]; then
+  if [ -n "$CHAMBER_AWS_ROLE_ARN" ]; then
+    TOKEN_FILE=$(mktemp)
+    curl -sf --unix-socket /.fly/api \
+      -X POST "http://localhost/v1/tokens/oidc" \
+      -H "Content-Type: application/json" \
+      --data '{"aud":"sts.amazonaws.com"}' \
+      | python3 -c "import sys,json; print(json.load(sys.stdin)['token'],end='')" \
+      > "$TOKEN_FILE"
+    export AWS_ROLE_ARN="$CHAMBER_AWS_ROLE_ARN"
+    export AWS_WEB_IDENTITY_TOKEN_FILE="$TOKEN_FILE"
+    export AWS_ROLE_SESSION_NAME="chamber"
+    unset CHAMBER_AWS_ROLE_ARN
+  fi
   exec chamber exec "$CHAMBER_SERVICE" -- "$@"
 else
   exec "$@"

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,7 @@
 app = "intercode"
 primary_region = "iad"
 swap_size_mb = 512
+console_command = "/usr/src/intercode/bin/entrypoint.sh /bin/bash"
 
 [build]
 image = "ghcr.io/neinteractiveliterature/intercode:latest"

--- a/fly.toml
+++ b/fly.toml
@@ -16,7 +16,7 @@ strategy = "bluegreen"
 
 [env]
 CHAMBER_SERVICE = "intercode_production"
-CHAMBER_AWS_ROLE_ARN = "" # filled in after tofu apply outputs intercode_chamber_role_arn
+CHAMBER_AWS_ROLE_ARN = "arn:aws:iam::689053117832:role/intercode-chamber"
 AWS_REGION = "us-east-1"
 ASSETS_HOST = "assets.neilhosting.net"
 AUTOSCALE_MIN_INSTANCES = "2"

--- a/fly.toml
+++ b/fly.toml
@@ -15,8 +15,9 @@ release_command = "bundle exec rails release:perform --trace"
 strategy = "bluegreen"
 
 [env]
-# Uncomment this once we're ready to move to Chamber-provided config
-# CHAMBER_SERVICE = "intercode_production"
+CHAMBER_SERVICE = "intercode_production"
+CHAMBER_AWS_ROLE_ARN = "" # filled in after tofu apply outputs intercode_chamber_role_arn
+AWS_REGION = "us-east-1"
 ASSETS_HOST = "assets.neilhosting.net"
 AUTOSCALE_MIN_INSTANCES = "2"
 AUTOSCALE_MAX_INSTANCES = "10"


### PR DESCRIPTION
## Summary

- Updates `bin/entrypoint.sh` to exchange a Fly OIDC token for temporary AWS credentials via `AWS_WEB_IDENTITY_TOKEN_FILE` before running chamber — no long-lived AWS keys needed as Fly secrets
- Uncomments `CHAMBER_SERVICE = "intercode_production"` in `fly.toml`
- Adds `AWS_REGION = "us-east-1"` to `fly.toml [env]` (needed before chamber loads SSM)
- Adds `CHAMBER_AWS_ROLE_ARN` placeholder (filled in after the corresponding neil-terraform apply)

## How it works

1. entrypoint fetches a short-lived Fly OIDC JWT from the machine's internal API socket
2. Writes it to a temp file and sets `AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`
3. The AWS SDK in chamber automatically calls STS `AssumeRoleWithWebIdentity` and gets temporary credentials
4. chamber reads `/intercode_production/*` from SSM using those credentials
5. The app starts with all secrets in the environment

## Test plan

- [ ] Apply neil-terraform to create the IAM OIDC provider and chamber role
- [ ] Fill in `CHAMBER_AWS_ROLE_ARN` in `fly.toml` with the Terraform output
- [ ] Deploy and verify all SSM-backed env vars are present
- [ ] Unset `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` Fly secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)