### PR TITLE
Fix N+1 query on registration_policy/buckets in SignupCountPresenter

### DIFF
--- a/app/presenters/signup_count_presenter.rb
+++ b/app/presenters/signup_count_presenter.rb
@@ -111,6 +111,18 @@ AND team_members.user_con_profile_id = signups.user_con_profile_id"
   end
 
   def self.for_runs(runs)
+    runs = runs.to_a
+    # Every presenter built below reads run.registration_policy.buckets (directly, or via
+    # RunAvailabilityPresenter which wraps this). Preload it here, once per batch, so that doesn't
+    # turn into a registration_policy + buckets query pair per run.
+    ActiveRecord::Associations::Preloader.new(
+      records: runs,
+      associations: {
+        event: {
+          registration_policy: :buckets
+        }
+      }
+    ).call
     data_by_run_id = signup_count_data_for_runs(runs)
     runs.to_h { |run| [run.id, new(run, count_data: data_by_run_id[run.id] || SignupCountData.new(DIMENSIONS[0], []))] }
   end

--- a/test/presenters/signup_count_presenter_test.rb
+++ b/test/presenters/signup_count_presenter_test.rb
@@ -132,4 +132,39 @@ class SignupCountPresenterTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe ".for_runs over many runs" do
+    let(:registration_policy) do
+      RegistrationPolicy.build_from_hash(
+        buckets: [{ key: "attendees", name: "Attendees", slots_limited: true, total_slots: 10 }]
+      )
+    end
+    let(:event) { create(:event, convention:, registration_policy:) }
+    let(:runs) { create_list(:run, 10, event:) }
+
+    before { runs.each { |run| create(:signup, run:) } }
+
+    it "does not issue a registration_policy/buckets query pair per run" do
+      # Load fresh Run records so each has its own unloaded `event` association, rather than all
+      # 10 sharing the single memoized `event` (and thus already-cached registration_policy) from
+      # the `let` above -- that would mask the N+1 this test exists to catch.
+      fresh_runs = Run.where(id: runs.map(&:id)).to_a
+      queries = count_queries(/registration_polic/) { SignupCountPresenter.for_runs(fresh_runs).each_value(&:buckets) }
+      assert_operator queries, :<=, 2, "expected a constant number of registration_policy/bucket queries"
+    end
+  end
+
+  private
+
+  def count_queries(pattern)
+    count = 0
+    subscriber =
+      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        count += 1 if pattern.match?(payload[:sql])
+      end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
 end


### PR DESCRIPTION
## Summary

Sentry surfaced a cluster of N+1 queries after #11871/#11872 shipped (INTERCODE-176/178/17C/179/17D/17B/17E), all showing the same repeated pair, 33-100 times per request:

```
SELECT "registration_policies".* FROM "registration_policies" WHERE "registration_policies"."id" = $1 LIMIT $2
SELECT "registration_policy_buckets".* FROM "registration_policy_buckets" WHERE "registration_policy_buckets"."registration_policy_id" = $1 ORDER BY "registration_policy_buckets"."position" ASC
```

across page-load queries (`AppRootLayoutQuery`/`CmsPageQuery`, rendered via CMS Liquid tags), `Convention.event_categories`, and signup mutations.

## Root cause

`SignupCountPresenter.for_runs(runs)` batches the signup-count SQL across all runs in one query, but constructs a `SignupCountPresenter` per run without preloading `run.event.registration_policy.buckets` first. Each presenter's `#registration_policy`/`#buckets` then hits that association fresh — once per run. `RunAvailabilityPresenter.for_runs` wraps `SignupCountPresenter.for_runs` and has the same exposure through its own `#registration_policy`/`#buckets` delegation, so it inherits the fix for free once the underlying batch is preloaded.

This is a sibling gap to the N+1 #11869 already fixed: that PR wired `registration_policy`/`buckets` into the GraphQL dataloader (`association_loaders`) for `EventType`/`EventProposalType`/`RegistrationPolicyType`, but `SignupCountPresenter`/`RunAvailabilityPresenter` (used by CMS Liquid drops and the `Sources::SignupCount` dataloader source) never got the same treatment.

## Fix

`SignupCountPresenter.for_runs` now preloads `event: { registration_policy: :buckets }` across the full batch of runs before constructing any presenters, via `ActiveRecord::Associations::Preloader` (the same primitive the GraphQL dataloader's `Sources::ActiveRecordAssociation` uses). This fixes all callers that go through `.for_runs`: `RunAvailabilityPresenter.for_runs` (CMS `run_availabilities`/`runs_with_openings` Liquid tags) and the `Sources::SignupCount` GraphQL dataloader source (`RunType#confirmed_limited_signup_count`, `#grouped_signup_counts`).

Added a regression test (verified it fails without the fix — 20 queries for 10 runs — and passes with it, ≤2 queries regardless of run count).

## Out of scope

Sentry also showed a smaller, lower-volume version of the same query pair in `Mutation.createSignupRequest` and sibling mutations (`createMySignup`, `createUserSignup`, `updateSignupBucket`, `forceConfirmSignup`, `createSignupRequest`) -- 4-11 occurrences per event vs. 33-100 for the page-load path above. I wasn't able to pin down a concrete root cause for that one (the registration_policy/buckets association should already be memoized within a single mutation call), so I'm leaving it for a follow-up rather than guessing at a fix.

## Test plan

- [x] `test/presenters/signup_count_presenter_test.rb` (new N+1 regression test + full existing suite)
- [x] `test/liquid_drops/convention_drop_test.rb`, `test/models/run_test.rb`
- [x] Broader registration-policy/signup service suite (126 tests)
- [x] rubocop / stree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
