### PR TITLE
Fix blank page for new convention attendees after login

### DIFF
--- a/app/javascript/AppRouter.tsx
+++ b/app/javascript/AppRouter.tsx
@@ -1107,7 +1107,27 @@ const appRootLoader: LoaderFunction<RouterContextProvider> = async ({ context, r
 
     if (!myProfile) {
       try {
-        await client.mutate({ mutation: SetupMyProfileDocument });
+        const convention = data.convention;
+        await client.mutate({
+          mutation: SetupMyProfileDocument,
+          update(cache, result) {
+            const newProfile = result.data?.setupMyProfile?.my_profile;
+            if (!newProfile) return;
+            // After creating the profile, wire up the Convention.my_profile reference
+            // in the normalized cache so cache-first queries (e.g. MyProfileForm.loader)
+            // see the new profile instead of the stale null entry. Without this,
+            // MyProfileQuery returns null from cache even though the profile now exists,
+            // causing MyProfileForm.loader to return a 404 and show a broken page.
+            const conventionRef = cache.identify({ __typename: 'Convention', id: convention.id });
+            const profileRef = cache.identify({ __typename: 'UserConProfile', id: newProfile.id });
+            if (conventionRef && profileRef) {
+              cache.modify({
+                id: conventionRef,
+                fields: { my_profile: () => ({ __ref: profileRef }) },
+              });
+            }
+          },
+        });
         freshlyCreated = true;
       } catch {
         return data;


### PR DESCRIPTION
## Summary

- When a user logged into a convention site for the first time, `appRootLoader` correctly detected a missing profile, ran `SetupMyProfile`, and redirected to `/my_profile/setup`.
- On that redirect, `MyProfileForm.loader` ran `MyProfileQuery` with the default `cache-first` policy. Because `SetupMyProfile`'s mutation result is stored under `setupMyProfile.my_profile`, the Apollo normalized cache still had `Convention.my_profile = null`. A `null` reference is treated as a *complete* cache hit, so no network request was made. The loader returned a 404 response, which surfaced as a `RouteErrorBoundary` error (a cryptic `[object Response]` message) — effectively a blank/broken page instead of the profile setup form.
- Fix: add an `update` callback to the `SetupMyProfile` `mutate()` call in `appRootLoader`. After the mutation succeeds, the callback patches `Convention.my_profile` in the normalized cache to reference the newly created `UserConProfile` entity. Subsequent `cache-first` queries then find a valid (but incomplete) reference and correctly make a real network fetch for the full profile fields, allowing `MyProfileForm.loader` to succeed and the form to render normally.

## Test plan

- [ ] Log into a convention site with an account that has no existing `UserConProfile` for that convention (first-time attendee)
- [ ] Verify the profile setup form (`/my_profile/setup`) renders correctly after login instead of showing a blank page or error
- [ ] Log in as a returning attendee (existing profile) and verify the normal login flow is unaffected
- [ ] Log in as an attendee with `needs_update: true` and verify the profile edit form renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)