### PR TITLE
Fix single-event site Liquid components

### DIFF
--- a/app/javascript/parseCmsContent.tsx
+++ b/app/javascript/parseCmsContent.tsx
@@ -1,6 +1,8 @@
+import { useSuspenseQuery } from '@apollo/client/react';
 import { lazyWithAppEntrypointHeadersCheck } from './checkAppEntrypointHeadersMatch';
 import parsePageContent, { DEFAULT_COMPONENT_MAP, ComponentMap } from './parsePageContent';
 import CookieConsent from './UIComponents/CookieConsent';
+import { EventPageQueryDocument } from 'EventsApp/EventPage/queries.generated';
 
 const AddToCalendarDropdown = lazyWithAppEntrypointHeadersCheck(
   () => import('./EventsApp/SignupAdmin/AddToCalendarDropdown'),
@@ -24,17 +26,37 @@ const WithdrawMySignupButton = lazyWithAppEntrypointHeadersCheck(
   () => import(/* webpackChunkName: 'withdraw-my-signup-button' */ './EventsApp/EventPage/WithdrawMySignupButton'),
 );
 
+function EventAdminMenuWrapper({ eventId }: { eventId: string }) {
+  const { data } = useSuspenseQuery(EventPageQueryDocument, { variables: { eventId } });
+  return <EventAdminMenu data={data} />;
+}
+
+function LongFormEventDetailsWrapper({ eventId }: { eventId: string }) {
+  const { data } = useSuspenseQuery(EventPageQueryDocument, { variables: { eventId } });
+  return <LongFormEventDetails data={data} />;
+}
+
+function RunsSectionWrapper({ eventId }: { eventId: string }) {
+  const { data } = useSuspenseQuery(EventPageQueryDocument, { variables: { eventId } });
+  return <RunsSection data={data} />;
+}
+
+function ShortFormEventDetailsWrapper({ eventId }: { eventId: string }) {
+  const { data } = useSuspenseQuery(EventPageQueryDocument, { variables: { eventId } });
+  return <ShortFormEventDetails data={data} />;
+}
+
 export const CMS_COMPONENT_MAP: ComponentMap = {
   ...DEFAULT_COMPONENT_MAP,
   AddToCalendarDropdown,
   ConventionLocationMap,
   CookieConsent,
-  EventAdminMenu,
-  LongFormEventDetails,
+  EventAdminMenu: EventAdminMenuWrapper,
+  LongFormEventDetails: LongFormEventDetailsWrapper,
   ProposeEventButton,
-  RunsSection,
+  RunsSection: RunsSectionWrapper,
   MaximumEventSignupsPreview,
-  ShortFormEventDetails,
+  ShortFormEventDetails: ShortFormEventDetailsWrapper,
   WithdrawMySignupButton,
 };
 


### PR DESCRIPTION
At some point, we broke the single-event site Liquid tags by changing the props for their underlying components to accept data rather than an event ID.  This adds wrappers to get them loading their data and therefore rendering again.