### PR TITLE
Extend ImportConventionDataService to support Eventlite imports

### DIFF
--- a/app/services/import_convention_data_service.rb
+++ b/app/services/import_convention_data_service.rb
@@ -105,6 +105,12 @@ class ImportConventionDataService < CivilService::Service
     import_cms_pages(convention, layout_map)
     import_cms_partials(convention)
     import_cms_navigation_items(convention)
+
+    con = data[:convention]
+    updates = {}
+    updates[:default_layout] = layout_map[con[:default_layout_name]] if con[:default_layout_name].present?
+    updates[:root_page] = convention.pages.find_by(slug: con[:root_page_slug]) if con[:root_page_slug].present?
+    convention.update!(updates) if updates.any?
   end
 
   def import_cms_layouts(convention)

--- a/app/services/import_convention_data_service.rb
+++ b/app/services/import_convention_data_service.rb
@@ -100,10 +100,20 @@ class ImportConventionDataService < CivilService::Service
   end
 
   def import_cms_content(convention)
+    layout_map = import_cms_layouts(convention)
     import_cms_files(convention)
-    import_cms_pages(convention)
+    import_cms_pages(convention, layout_map)
     import_cms_partials(convention)
     import_cms_navigation_items(convention)
+  end
+
+  def import_cms_layouts(convention)
+    (data[:cms_layouts] || []).each_with_object({}) do |layout_data, map|
+      layout = convention.cms_layouts.find_or_initialize_by(name: layout_data[:name])
+      layout.content = layout_data[:content]
+      layout.save!
+      map[layout_data[:name]] = layout
+    end
   end
 
   def import_cms_files(convention)
@@ -122,10 +132,11 @@ class ImportConventionDataService < CivilService::Service
     end
   end
 
-  def import_cms_pages(convention)
+  def import_cms_pages(convention, layout_map = {})
     (data[:cms_pages] || []).each do |page_data|
       page = convention.pages.find_or_initialize_by(slug: page_data[:slug])
       page.assign_attributes(name: page_data[:name], content: page_data[:content])
+      page.cms_layout = layout_map[page_data[:cms_layout_name]] if page_data[:cms_layout_name].present?
       page.save!
     end
   end
@@ -409,12 +420,22 @@ class ImportConventionDataService < CivilService::Service
   end
 
   def import_store_items(convention)
+    ticket_type_map = convention.ticket_types.index_by(&:name)
+
     (data[:store_items] || []).each_with_object({}) do |item, map|
+      price_money = item[:price] ? money_value(item[:price]) : Money.new(0, Money.default_currency)
+      pricing_structure = PricingStructure.new(pricing_strategy: "fixed", value: price_money)
+      payment_options = price_money.positive? ? ["stripe"] : []
+
       product =
         convention.products.create!(
           name: item[:name],
           description: item[:description],
-          available: item.key?(:available) ? item[:available] : false
+          available: item.key?(:available) ? item[:available] : false,
+          pricing_structure: pricing_structure,
+          payment_options: payment_options,
+          provides_ticket_type:
+            item[:provides_ticket_type_name] ? ticket_type_map[item[:provides_ticket_type_name]] : nil
         )
       map[item[:name]] = product
     end

--- a/test/services/import_convention_data_service_test.rb
+++ b/test/services/import_convention_data_service_test.rb
@@ -613,5 +613,112 @@ class ImportConventionDataServiceTest < ActiveSupport::TestCase
       assert_equal org, convention.organization
     end
   end
