### PR TITLE
Default first_name/last_name to empty string in profile import

### DIFF
--- a/app/services/import_convention_data_service.rb
+++ b/app/services/import_convention_data_service.rb
@@ -283,8 +283,8 @@ class ImportConventionDataService < CivilService::Service
 
   def profile_form_response_attrs(prof)
     {
-      first_name: prof[:first_name],
-      last_name: prof[:last_name],
+      first_name: prof[:first_name].to_s,
+      last_name: prof[:last_name].to_s,
       nickname: prof[:nickname],
       bio: prof[:bio],
       show_nickname_in_bio: prof[:show_nickname_in_bio],

--- a/app/services/import_convention_data_service.rb
+++ b/app/services/import_convention_data_service.rb
@@ -117,6 +117,7 @@ class ImportConventionDataService < CivilService::Service
     (data[:cms_layouts] || []).each_with_object({}) do |layout_data, map|
       layout = convention.cms_layouts.find_or_initialize_by(name: layout_data[:name])
       layout.content = layout_data[:content]
+      layout.navbar_classes = layout_data[:navbar_classes]
       layout.save!
       map[layout_data[:name]] = layout
     end


### PR DESCRIPTION
Exporters omit name fields from profiles when they are blank, so prof[:first_name] and prof[:last_name] can be nil. Passing nil directly to assign_form_response_attributes triggers a NOT NULL violation on the user_con_profiles table. .to_s converts nil to "" safely.