### PR TITLE
Drop legacy bucket_key/requested_bucket_key columns

### DIFF
--- a/app/models/signup.rb
+++ b/app/models/signup.rb
@@ -4,19 +4,17 @@
 #
 # Table name: signups
 #
-#  id                   :bigint           not null, primary key
-#  bucket_key           :string
-#  counted              :boolean
-#  expires_at           :datetime
-#  requested_bucket_key :string
-#  state                :string           default("confirmed"), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  bucket_id            :bigint
-#  requested_bucket_id  :bigint
-#  run_id               :bigint           not null
-#  updated_by_id        :bigint
-#  user_con_profile_id  :bigint           not null
+#  id                  :bigint           not null, primary key
+#  counted             :boolean
+#  expires_at          :datetime
+#  state               :string           default("confirmed"), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  bucket_id           :bigint
+#  requested_bucket_id :bigint
+#  run_id              :bigint           not null
+#  updated_by_id       :bigint
+#  user_con_profile_id :bigint           not null
 #
 # Indexes
 #

--- a/app/models/signup_change.rb
+++ b/app/models/signup_change.rb
@@ -6,10 +6,8 @@
 #
 #  id                        :bigint           not null, primary key
 #  action                    :string           not null
-#  bucket_key                :string
 #  bucket_name               :string
 #  counted                   :boolean
-#  requested_bucket_key      :string
 #  requested_bucket_name     :string
 #  state                     :string           not null
 #  created_at                :datetime         not null

--- a/app/models/signup_ranked_choice.rb
+++ b/app/models/signup_ranked_choice.rb
@@ -6,7 +6,6 @@
 #  id                       :bigint           not null, primary key
 #  prioritize_waitlist      :boolean          default(FALSE), not null
 #  priority                 :integer          not null
-#  requested_bucket_key     :string
 #  state                    :string           not null
 #  waitlist_position_cap    :integer
 #  created_at               :datetime         not null

--- a/app/models/signup_request.rb
+++ b/app/models/signup_request.rb
@@ -4,17 +4,16 @@
 #
 # Table name: signup_requests
 #
-#  id                   :bigint           not null, primary key
-#  requested_bucket_key :string
-#  state                :string           default("pending"), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  replace_signup_id    :bigint
-#  requested_bucket_id  :bigint
-#  result_signup_id     :bigint
-#  target_run_id        :bigint           not null
-#  updated_by_id        :bigint
-#  user_con_profile_id  :bigint           not null
+#  id                  :bigint           not null, primary key
+#  state               :string           default("pending"), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  replace_signup_id   :bigint
+#  requested_bucket_id :bigint
+#  result_signup_id    :bigint
+#  target_run_id       :bigint           not null
+#  updated_by_id       :bigint
+#  user_con_profile_id :bigint           not null
 #
 # Indexes
 #

--- a/db/migrate/20260805191230_drop_bucket_key_columns_from_signups_signup_requests_signup_ranked_choices_and_signup_changes.rb
+++ b/db/migrate/20260805191230_drop_bucket_key_columns_from_signups_signup_requests_signup_ranked_choices_and_signup_changes.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+class DropBucketKeyColumnsFromSignupsSignupRequestsSignupRankedChoicesAndSignupChanges < ActiveRecord::Migration[8.1]
+  def change
+    reversible do |dir|
+      dir.up { remove_check_constraint :signups, name: "bucket_key_null_for_non_slot_occupying_states" }
+
+      dir.down do
+        add_check_constraint :signups,
+                             "(bucket_key IS NULL) OR ((state)::text = ANY (ARRAY['confirmed'::text, 'ticket_purchase_hold'::text]))", # rubocop:disable Layout/LineLength
+                             name: "bucket_key_null_for_non_slot_occupying_states"
+      end
+    end
+
+    change_table :signups, bulk: true do |t|
+      t.remove :bucket_key, type: :string
+      t.remove :requested_bucket_key, type: :string
+    end
+
+    remove_column :signup_requests, :requested_bucket_key, :string
+
+    remove_column :signup_ranked_choices, :requested_bucket_key, :string
+
+    change_table :signup_changes, bulk: true do |t|
+      t.remove :bucket_key, type: :string
+      t.remove :requested_bucket_key, type: :string
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2403,9 +2403,7 @@ CREATE TABLE public.signup_changes (
     bucket_id bigint,
     bucket_name character varying,
     requested_bucket_id bigint,
-    requested_bucket_name character varying,
-    requested_bucket_key character varying,
-    bucket_key character varying
+    requested_bucket_name character varying
 );
 
 
