### PR TITLE
Convert route guards to React Router v8 middleware

### DIFF
--- a/app/javascript/AppContexts.ts
+++ b/app/javascript/AppContexts.ts
@@ -2,6 +2,7 @@ import { ApolloClient } from '@apollo/client';
 import { Session, createContext } from 'react-router';
 import { SessionData, SessionFlashData } from 'sessions';
 import AuthenticityTokensManager from 'AuthenticityTokensContext';
+import { AppRootQueryData } from 'appRootQueries.generated';
 
 // Bootstrap configuration served from `GET /client_configuration`. Fetched
 // once at module load before any GraphQL traffic, so the SPA has enough to
@@ -25,3 +26,4 @@ export const apolloClientContext = createContext<ApolloClient>();
 export const clientConfigurationContext = createContext<ClientConfiguration>();
 export const fetchContext = createContext<typeof fetch>();
 export const sessionContext = createContext<Session<SessionData, SessionFlashData> | undefined>();
+export const appRootDataContext = createContext<AppRootQueryData | undefined>();

--- a/app/javascript/AppRoot.tsx
+++ b/app/javascript/AppRoot.tsx
@@ -1,5 +1,13 @@
 import { Suspense, useMemo, useState, useEffect, useRef } from 'react';
-import { useLocation, useLoaderData, Outlet, useNavigation } from 'react-router';
+import {
+  useLocation,
+  useLoaderData,
+  Outlet,
+  useNavigation,
+  LoaderFunction,
+  redirect,
+  RouterContextProvider,
+} from 'react-router';
 import { Settings } from 'luxon';
 import { PageLoadingIndicator } from '@neinteractiveliterature/litform';
 
@@ -12,6 +20,72 @@ import { LazyStripeContext } from './LazyStripe';
 import { Stripe } from '@stripe/stripe-js';
 import { reloadOnAppEntrypointHeadersMismatch } from './checkAppEntrypointHeadersMatch';
 import errorReporting from 'ErrorReporting';
+import { apolloClientContext, appRootDataContext } from 'AppContexts';
+import { SetupMyProfileDocument } from 'Authentication/mutations.generated';
+import RouteErrorBoundary from 'RouteErrorBoundary';
+
+export const ErrorBoundary = RouteErrorBoundary;
+
+export const loader: LoaderFunction<RouterContextProvider> = async ({ context, request }) => {
+  const client = context.get(apolloClientContext);
+  const data = context.get(appRootDataContext);
+  if (!data) return data;
+
+  const { pathname } = new URL(request.url);
+
+  if (data.currentUser && data.convention) {
+    const myProfile = data.convention.my_profile;
+    let freshlyCreated = false;
+
+    if (!myProfile) {
+      try {
+        const convention = data.convention;
+        await client.mutate({
+          mutation: SetupMyProfileDocument,
+          update(cache, result) {
+            const newProfile = result.data?.setupMyProfile?.my_profile;
+            if (!newProfile) return;
+            // After creating the profile, wire up the Convention.my_profile reference
+            // in the normalized cache so cache-first queries (e.g. MyProfileForm.loader)
+            // see the new profile instead of the stale null entry. Without this,
+            // MyProfileQuery returns null from cache even though the profile now exists,
+            // causing MyProfileForm.loader to return a 404 and show a broken page.
+            const conventionRef = cache.identify({ __typename: 'Convention', id: convention.id });
+            const profileRef = cache.identify({ __typename: 'UserConProfile', id: newProfile.id });
+            if (conventionRef && profileRef) {
+              cache.modify({
+                id: conventionRef,
+                fields: { my_profile: () => ({ __ref: profileRef }) },
+              });
+            }
+          },
+        });
+        freshlyCreated = true;
+      } catch {
+        return data;
+      }
+    }
+
+    const clickwrapRequired = (data.convention.clickwrap_agreement || '').trim() !== '';
+    const acceptedClickwrap = freshlyCreated ? false : (myProfile?.accepted_clickwrap_agreement ?? false);
+    const needsUpdate = freshlyCreated || (myProfile?.needs_update ?? false);
+
+    const clickwrapNeeded =
+      clickwrapRequired &&
+      !acceptedClickwrap &&
+      pathname !== '/clickwrap_agreement' &&
+      pathname !== '/' &&
+      !pathname.startsWith('/pages');
+
+    if (clickwrapNeeded) return redirect('/clickwrap_agreement');
+
+    if (needsUpdate && pathname !== '/my_profile/setup' && pathname !== '/clickwrap_agreement') {
+      return redirect('/my_profile/setup');
+    }
+  }
+
+  return data;
+};
 
 export function buildAppRootContextValue(
   data: AppRootQueryData | null | undefined,
@@ -125,7 +199,7 @@ function AppRoot(): React.JSX.Element {
           </div>
           {/* Disabling ScrollRestoration for now because it's breaking hash links within the same page (reproducible with Mac Chrome) */}
           {/* <ScrollRestoration /> */}
-          <Suspense fallback={<PageLoadingIndicator visible iconSet="bootstrap-icons" />}>
+          <Suspense fallback={<PageLoadingIndicator visible />}>
             <Outlet />
           </Suspense>
         </div>
@@ -134,4 +208,4 @@ function AppRoot(): React.JSX.Element {
   );
 }
 
-export default AppRoot;
+export const Component = AppRoot;

--- a/app/javascript/AppRouter.tsx
+++ b/app/javascript/AppRouter.tsx
@@ -21,7 +21,6 @@ import {
   eventTicketTypesLoader,
 } from './TicketTypeAdmin/loaders';
 import { organizationsLoader, singleOrganizationLoader } from './OrganizationAdmin/loaders';
-import useLoginRequired from './Authentication/useLoginRequired';
 import { eventProposalWithOwnerLoader } from './EventProposals/loaders';
 import { conventionDayLoader } from './EventsApp/conventionDayUrls';
 import { signupAdminEventLoader, singleSignupLoader } from './EventsApp/SignupAdmin/loaders';
@@ -104,14 +103,13 @@ function makeAppRootContextMiddleware(guard: (data: AppRootQueryData) => boolean
   };
 }
 
