### PR TITLE
Fix error message when adding to queue that resolves after refresh

### DIFF
--- a/app/javascript/EventsApp/EventPage/EventPageRunCard.tsx
+++ b/app/javascript/EventsApp/EventPage/EventPageRunCard.tsx
@@ -112,11 +112,8 @@ function EventPageRunCard({
           },
         });
 
+        await client.resetStore();
         revalidator.revalidate();
-        window.requestAnimationFrame(async () => {
-          await client.resetStore();
-          revalidator.revalidate();
-        });
       } else {
         const response = await client.mutate({
           mutation: CreateMySignupDocument,
@@ -133,11 +130,8 @@ function EventPageRunCard({
           },
         });
 
+        await client.resetStore();
         revalidator.revalidate();
-        window.requestAnimationFrame(async () => {
-          await client.resetStore();
-          revalidator.revalidate();
-        });
         return response.data?.createMySignup.signup;
       }
     },


### PR DESCRIPTION
## Summary
- User report: adding a game to the queue shows an error message, but refreshing the page shows the game was actually added.
- Root cause: `EventPageRunCard.tsx`'s `selfServiceSignup` called `revalidator.revalidate()` immediately after the mutation, then `client.resetStore()` a moment later inside a `requestAnimationFrame` callback. If the revalidate-triggered query was still in flight when `resetStore()` ran, Apollo aborted it with `"Store reset while query was in flight (not completed in link chain)"`, which surfaced as an error even though the mutation had already succeeded server-side.
- This is a regression of a bug fixed once before (#9978 / commit `1a258b83c1`) — that fix removed a duplicate `resetStore()` call but not the underlying race.
- Fix: await `resetStore()` before calling `revalidate()` once, matching every other call site in the codebase (`WithdrawMySignupModal.tsx`, `CreateModeratedSignupModal.tsx`, `RunSignupsTable.tsx`, `BlockPartial.tsx`).
- Audited all other `resetStore()`/`clearStore()` call sites and `requestAnimationFrame` usages in the app — this race pattern was unique to these two branches.

## Test plan
- [ ] Add a game to the signup queue and confirm no error message appears
- [ ] Confirm a regular self-service signup still works without an error message
- [ ] Confirm the queue/signup state is correctly reflected immediately, without needing a refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)