### PR TITLE
Fix missing fields and GraphQL param duplication in JSON request logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,6 +71,20 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  # Lograge's custom_options (see config/initializers/json_logging.rb) reads these keys
+  # straight off the process_action.action_controller event payload, so they need to be
+  # added here rather than via config.lograge.custom_payload (which nests them instead).
+  def append_info_to_payload(payload)
+    super
+    payload[:request_host] = request.host
+    payload[:remote_ip] = request.remote_ip
+    payload[:ip] = request.ip
+    payload[:user_agent] = request.headers["User-Agent"]
+    payload[:x_forwarded_for] = request.headers["X-Forwarded-For"]
+    payload[:current_user_id] = current_user&.id
+    payload[:assumed_identity_from_profile_id] = assumed_identity_from_profile&.id
+  end
+
   def pundit_user
     @pundit_user ||=
       AuthorizationInfo.new(

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -74,6 +74,11 @@ class GraphqlController < ApplicationController
   skip_before_action :redirect_if_user_con_profile_needs_update
   skip_before_action :ensure_clickwrap_agreement_accepted
 
+  # The default ParamsWrapper nests a second copy of the request body under a "graphql" key
+  # (named after this controller), since it assumes JSON POST bodies map to a model. We don't
+  # have a model here and never read the wrapped copy, so it's just duplicate data in every log line.
+  wrap_parameters false
+
   def execute
     ActiveRecord::Base.transaction do
       result = clean_backtraces(execute_from_params(params))
@@ -160,6 +165,22 @@ class GraphqlController < ApplicationController
       {}
     else
       raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
+    end
+  end
+
+  # Surfaces operation name(s)/variables as their own request-log fields (see
+  # config/initializers/json_logging.rb), instead of leaving them buried in the raw params.
+  def append_info_to_payload(payload)
+    super
+
+    batched_queries = params[:_json]
+
+    if batched_queries.is_a?(Array)
+      payload[:graphql_operation_name] = batched_queries.pluck(:operationName)
+      payload[:graphql_variables] = batched_queries.map { |query| ensure_hash(query[:variables]) }
+    else
+      payload[:graphql_operation_name] = params[:operationName]
+      payload[:graphql_variables] = variables
     end
   end
 

--- a/config/initializers/json_logging.rb
+++ b/config/initializers/json_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV["JSON_LOGGING"]
   Rails.application.configure do
     config.lograge.formatter = Lograge::Formatters::Json.new
@@ -7,10 +9,10 @@ if ENV["JSON_LOGGING"]
     config.lograge.custom_options =
       lambda do |event|
         custom_options = {
-          request_time: Time.now,
+          request_time: Time.current,
           application: Rails.application.class.name.delete_suffix("::Application"),
           process_id: Process.pid,
-          host: event.payload[:host],
+          request_host: event.payload[:request_host],
           remote_ip: event.payload[:remote_ip],
           user_agent: event.payload[:user_agent],
           ip: event.payload[:ip],

--- a/config/initializers/json_logging.rb
+++ b/config/initializers/json_logging.rb
@@ -1,34 +1,37 @@
 # frozen_string_literal: true
 
 if ENV["JSON_LOGGING"]
+  json_logging_custom_options =
+    lambda do |event|
+      custom_options = {
+        request_time: Time.current,
+        application: Rails.application.class.name.delete_suffix("::Application"),
+        process_id: Process.pid,
+        request_host: event.payload[:request_host],
+        remote_ip: event.payload[:remote_ip],
+        user_agent: event.payload[:user_agent],
+        ip: event.payload[:ip],
+        x_forwarded_for: event.payload[:x_forwarded_for],
+        params: event.payload[:params],
+        rails_env: Rails.env,
+        exception: event.payload[:exception]&.first,
+        request_id: event.payload[:headers]["action_dispatch.request_id"],
+        current_user_id: event.payload[:current_user_id],
+        assumed_identity_from_profile_id: event.payload[:assumed_identity_from_profile_id],
+        graphql_operation_name: event.payload[:graphql_operation_name],
+        graphql_variables: event.payload[:graphql_variables],
+        fly_process_group: ENV.fetch("FLY_PROCESS_GROUP", nil)
+      }.compact
+
+      custom_options[:gc_stat] = GC.stat if ENV["GC_DEBUG"]
+
+      custom_options
+    end
+
   Rails.application.configure do
     config.lograge.formatter = Lograge::Formatters::Json.new
     config.lograge.enabled = true
     config.lograge.base_controller_class = ["ActionController::Base"]
-
-    config.lograge.custom_options =
-      lambda do |event|
-        custom_options = {
-          request_time: Time.current,
-          application: Rails.application.class.name.delete_suffix("::Application"),
-          process_id: Process.pid,
-          request_host: event.payload[:request_host],
-          remote_ip: event.payload[:remote_ip],
-          user_agent: event.payload[:user_agent],
-          ip: event.payload[:ip],
-          x_forwarded_for: event.payload[:x_forwarded_for],
-          params: event.payload[:params],
-          rails_env: Rails.env,
-          exception: event.payload[:exception]&.first,
-          request_id: event.payload[:headers]["action_dispatch.request_id"],
-          current_user_id: event.payload[:current_user_id],
-          assumed_identity_from_profile_id: event.payload[:assumed_identity_from_profile_id],
-          fly_process_group: ENV.fetch("FLY_PROCESS_GROUP", nil)
-        }.compact
-
-        custom_options[:gc_stat] = GC.stat if ENV["GC_DEBUG"]
-
-        custom_options
-      end
+    config.lograge.custom_options = json_logging_custom_options
   end
 end


### PR DESCRIPTION
## Summary
- `current_user_id`, `remote_ip`, `ip`, `user_agent`, `x_forwarded_for`, and `assumed_identity_from_profile_id` have been silently missing from our CloudWatch JSON request logs since a Dec 2023 commit removed the `append_info_to_payload` override that populated them, leaving `custom_options` in `json_logging.rb` reading `nil` and `.compact`-ing them away. Restored via a new `append_info_to_payload` on `ApplicationController`. Renamed `host` → `request_host` in the process, since a bare `host` key collides with the hostname field our Fly→CloudWatch log shipper already injects.
- GraphQL request logs were also duplicating the entire request body: `ActionController::ParamsWrapper` (enabled globally for JSON) nests a second copy of the params under a `"graphql"` key by default, but `GraphqlController` never reads from it. Disabled wrapping for that controller, and added dedicated `graphql_operation_name`/`graphql_variables` log fields (including for Apollo's batched multi-query requests) so operations are easy to search on without parsing the raw query text.

## Test plan
- [x] Verified via a scratch integration test (not committed) that `process_action.action_controller` payload now includes `remote_ip`, `current_user_id`, and `request_host`
- [x] Verified via scratch integration tests that single and batched GraphQL requests produce correct `graphql_operation_name`/`graphql_variables`, and that `params` no longer contains a duplicate `"graphql"` key
- [x] `bundle exec rubocop` clean on both changed files
- [ ] Confirm real log output in a deployed environment shows the new fields as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)