### PR TITLE
Fix Slack notification corruption and truncate long messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,12 +413,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Format Slack post
         id: slack-post
+        env:
+          RELEASE_NAME: ${{ steps.release-drafter.outputs.name }}
+          RELEASE_URL: ${{ steps.release-drafter.outputs.html_url }}
+          COMMIT_MESSAGES: ${{ join(github.event.commits.*.message, '\n- ') }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          echo "text<<END_OF_SLACK_MESSAGE" >> "$GITHUB_OUTPUT"
-          echo -e "Draft release ${{ steps.release-drafter.outputs.name }} updated:\n" >> "$GITHUB_OUTPUT"
-          echo -e "- ${{ join(github.event.commits.*.message, '\n- ') }}\n" >> "$GITHUB_OUTPUT"
-          echo "To release Intercode to production, visit: ${{ steps.release-drafter.outputs.html_url }}" >> "$GITHUB_OUTPUT"
-          echo END_OF_SLACK_MESSAGE >> "$GITHUB_OUTPUT"
+          MAX_LENGTH=2800
+          BODY=$(printf 'Draft release %s updated:\n\n- %s\n\nTo release Intercode to production, visit: %s' \
+            "$RELEASE_NAME" "$COMMIT_MESSAGES" "$RELEASE_URL")
+          if [ "${#BODY}" -gt "$MAX_LENGTH" ]; then
+            BODY="${BODY:0:$MAX_LENGTH}"$'\n\n... (truncated; see the full run: '"$RUN_URL"')'
+          fi
+          {
+            echo "text<<SLACK_MSG_EOF_${{ github.run_id }}_${{ github.run_attempt }}"
+            echo "$BODY"
+            echo "SLACK_MSG_EOF_${{ github.run_id }}_${{ github.run_attempt }}"
+          } >> "$GITHUB_OUTPUT"
       - name: Post about drafted release to Slack
         id: slack
         uses: slackapi/slack-github-action@v3.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,23 @@ jobs:
         uses: LoveToKnow/slackify-markdown-action@v1.1.1
         with:
           text: ${{ github.event.release.body }}
+      - name: Truncate release notes for Slack
+        id: truncate-release-notes
+        env:
+          RELEASE_NOTES: ${{ steps.format-release-notes.outputs.text }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          # Slack section blocks cap mrkdwn text at 3000 characters.
+          MAX_LENGTH=2800
+          BODY="$RELEASE_NOTES"
+          if [ "${#BODY}" -gt "$MAX_LENGTH" ]; then
+            BODY="${BODY:0:$MAX_LENGTH}"$'\n\n... (truncated; see the full release notes: '"$RELEASE_URL"')'
+          fi
+          {
+            echo "text<<SLACK_MSG_EOF_${{ github.run_id }}_${{ github.run_attempt }}"
+            echo "$BODY"
+            echo "SLACK_MSG_EOF_${{ github.run_id }}_${{ github.run_attempt }}"
+          } >> "$GITHUB_OUTPUT"
       - name: Post about release to Slack
         id: slack
         uses: slackapi/slack-github-action@v3.0.3
@@ -82,7 +99,7 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: ${{ toJSON(steps.format-release-notes.outputs.text) }}
+                  text: ${{ toJSON(steps.truncate-release-notes.outputs.text) }}
   doc-site-release:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- The release-draft Slack step (`ci.yml`) interpolated raw commit messages directly into a shell script via `${{ }}`, so backticks/`$()`/quotes in commit bodies got parsed as shell syntax instead of literal text. This is what actually broke [this run](https://github.com/neinteractiveliterature/intercode/actions/runs/30830826772/job/91744935400) — a commit message body containing backticks caused the script to try executing part of it as a command, which aborted before the `$GITHUB_OUTPUT` heredoc delimiter was ever written. Commit/release data now flows through `env:` vars instead, so it's treated as plain string content, not re-parsed shell code.
- Both Slack-posting steps (`ci.yml` draft-release notification, `release.yml` release notification) now truncate the assembled message before sending, appending a link back to the full Actions run or release page when truncated. This avoids the release-notes `section` block ever exceeding Slack's 3000-character mrkdwn limit.

## Test plan
- [x] Validated both workflow YAML files parse correctly
- [x] Locally simulated the bash logic with a "hostile" commit message containing backticks, `$()`, and quotes — confirmed it now passes through as literal text with exit status 0
- [x] Locally simulated an oversized message — confirmed it truncates to the configured limit and appends the truncation notice + link
- [ ] Merge and confirm the next real draft-release / release Slack notification posts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)