### PR TITLE
Reduce tsc memory usage by removing deep node_modules JS crawling

### DIFF
--- a/app/javascript/@types/untyped-modules.d.ts
+++ b/app/javascript/@types/untyped-modules.d.ts
@@ -1,0 +1,5 @@
+declare module 'array-to-sentence';
+declare module 'porter-stemmer';
+declare module 'html-to-react/lib/is-valid-node-definitions';
+declare module 'html-to-react/lib/camel-case-attribute-names';
+declare module 'apollo-upload-client/UploadHttpLink.mjs';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepare": "husky install",
     "preview": "vite preview --outDir ./public",
     "start": "vite",
-    "ts:check": "tsc --noEmit --incremental",
+    "ts:check": "NODE_OPTIONS=\"$NODE_OPTIONS --max-old-space-size=8192\" tsc --noEmit --incremental",
     "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:watch": "vitest watch"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "noImplicitAny": true,
     "skipLibCheck": true,
-    "maxNodeModuleJsDepth": 10,
     "types": ["vitest/globals", "vite/client"],
     "incremental": true,
     "tsBuildInfoFile": ".tsbuildinfo",


### PR DESCRIPTION
## Summary
- `tsc --noEmit` was reliably running out of memory locally — it never completed even with the Node heap raised to 12 GB.
- Root cause: `maxNodeModuleJsDepth: 10` combined with `allowJs: true` forced TypeScript to fully type-*infer* (not just read `.d.ts` for) plain `.js` files reachable through `node_modules`. This pulled in ~165 extra files (e.g. `aria-query`'s ~140 internal role-definition files), and inferring types for that untyped code appears to have caused a combinatorial blowup in checking cost — likely because those inferred types get referenced pervasively elsewhere (e.g. testing-library's role-based queries).
- The high depth setting was only there so a handful of untyped packages wouldn't fail `noImplicitAny`: `array-to-sentence`, `porter-stemmer`, two `html-to-react` subpaths, and `apollo-upload-client/UploadHttpLink.mjs`. Replaced it with explicit ambient module declarations for just those five imports (`app/javascript/@types/untyped-modules.d.ts`), following the existing pattern in that directory.
- Also bumped the heap ceiling for the `ts:check` script, appending to `NODE_OPTIONS` (not overwriting it — Yarn PnP relies on its own `NODE_OPTIONS` value to hook in module resolution, so a naive overwrite breaks `tsc` resolution entirely).

## Results
Measured `tsc --noEmit --incremental` from a cold `.tsbuildinfo`, twice for consistency:

| Run | Wall time | Peak RSS |
|-----|-----------|----------|
| Before | never completes | OOM at 12 GB heap |
| After (1) | 8.03s | 1.66 GB |
| After (2) | 7.54s | 1.62 GB |

Both post-fix runs exit 0 with zero type errors.

## Test plan
- [x] `yarn run ts:check` completes successfully with no type errors
- [ ] CI type-check job passes
- [ ] Spot-check that the five newly-declared modules (`array-to-sentence`, `porter-stemmer`, `html-to-react` subpaths, `apollo-upload-client`) still work correctly at runtime (only their type-checking behavior changed, not their runtime code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)