-function LoginRequiredRouteGuard() {
-  const loginRequired = useLoginRequired();
-  if (loginRequired) {
-    return loginRequired;
+const loginRequiredMiddleware: MiddlewareFunction = ({ context }) => {
+  const appRootData = context.get(appRootDataContext);
+  if (appRootData == null) return;
+  if (!appRootData.currentUser) {
+    return new Response(null, { status: 401 });
   }
-
-  return <Outlet />;
-}
+};
 
 function makeAuthorizationMiddleware(...abilities: AbilityName[]): MiddlewareFunction {
   return ({ context }) => {
@@ -231,8 +229,7 @@ const eventsRoutes: RouteObject[] = [
       },
       {
         path: 'edit',
-        middleware: [editEventMiddleware],
-        element: <LoginRequiredRouteGuard />,
+        middleware: [editEventMiddleware, loginRequiredMiddleware],
         children: [
           {
             index: true,
@@ -671,7 +668,7 @@ const commonInConventionRoutes: RouteObject[] = [
   },
   {
     path: '/my_profile',
-    element: <LoginRequiredRouteGuard />,
+    middleware: [loginRequiredMiddleware],
     children: [
       { path: 'edit_bio', loader: () => replace('./edit') },
       { path: 'edit', lazy: () => import('./MyProfile/MyProfileForm') },

--- a/app/javascript/AppRouter.tsx
+++ b/app/javascript/AppRouter.tsx
@@ -530,6 +530,10 @@ const commonInConventionRoutes: RouteObject[] = [
     id: NamedRoute.EventAdmin,
     children: [
       {
+        element: <AppRootContextRouteGuard guard={({ siteMode }) => siteMode === SiteMode.SingleEvent} />,
+        children: [{ path: ':eventId/edit', lazy: () => import('./EventAdmin/EventAdminEditEvent') }],
+      },
+      {
         element: <AppRootContextRouteGuard guard={({ siteMode }) => siteMode !== SiteMode.SingleEvent} />,
         children: [
           { path: 'dropped_events', lazy: () => import('./EventAdmin/DroppedEventAdmin') },

--- a/app/javascript/AppRouter.tsx
+++ b/app/javascript/AppRouter.tsx
@@ -1,4 +1,3 @@
-import { useContext } from 'react';
 import {
   RouteObject,
   replace,
@@ -11,10 +10,9 @@ import {
 
 import FourOhFourPage from './FourOhFourPage';
 import { SignupAutomationMode, SignupMode, SiteMode, TicketMode } from './graphqlTypes.generated';
-import AppRootContext, { AppRootContextValue } from './AppRootContext';
 import useAuthorizationRequired, { AbilityName } from './Authentication/useAuthorizationRequired';
 import { EventAdminEventsQueryDocument } from './EventAdmin/queries.generated';
-import { AppRootQueryDocument } from './appRootQueries.generated';
+import { AppRootQueryData, AppRootQueryDocument } from './appRootQueries.generated';
 import buildEventCategoryUrl from './EventAdmin/buildEventCategoryUrl';
 import {
   adminSingleTicketTypeLoader,
@@ -97,18 +95,13 @@ export enum NamedRoute {
 
 export type RouteName = keyof typeof NamedRoute & string;
 
-export type AppRootContextRouteGuardProps = {
-  guard: (context: AppRootContextValue) => boolean;
-};
-
-export function AppRootContextRouteGuard({ guard }: AppRootContextRouteGuardProps) {
-  const context = useContext(AppRootContext);
-
-  if (guard(context)) {
-    return <Outlet />;
-  } else {
-    return <FourOhFourPage />;
-  }
+function makeAppRootContextMiddleware(guard: (data: AppRootQueryData) => boolean): MiddlewareFunction {
+  return ({ context }) => {
+    const appRootData = context.get(appRootDataContext);
+    if (appRootData != null && !guard(appRootData)) {
+      return new Response(null, { status: 404 });
+    }
+  };
 }
 
 function LoginRequiredRouteGuard() {
@@ -180,7 +173,7 @@ const editEventMiddleware: MiddlewareFunction = ({ context }) => {
 
 const eventsRoutes: RouteObject[] = [
   {
-    element: <AppRootContextRouteGuard guard={({ siteMode }) => siteMode !== SiteMode.SingleEvent} />,
+    middleware: [makeAppRootContextMiddleware(({ convention }) => convention?.site_mode !== SiteMode.SingleEvent)],
     children: [
       {
         path: 'schedule',
@@ -202,11 +195,11 @@ const eventsRoutes: RouteObject[] = [
     ],
   },
   {
-    element: (
-      <AppRootContextRouteGuard
-        guard={({ signupAutomationMode }) => signupAutomationMode === SignupAutomationMode.RankedChoice}
-      />
-    ),
+    middleware: [
+      makeAppRootContextMiddleware(
+        ({ convention }) => convention?.signup_automation_mode === SignupAutomationMode.RankedChoice,
+      ),
+    ],
     children: [{ path: 'my-signup-queue', lazy: () => import('./EventsApp/MySignupQueue') }],
   },
   {
@@ -215,7 +208,9 @@ const eventsRoutes: RouteObject[] = [
     children: [
       { path: 'attach_image', lazy: () => import('./EventsApp/attach_image') },
       {
-        element: <AppRootContextRouteGuard guard={({ ticketMode }) => ticketMode === TicketMode.TicketPerEvent} />,
+        middleware: [
+          makeAppRootContextMiddleware(({ convention }) => convention?.ticket_mode === TicketMode.TicketPerEvent),
+        ],
         children: [
           {
             path: 'ticket_types',
@@ -455,7 +450,7 @@ const commonRoutes: RouteObject[] = [
         ],
       },
       {
-        element: <AppRootContextRouteGuard guard={({ conventionName }) => conventionName == null} />,
+        middleware: [makeAppRootContextMiddleware(({ convention }) => convention?.name == null)],
         children: [{ path: '/root_site', lazy: () => import('./RootSiteAdmin/EditRootSite') }],
       },
     ],
@@ -514,11 +509,11 @@ const commonInConventionRoutes: RouteObject[] = [
     id: NamedRoute.EventAdmin,
     children: [
       {
-        element: <AppRootContextRouteGuard guard={({ siteMode }) => siteMode === SiteMode.SingleEvent} />,
+        middleware: [makeAppRootContextMiddleware(({ convention }) => convention?.site_mode === SiteMode.SingleEvent)],
         children: [{ path: ':eventId/edit', lazy: () => import('./EventAdmin/EventAdminEditEvent') }],
       },
       {
-        element: <AppRootContextRouteGuard guard={({ siteMode }) => siteMode !== SiteMode.SingleEvent} />,
+        middleware: [makeAppRootContextMiddleware(({ convention }) => convention?.site_mode !== SiteMode.SingleEvent)],
         children: [
           { path: 'dropped_events', lazy: () => import('./EventAdmin/DroppedEventAdmin') },
           {
@@ -703,18 +698,18 @@ const commonInConventionRoutes: RouteObject[] = [
     children: [{ path: ':id', lazy: () => import('./RoomsAdmin/$id/route') }],
   },
   {
-    element: <AppRootContextRouteGuard guard={({ signupMode }) => signupMode === SignupMode.Moderated} />,
+    middleware: [makeAppRootContextMiddleware(({ convention }) => convention?.signup_mode === SignupMode.Moderated)],
     children: [
       {
         path: '/signup_moderation',
         lazy: () => import('./SignupModeration'),
         children: [
           {
-            element: (
-              <AppRootContextRouteGuard
-                guard={({ signupAutomationMode }) => signupAutomationMode === SignupAutomationMode.RankedChoice}
-              />
-            ),
+            middleware: [
+              makeAppRootContextMiddleware(
+                ({ convention }) => convention?.signup_automation_mode === SignupAutomationMode.RankedChoice,
+              ),
+            ],
             children: [
               {
                 path: 'ranked_choice_queue',
@@ -797,7 +792,9 @@ const commonInConventionRoutes: RouteObject[] = [
     ],
   },
   {
-    element: <AppRootContextRouteGuard guard={({ ticketMode }) => ticketMode === TicketMode.RequiredForSignup} />,
+    middleware: [
+      makeAppRootContextMiddleware(({ convention }) => convention?.ticket_mode === TicketMode.RequiredForSignup),
+    ],
     children: [
       {
         path: '/ticket_types',
@@ -1051,27 +1048,27 @@ export const appLayoutRoutes: RouteObject[] = [
     element: <NonCMSPageWrapper />,
     children: [
       {
-        element: (
-          <AppRootContextRouteGuard
-            guard={({ conventionName, siteMode }) => conventionName != null && siteMode !== SiteMode.SingleEvent}
-          />
-        ),
+        middleware: [
+          makeAppRootContextMiddleware(
+            ({ convention }) => convention?.name != null && convention?.site_mode !== SiteMode.SingleEvent,
+          ),
+        ],
         children: conventionModeRoutes,
       },
       {
-        element: (
-          <AppRootContextRouteGuard
-            guard={({ conventionName, siteMode }) => conventionName != null && siteMode === SiteMode.SingleEvent}
-          />
-        ),
+        middleware: [
+          makeAppRootContextMiddleware(
+            ({ convention }) => convention?.name != null && convention?.site_mode === SiteMode.SingleEvent,
+          ),
+        ],
         children: singleEventModeRoutes,
       },
       {
-        element: <AppRootContextRouteGuard guard={({ conventionName }) => conventionName != null} />,
+        middleware: [makeAppRootContextMiddleware(({ convention }) => convention?.name != null)],
         children: commonInConventionRoutes,
       },
       {
-        element: <AppRootContextRouteGuard guard={({ conventionName }) => conventionName == null} />,
+        middleware: [makeAppRootContextMiddleware(({ convention }) => convention?.name == null)],
         children: rootSiteRoutes,
       },
       ...commonRoutes,

--- a/app/javascript/AppRouter.tsx
+++ b/app/javascript/AppRouter.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import {
   RouteObject,
   replace,
@@ -6,16 +6,16 @@ import {
   LoaderFunction,
   redirect,
   useNavigate,
-  useRouteError,
   RouterContextProvider,
+  MiddlewareFunction,
 } from 'react-router';
-import { ErrorDisplay } from '@neinteractiveliterature/litform';
 
 import FourOhFourPage from './FourOhFourPage';
 import { SignupAutomationMode, SignupMode, SiteMode, TicketMode } from './graphqlTypes.generated';
 import AppRootContext, { AppRootContextValue } from './AppRootContext';
 import useAuthorizationRequired, { AbilityName } from './Authentication/useAuthorizationRequired';
 import { EventAdminEventsQueryDocument } from './EventAdmin/queries.generated';
+import { AppRootQueryDocument } from './appRootQueries.generated';
 import buildEventCategoryUrl from './EventAdmin/buildEventCategoryUrl';
 import {
   adminSingleTicketTypeLoader,
@@ -32,9 +32,6 @@ import { teamMembersLoader } from './EventsApp/TeamMemberAdmin/loader';
 import { cmsAdminBaseQueryLoader } from './CmsAdmin/loaders';
 import { cmsPagesAdminLoader } from './CmsAdmin/CmsPagesAdmin/loaders';
 import { cmsPartialsAdminLoader } from './CmsAdmin/CmsPartialsAdmin/loaders';
-import AppRoot from './AppRoot';
-import { AppRootQueryDocument } from './appRootQueries.generated';
-import { SetupMyProfileDocument } from './Authentication/mutations.generated';
 import { liquidDocsLoader } from './LiquidDocs/loader';
 import { cmsLayoutsAdminLoader } from './CmsAdmin/CmsLayoutsAdmin/loaders';
 import { cmsGraphqlQueriesAdminLoader } from './CmsAdmin/CmsGraphqlQueriesAdmin/loaders';
@@ -42,7 +39,8 @@ import { cmsContentGroupsAdminLoader } from './CmsAdmin/CmsContentGroupsAdmin/lo
 import { departmentAdminLoader } from './DepartmentAdmin/loaders';
 import { eventCategoryAdminLoader } from './EventCategoryAdmin/loaders';
 import { eventAdminEventsLoader } from './EventAdmin/loaders';
-import { apolloClientContext } from 'AppContexts';
+import { apolloClientContext, appRootDataContext } from 'AppContexts';
+import RouteErrorBoundary from 'RouteErrorBoundary';
 
 export enum NamedRoute {
   AdminEditEventProposal = 'AdminEditEventProposal',
@@ -163,37 +161,33 @@ function EventPageGuard() {
   const { siteMode } = useContext(AppRootContext);
   const navigate = useNavigate();
 
+  useEffect(() => {
+    if (siteMode === SiteMode.SingleEvent) {
+      navigate('/', { replace: true });
+    }
+  }, []);
+
   if (siteMode === SiteMode.SingleEvent) {
-    navigate('/', { replace: true });
     return <></>;
   } else {
     return <Outlet />;
   }
 }
 
-function EditEventGuard() {
-  const { siteMode } = useContext(AppRootContext);
-  const navigate = useNavigate();
-
-  if (siteMode === SiteMode.SingleEvent) {
-    navigate('/admin_events', { replace: true });
-    return <></>;
-  } else {
-    return <LoginRequiredRouteGuard />;
+const appRootMiddleware: MiddlewareFunction = async ({ context }) => {
+  const client = context.get(apolloClientContext);
+  const { data } = await client.query({ query: AppRootQueryDocument });
+  if (data) {
+    context.set(appRootDataContext, data);
   }
-}
+};
 
-function RouteErrorBoundary() {
-  const error = useRouteError();
-
-  if (error instanceof Error) {
-    return <ErrorDisplay stringError={error.message} />;
-  } else if (typeof error === 'object' && error) {
-    return <ErrorDisplay stringError={error.toString()} />;
-  } else {
-    return <ErrorDisplay stringError={error as string} />;
+const editEventMiddleware: MiddlewareFunction = ({ context }) => {
+  const appRootData = context.get(appRootDataContext);
+  if (appRootData?.convention?.site_mode === SiteMode.SingleEvent) {
+    return redirect('/admin_events');
   }
-}
+};
 
 const eventsRoutes: RouteObject[] = [
   {
@@ -252,7 +246,8 @@ const eventsRoutes: RouteObject[] = [
       },
       {
         path: 'edit',
-        element: <EditEventGuard />,
+        middleware: [editEventMiddleware],
+        element: <LoginRequiredRouteGuard />,
         children: [
           {
             index: true,
@@ -1097,73 +1092,10 @@ export const appLayoutRoutes: RouteObject[] = [
   { path: '*', element: <FourOhFourPage /> },
 ];
 
-const appRootLoader: LoaderFunction<RouterContextProvider> = async ({ context, request }) => {
-  const client = context.get(apolloClientContext);
-  const { data } = await client.query({ query: AppRootQueryDocument });
-
-  if (!data) return data;
-
-  const { pathname } = new URL(request.url);
-
-  if (data.currentUser && data.convention) {
-    const myProfile = data.convention.my_profile;
-    let freshlyCreated = false;
-
-    if (!myProfile) {
-      try {
-        const convention = data.convention;
-        await client.mutate({
-          mutation: SetupMyProfileDocument,
-          update(cache, result) {
-            const newProfile = result.data?.setupMyProfile?.my_profile;
-            if (!newProfile) return;
-            // After creating the profile, wire up the Convention.my_profile reference
-            // in the normalized cache so cache-first queries (e.g. MyProfileForm.loader)
-            // see the new profile instead of the stale null entry. Without this,
-            // MyProfileQuery returns null from cache even though the profile now exists,
-            // causing MyProfileForm.loader to return a 404 and show a broken page.
-            const conventionRef = cache.identify({ __typename: 'Convention', id: convention.id });
-            const profileRef = cache.identify({ __typename: 'UserConProfile', id: newProfile.id });
-            if (conventionRef && profileRef) {
-              cache.modify({
-                id: conventionRef,
-                fields: { my_profile: () => ({ __ref: profileRef }) },
-              });
-            }
-          },
-        });
-        freshlyCreated = true;
-      } catch {
-        return data;
-      }
-    }
-
-    const clickwrapRequired = (data.convention.clickwrap_agreement || '').trim() !== '';
-    const acceptedClickwrap = freshlyCreated ? false : (myProfile?.accepted_clickwrap_agreement ?? false);
-    const needsUpdate = freshlyCreated || (myProfile?.needs_update ?? false);
-
-    const clickwrapNeeded =
-      clickwrapRequired &&
-      !acceptedClickwrap &&
-      pathname !== '/clickwrap_agreement' &&
-      pathname !== '/' &&
-      !pathname.startsWith('/pages');
-
-    if (clickwrapNeeded) return redirect('/clickwrap_agreement');
-
-    if (needsUpdate && pathname !== '/my_profile/setup' && pathname !== '/clickwrap_agreement') {
-      return redirect('/my_profile/setup');
-    }
-  }
-
-  return data;
-};
-
 export const appRootRoutes: RouteObject[] = [
   {
-    element: <AppRoot />,
-    errorElement: <RouteErrorBoundary />,
-    loader: appRootLoader,
+    lazy: () => import('./AppRoot'),
+    middleware: [appRootMiddleware],
     children: [
       {
         path: '/admin_forms/:id/edit',
@@ -1219,7 +1151,7 @@ export const appRootRoutes: RouteObject[] = [
       },
       {
         lazy: () => import('./AppRootLayout'),
-        children: [{ errorElement: <RouteErrorBoundary />, children: appLayoutRoutes }],
+        children: [{ ErrorBoundary: RouteErrorBoundary, children: appLayoutRoutes }],
       },
     ],
   },

--- a/app/javascript/AppRouter.tsx
+++ b/app/javascript/AppRouter.tsx
@@ -10,7 +10,7 @@ import {
 
 import FourOhFourPage from './FourOhFourPage';
 import { SignupAutomationMode, SignupMode, SiteMode, TicketMode } from './graphqlTypes.generated';
-import useAuthorizationRequired, { AbilityName } from './Authentication/useAuthorizationRequired';
+import { AbilityName } from './Authentication/useAuthorizationRequired';
 import { EventAdminEventsQueryDocument } from './EventAdmin/queries.generated';
 import { AppRootQueryData, AppRootQueryDocument } from './appRootQueries.generated';
 import buildEventCategoryUrl from './EventAdmin/buildEventCategoryUrl';
@@ -113,16 +113,17 @@ function LoginRequiredRouteGuard() {
   return <Outlet />;
 }
 
-type AuthorizationRequiredRouteGuardProps = {
-  abilities: AbilityName[];
-};
-
-function AuthorizationRequiredRouteGuard({ abilities }: AuthorizationRequiredRouteGuardProps) {
-  const authorizationWarning = useAuthorizationRequired(...abilities);
-
-  if (authorizationWarning) return authorizationWarning;
-
-  return <Outlet />;
+function makeAuthorizationMiddleware(...abilities: AbilityName[]): MiddlewareFunction {
+  return ({ context }) => {
+    const appRootData = context.get(appRootDataContext);
+    if (appRootData == null) return;
+    if (!appRootData.currentUser) {
+      return new Response(null, { status: 401 });
+    }
+    if (!abilities.every((ability) => appRootData.currentAbility[ability])) {
+      return new Response(null, { status: 403 });
+    }
+  };
 }
 
 const eventAdminRootRedirect: LoaderFunction<RouterContextProvider> = async ({ context }) => {
@@ -486,7 +487,7 @@ const commonRoutes: RouteObject[] = [
 const commonInConventionRoutes: RouteObject[] = [
   {
     path: '/admin_departments',
-    element: <AuthorizationRequiredRouteGuard abilities={['can_update_departments']} />,
+    middleware: [makeAuthorizationMiddleware('can_update_departments')],
     id: NamedRoute.DepartmentAdmin,
     loader: departmentAdminLoader,
     children: [
@@ -574,7 +575,7 @@ const commonInConventionRoutes: RouteObject[] = [
   },
   {
     path: '/admin_notifications',
-    element: <AuthorizationRequiredRouteGuard abilities={['can_update_notification_templates']} />,
+    middleware: [makeAuthorizationMiddleware('can_update_notification_templates')],
     children: [
       {
         path: ':eventKey',
@@ -657,7 +658,7 @@ const commonInConventionRoutes: RouteObject[] = [
   { path: '/events', children: eventsRoutes },
   {
     path: '/mailing_lists',
-    element: <AuthorizationRequiredRouteGuard abilities={['can_read_any_mailing_list']} />,
+    middleware: [makeAuthorizationMiddleware('can_read_any_mailing_list')],
     children: [
       { path: 'ticketed_attendees', lazy: () => import('./MailingLists/TicketedAttendees') },
       { path: 'event_proposers', lazy: () => import('./MailingLists/EventProposers') },
@@ -682,7 +683,7 @@ const commonInConventionRoutes: RouteObject[] = [
   { path: '/products/:id', lazy: () => import('./Store/ProductPage') },
   {
     path: '/reports',
-    element: <AuthorizationRequiredRouteGuard abilities={['can_read_reports']} />,
+    middleware: [makeAuthorizationMiddleware('can_read_reports')],
     children: [
       { path: 'new_and_returning_attendees', lazy: () => import('./Reports/NewAndReturningAttendees') },
       { path: 'attendance_by_payment_amount', lazy: () => import('./Reports/AttendanceByPaymentAmount') },
@@ -798,7 +799,7 @@ const commonInConventionRoutes: RouteObject[] = [
     children: [
       {
         path: '/ticket_types',
-        element: <AuthorizationRequiredRouteGuard abilities={['can_manage_ticket_types']} />,
+        middleware: [makeAuthorizationMiddleware('can_manage_ticket_types')],
         children: [
           { path: 'new', loader: adminTicketTypesLoader, lazy: () => import('./TicketTypeAdmin/NewTicketType') },
           {
@@ -833,7 +834,7 @@ const commonInConventionRoutes: RouteObject[] = [
   },
   {
     path: '/user_con_profiles',
-    element: <AuthorizationRequiredRouteGuard abilities={['can_read_user_con_profiles']} />,
+    middleware: [makeAuthorizationMiddleware('can_read_user_con_profiles')],
     children: [
       {
         path: ':id',
@@ -898,7 +899,7 @@ const conventionModeRoutes: RouteObject[] = [
     ],
   },
   {
-    element: <AuthorizationRequiredRouteGuard abilities={['can_update_event_categories']} />,
+    middleware: [makeAuthorizationMiddleware('can_update_event_categories')],
     children: [
       {
         path: '/event_categories',
@@ -1022,7 +1023,7 @@ const rootSiteRoutes: RouteObject[] = [
     ],
   },
   {
-    element: <AuthorizationRequiredRouteGuard abilities={['can_read_users']} />,
+    middleware: [makeAuthorizationMiddleware('can_read_users')],
     children: [
       {
         path: '/users',

--- a/app/javascript/AppRouter.tsx
+++ b/app/javascript/AppRouter.tsx
@@ -1,11 +1,10 @@
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import {
   RouteObject,
   replace,
   Outlet,
   LoaderFunction,
   redirect,
-  useNavigate,
   RouterContextProvider,
   MiddlewareFunction,
 } from 'react-router';
@@ -157,22 +156,12 @@ const eventAdminRootRedirect: LoaderFunction<RouterContextProvider> = async ({ c
   return redirect(buildEventCategoryUrl(firstEventCategory));
 };
 
-function EventPageGuard() {
-  const { siteMode } = useContext(AppRootContext);
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (siteMode === SiteMode.SingleEvent) {
-      navigate('/', { replace: true });
-    }
-  }, []);
-
-  if (siteMode === SiteMode.SingleEvent) {
-    return <></>;
-  } else {
-    return <Outlet />;
+const eventPageMiddleware: MiddlewareFunction = ({ context }) => {
+  const appRootData = context.get(appRootDataContext);
+  if (appRootData?.convention?.site_mode === SiteMode.SingleEvent) {
+    return redirect('/');
   }
-}
+};
 
 const appRootMiddleware: MiddlewareFunction = async ({ context }) => {
   const client = context.get(apolloClientContext);
@@ -344,7 +333,7 @@ const eventsRoutes: RouteObject[] = [
       },
       {
         path: '',
-        element: <EventPageGuard />,
+        middleware: [eventPageMiddleware],
         children: [{ index: true, id: NamedRoute.EventPage, lazy: () => import('./EventsApp/EventPage') }],
       },
     ],

--- a/app/javascript/RouteErrorBoundary.tsx
+++ b/app/javascript/RouteErrorBoundary.tsx
@@ -1,0 +1,14 @@
+import { ErrorDisplay } from '@neinteractiveliterature/litform';
+import { useRouteError } from 'react-router';
+
+export default function RouteErrorBoundary() {
+  const error = useRouteError();
+
+  if (error instanceof Error) {
+    return <ErrorDisplay stringError={error.message} />;
+  } else if (typeof error === 'object' && error) {
+    return <ErrorDisplay stringError={error.toString()} />;
+  } else {
+    return <ErrorDisplay stringError={error as string} />;
+  }
+}

--- a/app/javascript/RouteErrorBoundary.tsx
+++ b/app/javascript/RouteErrorBoundary.tsx
@@ -1,8 +1,13 @@
+import { isRouteErrorResponse, useRouteError } from 'react-router';
 import { ErrorDisplay } from '@neinteractiveliterature/litform';
-import { useRouteError } from 'react-router';
+import FourOhFourPage from './FourOhFourPage';
 
 export default function RouteErrorBoundary() {
   const error = useRouteError();
+
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return <FourOhFourPage />;
+  }
 
   if (error instanceof Error) {
     return <ErrorDisplay stringError={error.message} />;

--- a/app/javascript/RouteErrorBoundary.tsx
+++ b/app/javascript/RouteErrorBoundary.tsx
@@ -1,12 +1,21 @@
 import { isRouteErrorResponse, useRouteError } from 'react-router';
 import { ErrorDisplay } from '@neinteractiveliterature/litform';
 import FourOhFourPage from './FourOhFourPage';
+import { AuthorizationError } from './Authentication/useAuthorizationRequired';
+import useLoginRequired from './Authentication/useLoginRequired';
+
+function LoginRequired() {
+  const loginRequired = useLoginRequired();
+  return loginRequired || null;
+}
 
 export default function RouteErrorBoundary() {
   const error = useRouteError();
 
-  if (isRouteErrorResponse(error) && error.status === 404) {
-    return <FourOhFourPage />;
+  if (isRouteErrorResponse(error)) {
+    if (error.status === 401) return <LoginRequired />;
+    if (error.status === 403) return <AuthorizationError />;
+    if (error.status === 404) return <FourOhFourPage />;
   }
 
   if (error instanceof Error) {

--- a/app/javascript/packs/application.tsx
+++ b/app/javascript/packs/application.tsx
@@ -12,6 +12,7 @@ import {
   fetchContext,
   sessionContext,
   ClientConfiguration,
+  appRootDataContext,
 } from 'AppContexts';
 import { appRootRoutes } from 'AppRouter';
 import { AuthenticationManager, AuthenticationManagerContext } from '../Authentication/authenticationManager';
@@ -132,6 +133,9 @@ function DataModeApplicationEntry() {
           },
         ]),
         {
+          future: {
+            v8_middleware: true,
+          },
           getContext: () => {
             const context = new RouterContextProvider();
             context.set(apolloClientContext, bootstrap.client);
@@ -139,6 +143,7 @@ function DataModeApplicationEntry() {
             context.set(authenticityTokensManagerContext, bootstrap.authenticityTokensManager);
             context.set(clientConfigurationContext, bootstrap.clientConfiguration);
             context.set(sessionContext, undefined);
+            context.set(appRootDataContext, undefined);
             return context;
           },
         },


### PR DESCRIPTION
## Summary

- Adds React Router v8 middleware support (`v8_middleware: true` future flag) with an `appRootMiddleware` that runs the AppRoot query once per navigation and stores the result in `appRootDataContext`, eliminating redundant fetches
- Converts all four render-time route guard components (`EventPageGuard`, `EditEventGuard`, `AppRootContextRouteGuard`, `AuthorizationRequiredRouteGuard`, `LoginRequiredRouteGuard`) to middleware that runs before loaders
- Adds `RouteErrorBoundary` to handle 401 (OAuth login spinner), 403 (authorization error), and 404 (FourOhFourPage) responses returned by middleware, preserving existing UX within the app layout
- Fixes a bug where `/admin_events/:eventId/edit` was inaccessible on single-event sites
- Adds wrappers to load the Liquid-wrapped versions of event components with correct data

## Test plan

- [ ] Navigate to a convention site — home page, events, schedule load correctly
- [ ] Navigate to a single-event site — event page loads, schedule/catalog routes redirect to `/`
- [ ] Visit an admin route while logged out — OAuth spinner appears, login redirects back correctly
- [ ] Visit an admin route without the required ability — authorization error is shown within the layout
- [ ] Visit a non-existent route — 404 page is shown within the layout
- [ ] On a single-event site, `/admin_events/:eventId/edit` is accessible; on a multi-event site it redirects to `/admin_events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)