### PR TITLE
Fix cookie_behavior and query_string_behavior values in forward_all policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,27 @@ jobs:
         with:
           recreate: true
           path: code-coverage-results.md
+  opentofu-validate:
+    name: OpenTofu validate (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module:
+          - cloudfront_intercode
+          - forwardemail_receiving
+          - ses_email_receiving
+          - intercode_aws_resources
+          - sentry
+    steps:
+      - uses: actions/checkout@v6
+      - uses: opentofu/setup-opentofu@v1
+      - name: tofu init
+        run: tofu init -backend=false
+        working-directory: terraform/modules/${{ matrix.module }}
+      - name: tofu validate
+        run: tofu validate
+        working-directory: terraform/modules/${{ matrix.module }}
+
   update-release-draft:
     runs-on: ubuntu-latest
     name: Update release draft

--- a/terraform/modules/cloudfront_intercode/main.tf
+++ b/terraform/modules/cloudfront_intercode/main.tf
@@ -29,8 +29,8 @@ locals {
 resource "aws_cloudfront_origin_request_policy" "forward_all" {
   name = "${var.name}-forward-all"
 
-  cookies_config { cookie_behavior = "allViewer" }
-  query_strings_config { query_string_behavior = "allViewer" }
+  cookies_config { cookie_behavior = "all" }
+  query_strings_config { query_string_behavior = "all" }
   headers_config { header_behavior = "allViewer" }
 }
 


### PR DESCRIPTION
## Summary

- Fixes a Terraform validation error introduced in #11697
- `allViewer` is only valid for `header_behavior` in `aws_cloudfront_origin_request_policy`; the correct value for `cookie_behavior` and `query_string_behavior` is `"all"`

## Test plan

- [ ] `terraform plan` succeeds without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)