@@ -2445,8 +2443,7 @@ CREATE TABLE public.signup_ranked_choices (
     result_signup_request_id bigint,
     prioritize_waitlist boolean DEFAULT false NOT NULL,
     waitlist_position_cap integer,
-    requested_bucket_id bigint,
-    requested_bucket_key character varying
+    requested_bucket_id bigint
 );
 
 
@@ -2483,8 +2480,7 @@ CREATE TABLE public.signup_requests (
     updated_by_id bigint,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    requested_bucket_id bigint,
-    requested_bucket_key character varying
+    requested_bucket_id bigint
 );
 
 
@@ -2562,10 +2558,7 @@ CREATE TABLE public.signups (
     expires_at timestamp without time zone,
     bucket_id bigint,
     requested_bucket_id bigint,
-    requested_bucket_key character varying,
-    bucket_key character varying,
-    CONSTRAINT bucket_id_null_for_non_slot_occupying_states CHECK (((bucket_id IS NULL) OR ((state)::text = ANY (ARRAY['confirmed'::text, 'ticket_purchase_hold'::text])))),
-    CONSTRAINT bucket_key_null_for_non_slot_occupying_states CHECK (((bucket_key IS NULL) OR ((state)::text = ANY (ARRAY['confirmed'::text, 'ticket_purchase_hold'::text]))))
+    CONSTRAINT bucket_id_null_for_non_slot_occupying_states CHECK (((bucket_id IS NULL) OR ((state)::text = ANY (ARRAY['confirmed'::text, 'ticket_purchase_hold'::text]))))
 );
 
 
@@ -6191,6 +6184,7 @@ ALTER TABLE ONLY public.cms_files_pages
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260805191230'),
 ('20260803190446'),
 ('20260716155031'),
 ('20260615192952'),

--- a/test/factories/signup_ranked_choices.rb
+++ b/test/factories/signup_ranked_choices.rb
@@ -6,7 +6,6 @@
 #  id                       :bigint           not null, primary key
 #  prioritize_waitlist      :boolean          default(FALSE), not null
 #  priority                 :integer          not null
-#  requested_bucket_key     :string
 #  state                    :string           not null
 #  waitlist_position_cap    :integer
 #  created_at               :datetime         not null

--- a/test/factories/signup_requests.rb
+++ b/test/factories/signup_requests.rb
@@ -3,17 +3,16 @@
 #
 # Table name: signup_requests
 #
-#  id                   :bigint           not null, primary key
-#  requested_bucket_key :string
-#  state                :string           default("pending"), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  replace_signup_id    :bigint
-#  requested_bucket_id  :bigint
-#  result_signup_id     :bigint
-#  target_run_id        :bigint           not null
-#  updated_by_id        :bigint
-#  user_con_profile_id  :bigint           not null
+#  id                  :bigint           not null, primary key
+#  state               :string           default("pending"), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  replace_signup_id   :bigint
+#  requested_bucket_id :bigint
+#  result_signup_id    :bigint
+#  target_run_id       :bigint           not null
+#  updated_by_id       :bigint
+#  user_con_profile_id :bigint           not null
 #
 # Indexes
 #

--- a/test/factories/signups.rb
+++ b/test/factories/signups.rb
@@ -3,19 +3,17 @@
 #
 # Table name: signups
 #
-#  id                   :bigint           not null, primary key
-#  bucket_key           :string
-#  counted              :boolean
-#  expires_at           :datetime
-#  requested_bucket_key :string
-#  state                :string           default("confirmed"), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  bucket_id            :bigint
-#  requested_bucket_id  :bigint
-#  run_id               :bigint           not null
-#  updated_by_id        :bigint
-#  user_con_profile_id  :bigint           not null
+#  id                  :bigint           not null, primary key
+#  counted             :boolean
+#  expires_at          :datetime
+#  state               :string           default("confirmed"), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  bucket_id           :bigint
+#  requested_bucket_id :bigint
+#  run_id              :bigint           not null
+#  updated_by_id       :bigint
+#  user_con_profile_id :bigint           not null
 #
 # Indexes
 #

--- a/test/models/signup_change_test.rb
+++ b/test/models/signup_change_test.rb
@@ -5,10 +5,8 @@
 #
 #  id                        :bigint           not null, primary key
 #  action                    :string           not null
-#  bucket_key                :string
 #  bucket_name               :string
 #  counted                   :boolean
