### PR TITLE
Make static IAM credentials optional in intercode_aws_resources

### DIFF
--- a/terraform/modules/intercode_aws_resources/README.md
+++ b/terraform/modules/intercode_aws_resources/README.md
@@ -44,21 +44,22 @@ module "ses_email" {
 
 ## Inputs
 
-| Name                       | Description                               | Default |
-| -------------------------- | ----------------------------------------- | ------- |
-| `name`                     | Prefix for SQS queues and IAM resources   | —       |
-| `s3_bucket_name`           | Uploads S3 bucket name                    | —       |
-| `alarm_email_destinations` | Emails for CloudWatch alarm notifications | `[]`    |
+| Name                        | Description                                                                                                                                                                  | Default |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `name`                      | Prefix for SQS queues and IAM resources                                                                                                                                      | —       |
+| `s3_bucket_name`            | Uploads S3 bucket name                                                                                                                                                       | —       |
+| `alarm_email_destinations`  | Emails for CloudWatch alarm notifications                                                                                                                                    | `[]`    |
+| `create_static_credentials` | Whether to create a static IAM user/access key and write `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` to SSM. Set to `false` once the app authenticates via Fly OIDC instead. | `true`  |
 
 ## Outputs
 
-| Name                    | Description                                                              |
-| ----------------------- | ------------------------------------------------------------------------ |
-| `iam_group_name`        | IAM group name — pass to email modules so they can attach their policies |
-| `s3_bucket_name`        | Uploads bucket name                                                      |
-| `s3_bucket_arn`         | Uploads bucket ARN                                                       |
-| `sqs_queue_urls`        | Map of queue name → URL                                                  |
-| `sqs_queue_arns`        | Map of queue name → ARN                                                  |
-| `alarm_sns_topic_arn`   | CloudWatch alarms SNS topic ARN                                          |
-| `iam_access_key_id`     | App IAM access key ID                                                    |
-| `iam_access_key_secret` | App IAM secret access key (sensitive)                                    |
+| Name                    | Description                                                                             |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| `iam_group_name`        | IAM group name — pass to email modules so they can attach their policies                |
+| `s3_bucket_name`        | Uploads bucket name                                                                     |
+| `s3_bucket_arn`         | Uploads bucket ARN                                                                      |
+| `sqs_queue_urls`        | Map of queue name → URL                                                                 |
+| `sqs_queue_arns`        | Map of queue name → ARN                                                                 |
+| `alarm_sns_topic_arn`   | CloudWatch alarms SNS topic ARN                                                         |
+| `iam_access_key_id`     | App IAM access key ID (`null` if `create_static_credentials` is `false`)                |
+| `iam_access_key_secret` | App IAM secret access key (sensitive; `null` if `create_static_credentials` is `false`) |

--- a/terraform/modules/intercode_aws_resources/iam.tf
+++ b/terraform/modules/intercode_aws_resources/iam.tf
@@ -92,14 +92,35 @@ resource "aws_iam_group_policy" "this" {
 }
 
 resource "aws_iam_user" "this" {
-  name = var.name
+  count = var.create_static_credentials ? 1 : 0
+  name  = var.name
 }
 
 resource "aws_iam_user_group_membership" "this" {
-  user   = aws_iam_user.this.name
+  count  = var.create_static_credentials ? 1 : 0
+  user   = aws_iam_user.this[0].name
   groups = [aws_iam_group.this.name]
 }
 
 resource "aws_iam_access_key" "this" {
-  user = aws_iam_user.this.name
+  count = var.create_static_credentials ? 1 : 0
+  user  = aws_iam_user.this[0].name
+}
+
+# create_static_credentials defaults to true, so for existing callers these
+# resources keep their prior addresses (no destroy/recreate of the live
+# access key) despite gaining a count.
+moved {
+  from = aws_iam_user.this
+  to   = aws_iam_user.this[0]
+}
+
+moved {
+  from = aws_iam_user_group_membership.this
+  to   = aws_iam_user_group_membership.this[0]
+}
+
+moved {
+  from = aws_iam_access_key.this
+  to   = aws_iam_access_key.this[0]
 }

--- a/terraform/modules/intercode_aws_resources/outputs.tf
+++ b/terraform/modules/intercode_aws_resources/outputs.tf
@@ -39,13 +39,13 @@ output "alarm_sns_topic_arn" {
 }
 
 output "iam_access_key_id" {
-  description = "AWS access key ID for the app IAM user."
-  value       = aws_iam_access_key.this.id
+  description = "AWS access key ID for the app IAM user. Null if create_static_credentials is false."
+  value       = var.create_static_credentials ? aws_iam_access_key.this[0].id : null
 }
 
 output "iam_access_key_secret" {
-  description = "AWS secret access key for the app IAM user."
-  value       = aws_iam_access_key.this.secret
+  description = "AWS secret access key for the app IAM user. Null if create_static_credentials is false."
+  value       = var.create_static_credentials ? aws_iam_access_key.this[0].secret : null
   sensitive   = true
 }
 

--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -21,8 +21,6 @@ locals {
   # This map is sensitive (contains secrets); use nonsensitive(keys(...)) for for_each.
   _ssm_values = merge(
     {
-      AWS_ACCESS_KEY_ID          = aws_iam_access_key.this.id
-      AWS_SECRET_ACCESS_KEY      = aws_iam_access_key.this.secret
       AWS_S3_BUCKET              = aws_s3_bucket.uploads.bucket
       AWS_REGION                 = local.region
       EMAIL_FORWARDERS_API_TOKEN = local._email_forwarders_api_token
@@ -31,6 +29,10 @@ locals {
       OPENID_CONNECT_SIGNING_KEY = local._openid_connect_signing_key
       DEFAULT_CURRENCY           = var.default_currency
     },
+    var.create_static_credentials ? {
+      AWS_ACCESS_KEY_ID     = aws_iam_access_key.this[0].id
+      AWS_SECRET_ACCESS_KEY = aws_iam_access_key.this[0].secret
+    } : {},
     var.fly_api_token != null ? { FLY_API_TOKEN = var.fly_api_token } : {},
     var.stripe != null ? {
       STRIPE_SECRET_KEY              = var.stripe.secret_key
@@ -60,8 +62,6 @@ locals {
   # Maintained in parallel with _ssm_values; never sensitive.
   _ssm_types = merge(
     {
-      AWS_ACCESS_KEY_ID          = "SecureString"
-      AWS_SECRET_ACCESS_KEY      = "SecureString"
       AWS_S3_BUCKET              = "String"
       AWS_REGION                 = "String"
       EMAIL_FORWARDERS_API_TOKEN = "SecureString"
@@ -70,6 +70,10 @@ locals {
       OPENID_CONNECT_SIGNING_KEY = "SecureString"
       DEFAULT_CURRENCY           = "String"
     },
+    var.create_static_credentials ? {
+      AWS_ACCESS_KEY_ID     = "SecureString"
+      AWS_SECRET_ACCESS_KEY = "SecureString"
+    } : {},
     var.fly_api_token != null ? { FLY_API_TOKEN = "SecureString" } : {},
     var.stripe != null ? {
       STRIPE_SECRET_KEY              = "SecureString"

--- a/terraform/modules/intercode_aws_resources/variables.tf
+++ b/terraform/modules/intercode_aws_resources/variables.tf
@@ -124,3 +124,9 @@ variable "default_currency" {
   description = "ISO 4217 currency code for the default currency (e.g. 'USD'). Required — Intercode will not function without it."
   type        = string
 }
+
+variable "create_static_credentials" {
+  description = "Whether to create a static IAM user/access key and write AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY to SSM. Set to false once the app authenticates via Fly's OIDC identity (CHAMBER_AWS_ROLE_ARN) instead of a long-lived key — see intercode#11852."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary
- Adds a `create_static_credentials` variable (default `true`, no behavior change for existing callers) to `terraform/modules/intercode_aws_resources`
- Gates the static IAM user/group-membership/access-key and the `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` SSM params behind it
- Adds `moved` blocks so flipping to `count`-based resources doesn't force a destroy/recreate of the live access key for callers still on the default

This is prep work for #11852: it lets `neil-terraform` eventually call this module with `create_static_credentials = false` once Fly's OIDC identity (`CHAMBER_AWS_ROLE_ARN`) fully covers the app's AWS access, removing the class of incident where rotating the static key requires a manual `flyctl secrets set`. The actual cutover (flipping the flag) is a separate follow-up once the OIDC role's permissions and the Fly secret are confirmed working in production.

## Test plan
- [x] `tofu validate` passes in `terraform/modules/intercode_aws_resources`
- [x] `tofu fmt -check` passes
- [ ] Confirm a `tofu plan` in `neil-terraform` (once this is merged and the module ref updates) shows no unexpected replacement of `aws_iam_access_key.this`/`aws_iam_user.this`/`aws_iam_user_group_membership.this`