### PR TITLE
Catch boot/chunk-load failures instead of leaving a blank login page

### DIFF
--- a/app/javascript/BootErrorBoundary.tsx
+++ b/app/javascript/BootErrorBoundary.tsx
@@ -1,0 +1,97 @@
+/* eslint-disable i18next/no-literal-string -- This boundary is the last line of
+   defense for a broken boot; it must not depend on i18n (which may be exactly
+   what failed to load), so its copy is intentionally hard-coded English. */
+import { Component, ErrorInfo, ReactNode, CSSProperties } from 'react';
+import { reloadOnAppEntrypointHeadersMismatch } from './checkAppEntrypointHeadersMatch';
+import errorReporting from 'ErrorReporting';
+
+// Guard against an auto-reload loop: if we reloaded very recently, show the
+// manual fallback instead of reloading again.
+const RELOAD_GUARD_KEY = 'intercode.bootErrorReloadAt';
+const RELOAD_GUARD_WINDOW_MS = 15_000;
+
+function reloadedWithinGuardWindow(): boolean {
+  try {
+    const last = Number(sessionStorage.getItem(RELOAD_GUARD_KEY));
+    return Number.isFinite(last) && last > 0 && Date.now() - last < RELOAD_GUARD_WINDOW_MS;
+  } catch {
+    return false;
+  }
+}
+
+function markReloadAttempt(): void {
+  try {
+    sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+  } catch {
+    // sessionStorage may be unavailable (private mode / blocked); best effort.
+  }
+}
+
+const containerStyle: CSSProperties = {
+  maxWidth: '32rem',
+  margin: '4rem auto',
+  padding: '0 1rem',
+  fontFamily: 'system-ui, sans-serif',
+  textAlign: 'center',
+  lineHeight: 1.5,
+};
+
+const buttonStyle: CSSProperties = {
+  marginTop: '1rem',
+  padding: '0.5rem 1.25rem',
+  fontSize: '1rem',
+  cursor: 'pointer',
+};
+
+function BootErrorFallback() {
+  return (
+    <div style={containerStyle} role="alert">
+      <h1 style={{ fontSize: '1.25rem' }}>We couldn’t finish loading this page</h1>
+      <p>This is usually temporary and fixed by reloading. If it keeps happening, try again in a few minutes.</p>
+      <button type="button" style={buttonStyle} onClick={() => window.location.reload()}>
+        Reload the page
+      </button>
+    </div>
+  );
+}
+
+type Props = { children: ReactNode };
+type State = { hasError: boolean };
+
+// Catches failures during the SPA's initial boot/render — a rejected
+// bootstrapPromise, or an uncaught error rendering the route tree — that would
+// otherwise leave a blank white page with no recovery. A stale deploy (a chunk
+// hash that no longer exists) is the most common cause, so we try to reload
+// onto the fresh bundle; anything else gets a visible, reportable error instead
+// of a blank screen.
+export default class BootErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    try {
+      errorReporting().error(error, { tags: { context: 'boot' }, componentStack: info.componentStack });
+    } catch {
+      // Error reporting itself may be unavailable (e.g. its SDK was the chunk
+      // that failed to load); don't let that mask the fallback UI.
+    }
+
+    // Very often a blank boot is a stale deploy. If the deployed entrypoint has
+    // changed under this tab, reload to pick up the fresh bundle — but only if
+    // we didn't just try, so we never get stuck in a reload loop.
+    if (!reloadedWithinGuardWindow()) {
+      markReloadAttempt();
+      void reloadOnAppEntrypointHeadersMismatch();
+    }
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return <BootErrorFallback />;
+    }
+    return this.props.children;
+  }
+}

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -3,7 +3,7 @@ import 'regenerator-runtime/runtime';
 import mountReactComponents from '../mountReactComponents';
 import { StrictMode, Suspense, use, useLayoutEffect, useMemo, useState } from 'react';
 import AuthenticityTokensManager, { getAuthenticityTokensURL } from 'AuthenticityTokensContext';
