### PR TITLE
Fix OAuth callback login failures

### DIFF
--- a/app/javascript/Authentication/OAuthCallback.tsx
+++ b/app/javascript/Authentication/OAuthCallback.tsx
@@ -32,6 +32,18 @@ function OAuthCallback() {
     handleCallback();
   }, [authenticationManager]);
 
+  const handleRetry = async () => {
+    setProcessing(true);
+    setError(null);
+    try {
+      const { redirectUrl } = await authenticationManager.initiateAuthentication('/');
+      window.location.href = redirectUrl.toString();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Authentication failed');
+      setProcessing(false);
+    }
+  };
+
   if (processing) {
     return (
       <div className="container mt-4">
@@ -50,9 +62,14 @@ function OAuthCallback() {
       <div className="alert alert-danger">
         <h4>{t('authentication.oauthCallback.authenticationError')}</h4>
         <ErrorDisplay stringError={error} />
-        <Link className="btn btn-primary mt-3" to="/">
-          {t('authentication.oauthCallback.returnToHome')}
-        </Link>
+        <div className="mt-3 d-flex gap-2">
+          <button className="btn btn-primary" onClick={handleRetry}>
+            {t('authentication.oauthCallback.retryLogin')}
+          </button>
+          <Link className="btn btn-outline-secondary" to="/">
+            {t('authentication.oauthCallback.returnToHome')}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -58,6 +58,10 @@ const bootstrapPromise: Promise<Bootstrap> = (async () => {
   const client = buildBrowserApolloClient(authenticityTokensManager, authManager);
 
   window.addEventListener(GraphQLNotAuthenticatedErrorEvent.type, async () => {
+    // Don't interrupt an in-progress OAuth exchange on the callback page itself
+    if (window.location.pathname === '/oauth/callback') {
+      return;
+    }
     const { redirectUrl } = await authManager.initiateAuthentication(window.location.href);
     window.location.href = redirectUrl.toString();
   });

--- a/locales/en.json
+++ b/locales/en.json
@@ -633,6 +633,7 @@
     "oauthCallback": {
       "authenticationError": "Authentication Error",
       "completingLogin": "Completing login...",
+      "retryLogin": "Try logging in again",
       "returnToHome": "Return to Home"
     },
     "passwordInput": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -73,6 +73,7 @@
     "oauthCallback": {
       "authenticationError": "Authentication Error",
       "completingLogin": "Completing login...",
+      "retryLogin": "Try logging in again",
       "returnToHome": "Return to Home"
     },
     "passwordInput": {


### PR DESCRIPTION
### Purpose

Users were landing on a blank `/oauth/callback` page and getting stuck — `/oauth_session/exchange` was never called, and the page just sat there (or showed a confusing error with no way forward).

After digging through a HAR trace, the most likely culprit is a race condition: a `NOT_AUTHENTICATED` GraphQL error from any in-flight query could fire the `GraphQLNotAuthenticatedErrorEvent` handler while an OAuth exchange was already in progress. That handler calls `initiateAuthentication()`, which overwrites the PKCE challenge in `sessionStorage` and immediately redirects the user back to the OAuth server — replacing the valid PKCE state they'd arrived with. The exchange then fails because `currentLoginFlowData` is null, and the cycle potentially repeats.

Two fixes:

1. **Guard the event handler** (`application.tsx`): bail out immediately if `window.location.pathname === '/oauth/callback'`. There's no reason to start a new auth flow when we're actively trying to complete one.

2. **Make the error UI recoverable** (`OAuthCallback.tsx`): replaced the dead-end "Return to Home" button with a "Try logging in again" primary action that calls `initiateAuthentication('/')` and restarts the flow cleanly, plus keeps "Return to Home" as a secondary option. Previously, hitting the error state meant the user had to figure out on their own that they should navigate away and try again.

### Risks

The guard in #1 means that if somehow a user ends up on `/oauth/callback` without an active OAuth flow (e.g. bookmarked the URL), a NOT_AUTHENTICATED error won't auto-redirect them. They'd see the error UI instead, which now has the retry button — so they can still get logged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)