+
+  describe "CMS layouts" do
+    before do
+      data =
+        base_data.merge(
+          cms_layouts: [
+            { name: "Default Layout", content: "<html>{{ content_for_layout }}</html>" },
+            { name: "Minimal Layout", content: "{{ content_for_layout }}" }
+          ],
+          cms_pages: [
+            { name: "Home", slug: "home", content: "Welcome", cms_layout_name: "Default Layout" },
+            { name: "About", slug: "about", content: "About us" }
+          ]
+        )
+      ImportConventionDataService.new(data: data).call!
+    end
+
+    it "creates layouts" do
+      convention = Convention.find_by!(domain: "importtest.example.com")
+      assert convention.cms_layouts.find_by(name: "Default Layout")
+      assert convention.cms_layouts.find_by(name: "Minimal Layout")
+    end
+
+    it "sets layout content" do
+      convention = Convention.find_by!(domain: "importtest.example.com")
+      layout = convention.cms_layouts.find_by!(name: "Default Layout")
+      assert_equal "<html>{{ content_for_layout }}</html>", layout.content
+    end
+
+    it "assigns cms_layout to a page when cms_layout_name is present" do
+      convention = Convention.find_by!(domain: "importtest.example.com")
+      page = convention.pages.find_by!(slug: "home")
+      assert_equal "Default Layout", page.cms_layout.name
+    end
+
+    it "leaves cms_layout nil when cms_layout_name is absent" do
+      convention = Convention.find_by!(domain: "importtest.example.com")
+      page = convention.pages.find_by!(slug: "about")
+      assert_nil page.cms_layout
+    end
+  end
+
+  describe "store items with pricing" do
+    before do
+      data =
+        base_data.merge(
+          convention:
+            base_data[:convention].merge(
+              ticket_mode: "required_for_signup",
+              ticket_types: [
+                { name: "weekend_pass", allows_event_signups: true, counts_towards_convention_maximum: true }
+              ]
+            ),
+          store_items: [
+            {
+              name: "Weekend Pass",
+              available: true,
+              price: {
+                fractional: 5000,
+                currency_code: "USD"
+              },
+              provides_ticket_type_name: "weekend_pass"
+            },
+            { name: "Free Volunteer Pass", available: true, provides_ticket_type_name: "weekend_pass" }
+          ]
+        )
+      ImportConventionDataService.new(data: data).call!
+    end
+
+    it "creates products" do
+      convention = Convention.find_by!(domain: "importtest.example.com")
+      assert convention.products.find_by(name: "Weekend Pass")
+      assert convention.products.find_by(name: "Free Volunteer Pass")
+    end
+
+    it "sets pricing_structure to fixed with the given price" do
+      convention = Convention.find_by!(domain: "importtest.example.com")
+      product = convention.products.find_by!(name: "Weekend Pass")
+      assert_equal "fixed", product.pricing_structure.pricing_strategy
+      assert_equal Money.new(5000, "USD"), product.pricing_structure.value
+    end
+
+    it "sets pricing_structure to a zero fixed price when no price is given" do
+      convention = Convention.find_by!(domain: "importtest.example.com")
+      product = convention.products.find_by!(name: "Free Volunteer Pass")
+      assert_equal "fixed", product.pricing_structure.pricing_strategy
+      assert_equal Money.new(0, Money.default_currency), product.pricing_structure.value
+    end
+
+    it "sets payment_options to stripe when price is positive" do
+      convention = Convention.find_by!(domain: "importtest.example.com")
+      product = convention.products.find_by!(name: "Weekend Pass")
+      assert_equal ["stripe"], product.payment_options
+    end
+
+    it "sets payment_options to empty when price is zero" do
+      convention = Convention.find_by!(domain: "importtest.example.com")
+      product = convention.products.find_by!(name: "Free Volunteer Pass")
+      assert_equal [], product.payment_options
+    end
+
+    it "links provides_ticket_type to the named ticket type" do
+      convention = Convention.find_by!(domain: "importtest.example.com")
+      product = convention.products.find_by!(name: "Weekend Pass")
+      assert_equal "weekend_pass", product.provides_ticket_type.name
+    end
+  end
 end
 # rubocop:enable Metrics/ClassLength, Metrics/BlockLength


### PR DESCRIPTION
### Purpose

This is the Intercode side of importing data exported from [Eventlite](https://github.com/neinteractiveliterature/eventlite), a lightweight convention ticketing CMS. The companion intercode-import PR ([neinteractiveliterature/intercode-import#2](https://github.com/neinteractiveliterature/intercode-import/pull/2)) handles the export side.

There were three gaps in `ImportConventionDataService` that needed filling:

**CMS layouts**: Eventlite exports CMS layout records (full-page Liquid templates), but the importer had no `import_cms_layouts` method and no way to associate a layout with a page. This adds both, so imported pages can be linked to their layouts.

**Store item pricing**: The previous `import_store_items` code didn't set `pricing_structure`, but that column is `NOT NULL`. This means any import attempt with actual store items would have blown up at the DB level. This has now been wired up using `PricingStructure.new(pricing_strategy: "fixed", value: ...)`. Items without a price get a zero fixed-price structure and empty `payment_options`; priced items get `["stripe"]`.

**Ticket-providing products**: Eventlite exports a `provides_ticket_type_name` field on store items. This PR looks up the matching `TicketType` by name and assigns it to `provides_ticket_type` on the product.

### Testing

Added test cases covering layout creation, page layout assignment, pricing structure (priced and free), payment options, and `provides_ticket_type` linkage. All 53 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)