### PR TITLE
Fix N+1 query on signup bucket/requested_bucket in UserConProfileDrop

### DIFF
--- a/app/liquid_drops/user_con_profile_drop.rb
+++ b/app/liquid_drops/user_con_profile_drop.rb
@@ -51,6 +51,7 @@ class UserConProfileDrop < Liquid::Drop
 
   # @api
   def initialize(user_con_profile)
+    super()
     @user_con_profile = user_con_profile
   end
 
@@ -65,7 +66,17 @@ class UserConProfileDrop < Liquid::Drop
     user_con_profile
       .signups
       .where.not(state: "withdrawn")
-      .includes(event: :event_category, run: { rooms: nil, event: { team_members: :user_con_profile } })
+      .includes(
+        :bucket,
+        :requested_bucket,
+        event: :event_category,
+        run: {
+          rooms: nil,
+          event: {
+            team_members: :user_con_profile
+          }
+        }
+      )
       .to_a
   end
 

--- a/test/liquid_drops/user_con_profile_drop_test.rb
+++ b/test/liquid_drops/user_con_profile_drop_test.rb
@@ -63,5 +63,30 @@ describe UserConProfileDrop do
       signups = user_con_profile_drop.signups
       withdrawn_signups.each { |signup| assert_not_includes signups, signup }
     end
+
+    it "does not issue a bucket query per signup" do
+      queries =
+        count_queries(/registration_policy_buckets/) do
+          user_con_profile_drop.signups.each do |signup|
+            signup.bucket
+            signup.requested_bucket
+          end
+        end
+      assert_operator queries, :<=, 2, "expected a constant number of bucket queries regardless of signup count"
+    end
+  end
+
+  private
+
+  def count_queries(pattern)
+    count = 0
+    subscriber =
+      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        count += 1 if pattern.match?(payload[:sql])
+      end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
 end


### PR DESCRIPTION
## Summary

After #11880 deployed, Sentry surfaced a new batch of N+1 issues (INTERCODE-186, 187, 189) with the offending query `SELECT registration_policy_buckets.* WHERE id = $1 LIMIT $2`, under `AppRootLayoutQuery`/`CmsPageQuery`. This is a genuinely different N+1 than the one #11880 fixed -- that one was a `has_many` collection load (`registration_policy_buckets WHERE registration_policy_id = X`); this one is `belongs_to` lookups (`bucket`/`requested_bucket` by their own id), so #11880's preload didn't cover it. It's likely this N+1 already existed since #11871 but was masked in Sentry's grouping by the much larger N+1 #11880 just fixed -- once that one went quiet, this one became the dominant signal.

## Root cause

Traced it (by grepping actual CMS partial content in a production data dump) to a default/stock CMS partial pair present on most conventions' sites -- `user_signups`/`user_signup` (the "My Schedule" widget) and `signup_bucket_description`, which it renders per signup:

```liquid
{%- elsif signup.bucket.name -%}
  ...
  {%- if signup.requested_bucket -%}
```

`UserConProfileDrop#signups` backs `user_con_profile.signups` for this widget. It already preloads several associations (`event`, `run`, `rooms`, `team_members`) but never picked up `:bucket`/`:requested_bucket` -- these only became real `belongs_to` associations in #11871 (previously `bucket_key`/`requested_bucket_key` were plain string columns needing no extra query at all), so the widget's preload list was never updated for them.

## Fix

Added `:bucket`, `:requested_bucket` to `UserConProfileDrop#signups`'s `.includes(...)`. Added a regression test verified to fail without the fix (10 queries for 5 signups) and pass with it (2 total -- one batched query each for `bucket` and `requested_bucket`).

Also fixed a pre-existing (unrelated) `Lint/MissingSuper` rubocop offense on this same file's `initialize`, since the pre-commit hook rejects it once the file is touched at all.

## Test plan

- [x] `test/liquid_drops/user_con_profile_drop_test.rb` (new N+1 regression test + full existing suite)
- [x] Full `test/liquid_drops/` suite (39 tests)
- [x] rubocop / stree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