-import { createBrowserRouter, RouterContextProvider, RouterProvider } from 'react-router';
+import { createBrowserRouter, RouterContextProvider, RouterProvider, RouteObject } from 'react-router';
 import { buildBrowserApolloClient, GraphQLNotAuthenticatedErrorEvent } from 'useIntercodeApolloClient';
 import {
   apolloClientContext,
@@ -18,6 +18,8 @@ import { AuthenticationManager, AuthenticationManagerContext } from '../Authenti
 import { PageLoadingIndicator } from '@neinteractiveliterature/litform';
 import { ApolloClient } from '@apollo/client';
 import { initErrorReporting } from 'ErrorReporting';
+import { checkAppEntrypointHeadersOnError } from '../checkAppEntrypointHeadersMatch';
+import BootErrorBoundary from '../BootErrorBoundary';
 
 type Bootstrap = {
   clientConfiguration: ClientConfiguration;
@@ -118,19 +120,37 @@ function RouterLoadingOverlay({ router }: { router: BrowserRouter }) {
   );
 }
 
+// Wrap every route's lazy import so a failed chunk load — almost always a stale
+// deploy whose hashed chunk no longer exists — reloads onto the fresh bundle
+// instead of surfacing as an unrecoverable blank. Applied once to the whole tree.
+function withEntrypointReloadOnLazy(routes: RouteObject[]): RouteObject[] {
+  return routes.map((route) => {
+    let { lazy } = route;
+    if (typeof lazy === 'function') {
+      const load = lazy;
+      lazy = () => checkAppEntrypointHeadersOnError(load);
+    }
+    return {
+      ...route,
+      lazy,
+      children: route.children ? withEntrypointReloadOnLazy(route.children) : route.children,
+    } as RouteObject;
+  });
+}
+
 function DataModeApplicationEntry() {
   const bootstrap = use(bootstrapPromise);
 
   const router = useMemo(
     () =>
       createBrowserRouter(
-        [
+        withEntrypointReloadOnLazy([
           {
             id: 'root',
             lazy: () => import('root'),
             children: appRootRoutes,
           },
-        ],
+        ]),
         {
           getContext: () => {
             const context = new RouterContextProvider();
@@ -158,9 +178,11 @@ function DataModeApplicationEntry() {
 
 function DataModeApplicationEntrySuspenseWrapper() {
   return (
-    <Suspense fallback={<PageLoadingIndicator visible />}>
-      <DataModeApplicationEntry />
-    </Suspense>
+    <BootErrorBoundary>
+      <Suspense fallback={<PageLoadingIndicator visible />}>
+        <DataModeApplicationEntry />
+      </Suspense>
+    </BootErrorBoundary>
   );
 }
 

--- a/test/javascript/BootErrorBoundary.test.tsx
+++ b/test/javascript/BootErrorBoundary.test.tsx
@@ -1,0 +1,36 @@
+import { vi } from 'vitest';
+import { render } from '@testing-library/react';
+import BootErrorBoundary from '../../app/javascript/BootErrorBoundary';
+
+function Boom(): never {
+  throw new Error('boom');
+}
+
+describe('BootErrorBoundary', () => {
+  it('renders its children when nothing throws', () => {
+    const { getByText } = render(
+      <BootErrorBoundary>
+        <div>app content</div>
+      </BootErrorBoundary>,
+    );
+
+    expect(getByText('app content')).toBeTruthy();
+  });
+
+  it('renders a reload fallback instead of a blank page when a child throws', () => {
+    // React logs caught boundary errors to console.error; silence it for this case.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const { getByRole, queryByText } = render(
+        <BootErrorBoundary>
+          <Boom />
+        </BootErrorBoundary>,
+      );
+
+      expect(getByRole('button', { name: /reload/i })).toBeTruthy();
+      expect(queryByText('app content')).toBeNull();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
### Purpose

Follow-up to the login work in #11693 — and a response to the round of Summer Larpin' "blank page on login" reports.

After a lot of digging this round, those blanks turned out to be **boot-level failures** that happen *before* React renders the route tree — so the `useLoginRequired` spinner fix (#11693, login-required *routes*) can't catch them, and the page goes **fully blank with no recovery**. I couldn't reproduce them in a clean browser (clean prod renders fine, even with Sentry/Rollbar/fonts blocked), which is itself the tell: they need real-user conditions — most commonly a **stale deploy** ("I did a lot of cacheless refreshing and it eventually worked" is the textbook signature), and for some users an adblocker or odd cache/session state. They're also invisible in Sentry (the failing chunk can be the Sentry SDK itself; adblockers block ingest; boot crashes precede SDK init), so the fix has to degrade gracefully on its own rather than rely on telemetry.

Two gaps made any such failure unrecoverable, and this fixes both:

1. `use(bootstrapPromise)` had **no error boundary** — a rejected bootstrap or any uncaught render error blanked the whole app.
2. Route `lazy: () => import(...)` imports weren't wrapped for stale-bundle reload, so a chunk that 404s after a deploy blanked with no auto-reload.

The goal isn't to pin down every individual trigger (the adblocker case still wants an on/off HAR) — it's to turn the whole *class* of login blanks into either a silent auto-reload (stale deploy) or a visible, reportable "reload" page.

### Changes

💻 Engineer-facing
- **`BootErrorBoundary`** wraps the app mount. On a caught boot/render error it reports to `ErrorReporting`, calls `reloadOnAppEntrypointHeadersMismatch()` to reload onto a fresh bundle when the deployed entrypoint changed (guarded by a `sessionStorage` timestamp so it can't loop), and otherwise renders a dependency-free "couldn't finish loading — reload" fallback. Copy is hard-coded English on purpose — i18n may be exactly what failed to load.
- **`withEntrypointReloadOnLazy`** wraps every route's `lazy` import with the existing `checkAppEntrypointHeadersOnError`, so a stale-deploy chunk 404 reloads onto the fresh bundle instead of blanking. Non-chunk route errors are unaffected.
- Reuses the existing `checkAppEntrypointHeadersMatch.ts` helpers; no new reload machinery.

### Risks

Low. The boundary only renders on a thrown error; the lazy wrapping only changes behavior on a failed import (reload-if-stale, else reject as before). The reload-loop guard prevents repeated auto-reloads. Worst case is the fallback "reload" page instead of a blank — strictly better than today.

### Testing

`tsc --noEmit`, eslint, and the existing `useLoginRequired` / `openid` tests pass. New `BootErrorBoundary.test.tsx` covers rendering children normally and rendering the reload fallback (not a blank) when a child throws.

### Release plan and notes

🚢 — and this also makes future boot failures *visible and reportable* instead of silent white screens, so we stop flying blind. Still want an adblocker-on/off HAR to nail Brian's specific case as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
