### PR TITLE
Fix chamber exec failing on --trace flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ USER root
 # shared-mime-info: Rails dependency
 # libpq5: pg gem dependency
 # mariadb-client: dependency for Intercode 1 import
-RUN apt-get update && apt-get install -y --no-install-recommends openssh-server iproute2 curl python3 libvips42 poppler-utils xz-utils libjemalloc2 shared-mime-info libpq5 mariadb-client && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends openssh-server iproute2 curl python3 libvips42 poppler-utils xz-utils libjemalloc2 shared-mime-info libpq5 mariadb-client gosu && rm -rf /var/lib/apt/lists/*
 RUN useradd -ms $(which bash) www
 RUN mkdir /opt/node && \
   cd /opt/node && \

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 set -e
 
-# Drop to the www user while preserving the current environment (needed so
-# AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE are visible to the app process).
-# If already running as www (e.g. in tests), just exec directly.
 drop_to_www() {
   if [ "$(id -u)" -eq 0 ]; then
-    exec su -s /bin/bash --preserve-environment -c 'exec "$0" "$@"' www "$@"
+    exec gosu www "$@"
   else
     exec "$@"
   fi

--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,7 @@ console_command = "/usr/src/intercode/bin/entrypoint.sh /bin/bash"
 image = "ghcr.io/neinteractiveliterature/intercode:latest"
 
 [deploy]
-release_command = "bundle exec rails release:perform --trace"
+release_command = "bundle exec rails release:perform"
 strategy = "bluegreen"
 
 [env]


### PR DESCRIPTION
### Purpose

Two more fixes for the deployment/release-command flow, following on from the OIDC token work.

Chamber 3.1.5 uses cobra for CLI parsing, and cobra has a known quirk where it consumes `--trace` even after the `--` argument separator. So `chamber exec SERVICE -- bundle exec rails release:perform --trace` was failing with `Error: unknown flag: --trace`. The fix is just to drop `--trace` from the `release_command` in `fly.toml` — it's a Rails debug flag that's not useful in production anyway.

While in here, I also replaced the `su --preserve-environment` approach in `drop_to_www()` with `gosu`. `gosu` exec's directly without spawning an intermediate shell, which is cleaner and sidesteps any argument-mangling in the shell invocation layer. This also removes the need to install gosu separately — it's in the Debian package repos.

### Changes

- `fly.toml`: remove `--trace` from `release_command`
- `bin/entrypoint.sh`: replace `su --preserve-environment` with `exec gosu www "$@"`
- `Dockerfile`: add `gosu` to the `apt-get install` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)