### PR TITLE
Fix race condition in bearer-rejection retry that caused "link chain completed without emitting a value"

### DIFF
--- a/app/javascript/useIntercodeApolloClient.ts
+++ b/app/javascript/useIntercodeApolloClient.ts
@@ -123,14 +123,21 @@ export function buildRefreshOnRejectedBearerLink(authenticationManager?: Authent
       let activeSubscription: { unsubscribe(): void } | undefined;
 
       const runOnce = () => {
-        // Tear down the previous attempt so its `complete`/`error` events
-        // can't race the retry.
+        // Tear down any previous attempt before starting a new one.
         activeSubscription?.unsubscribe();
         activeSubscription = next(operation).subscribe({
           next: (result) => {
             const response = operation.getContext().response as Response | undefined;
             if (!attemptedRefresh && response?.headers?.get(BEARER_REJECTED_HEADER) === 'true') {
               attemptedRefresh = true;
+              // Unsubscribe synchronously so that BatchHttpLink's upcoming
+              // synchronous `complete` call (which immediately follows `next`
+              // in its promise chain) is a no-op on the now-closed subscriber.
+              // Without this, `observer.complete()` would fire before the retry
+              // emits a value, triggering Apollo's "link chain completed without
+              // emitting a value" error.
+              activeSubscription?.unsubscribe();
+              activeSubscription = undefined;
               // Mark the access token as known-bad so the auth-headers link
               // can't reuse it, then refresh and re-run the chain.
               authenticationManager.jwtToken = undefined;


### PR DESCRIPTION
### Purpose

Apollo was throwing \"The link chain completed without emitting a value\" when loading pages in background tabs (or whenever the server sends `X-Bearer-Token-Rejected: true` on a response).

The root cause was a race condition in `buildRefreshOnRejectedBearerLink`. `BatchHttpLink` calls `observer.next(result)` and then immediately calls `observer.complete()` synchronously in the same Promise `.then()` callback. When the `next` handler detected a bearer rejection, it kicked off an async token refresh and returned — without ever calling `observer.next()` on the outer observable. But the synchronous `complete: () => observer.complete()` handler fired before the retry had a chance to emit anything. Apollo Client 4's `validateDidEmitValue` guard sees this and throws.

The intended defense (calling `activeSubscription.unsubscribe()` at the top of `runOnce()`) only ran *after* `ensureFreshAccessToken()` resolved asynchronously — too late.

### Changes

💻 Engineer-facing
- In the bearer-rejection `next` handler, call `activeSubscription.unsubscribe()` **synchronously** the moment rejection is detected. This marks the rxjs `Subscriber` as `isStopped` before `BatchHttpLink`'s `.complete()` runs, making that call a no-op. The retry proceeds normally and emits a value through a fresh subscription.

Background tabs were the most common trigger because bearer rejection is more likely when a token is near expiry — tabs that have been sitting open for a while naturally hit this more often.

### Release plan and notes

🚢

🤖 Generated with [Claude Code](https://claude.com/claude-code)