-#  requested_bucket_key      :string
 #  requested_bucket_name     :string
 #  state                     :string           not null
 #  created_at                :datetime         not null

--- a/test/models/signup_ranked_choice_test.rb
+++ b/test/models/signup_ranked_choice_test.rb
@@ -6,7 +6,6 @@
 #  id                       :bigint           not null, primary key
 #  prioritize_waitlist      :boolean          default(FALSE), not null
 #  priority                 :integer          not null
-#  requested_bucket_key     :string
 #  state                    :string           not null
 #  waitlist_position_cap    :integer
 #  created_at               :datetime         not null

--- a/test/models/signup_request_test.rb
+++ b/test/models/signup_request_test.rb
@@ -3,17 +3,16 @@
 #
 # Table name: signup_requests
 #
-#  id                   :bigint           not null, primary key
-#  requested_bucket_key :string
-#  state                :string           default("pending"), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  replace_signup_id    :bigint
-#  requested_bucket_id  :bigint
-#  result_signup_id     :bigint
-#  target_run_id        :bigint           not null
-#  updated_by_id        :bigint
-#  user_con_profile_id  :bigint           not null
+#  id                  :bigint           not null, primary key
+#  state               :string           default("pending"), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  replace_signup_id   :bigint
+#  requested_bucket_id :bigint
+#  result_signup_id    :bigint
+#  target_run_id       :bigint           not null
+#  updated_by_id       :bigint
+#  user_con_profile_id :bigint           not null
 #
 # Indexes
 #

--- a/test/models/signup_test.rb
+++ b/test/models/signup_test.rb
@@ -3,19 +3,17 @@
 #
 # Table name: signups
 #
-#  id                   :bigint           not null, primary key
-#  bucket_key           :string
-#  counted              :boolean
-#  expires_at           :datetime
-#  requested_bucket_key :string
-#  state                :string           default("confirmed"), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  bucket_id            :bigint
-#  requested_bucket_id  :bigint
-#  run_id               :bigint           not null
-#  updated_by_id        :bigint
-#  user_con_profile_id  :bigint           not null
+#  id                  :bigint           not null, primary key
+#  counted             :boolean
+#  expires_at          :datetime
+#  state               :string           default("confirmed"), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  bucket_id           :bigint
+#  requested_bucket_id :bigint
+#  run_id              :bigint           not null
+#  updated_by_id       :bigint
+#  user_con_profile_id :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
## Summary

Drops the legacy `bucket_key`/`requested_bucket_key` string columns (and the `bucket_key_null_for_non_slot_occupying_states` check constraint on `signups`) that #11871 deliberately kept in place for one release, so a rolling/partial deploy couldn't have old code hit a missing-column error while new code was already writing `bucket_id`/`requested_bucket_id`.

- `signups`: drops `bucket_key`, `requested_bucket_key`, and the now-redundant check constraint (superseded by `bucket_id_null_for_non_slot_occupying_states` from #11871).
- `signup_requests`, `signup_ranked_choices`: drop `requested_bucket_key`.
- `signup_changes` (audit log): drops `bucket_key`, `requested_bucket_key` — the `bucket_name`/`requested_bucket_name` snapshot columns added in #11871 already cover display needs after a bucket is deleted.
- Migration is reversible (re-adds the columns and check constraint on rollback, though not the historical data).

## Verification before merging

Since this drop is only safe once the #11871 backfill is confirmed correct and the new code is actually live:

- Pulled a fresh production database dump (after the #11871 deploy had been running for a while) into development and ran a verification script against it, checking all four tables for backfill gaps, id/key mismatches, and unresolvable orphans:
  - Zero unbackfilled rows outside the documented pre-existing-orphan case (buckets removed from a policy before the migration ever ran) — orphan rate well under 1% on every table, matching #11871's stated known limitation.
  - Zero id/key mismatches anywhere.
  - Confirmed live post-deploy signups have `bucket_id` set with no legacy key ever written (the new code path), with none of that pattern appearing on rows from before the deploy timestamp — i.e., the cutover is real and clean, not just a coincidence of the backfill.
- Applied and tested the migration itself locally: migrates and rolls back cleanly against the current schema, relevant model/service/GraphQL/notifier/presenter tests (125 tests) pass against the new schema, and confirmed no application code still references the raw legacy columns (only the computed `bucket_key`/`requested_bucket_key` reader methods and the unrelated `registration_policy_buckets.key` column, both of which are intentionally kept).

Fixes #11872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
