### PR TITLE
Fix unrelated N+1 queries found during the bucket N+1 investigation

### DIFF
--- a/app/liquid_drops/event_drop.rb
+++ b/app/liquid_drops/event_drop.rb
@@ -27,6 +27,7 @@ class EventDrop < Liquid::Drop
 
   # @api
   def initialize(event)
+    super()
     @event = event
   end
 
@@ -86,10 +87,7 @@ class EventDrop < Liquid::Drop
     define_method field do
       markdown = event.public_send(field)
       return nil unless markdown
-      MarkdownPresenter.new("").render(
-        markdown,
-        local_images: event.images.includes(:blob).index_by { |image| image.filename.to_s }
-      )
+      MarkdownPresenter.new("").render(markdown, local_images: local_images)
     end
   end
 
@@ -103,5 +101,13 @@ class EventDrop < Liquid::Drop
       team_member_name: event.event_category.team_member_name,
       controller: @context.registers["controller"]
     ).as_json_with_rendered_markdown("event", event, "")
+  end
+
+  private
+
+  # Memoized so that rendering multiple markdown fields (description, short_blurb, etc.) on the
+  # same EventDrop only queries this event's image attachments once, rather than once per field.
+  def local_images
+    @local_images ||= event.images.includes(:blob).index_by { |image| image.filename.to_s }
   end
 end

--- a/app/services/event_signup_service.rb
+++ b/app/services/event_signup_service.rb
@@ -189,7 +189,7 @@ class EventSignupService < CivilService::Service
       SignupBucketFinder.new(
         run.registration_policy,
         requested_bucket&.key,
-        run.signups.includes(:bucket, :requested_bucket).to_a
+        run.signups.includes(:user_con_profile, :bucket, :requested_bucket).to_a
       )
   end
 

--- a/app/services/execute_ranked_choice_signup_service.rb
+++ b/app/services/execute_ranked_choice_signup_service.rb
@@ -117,7 +117,8 @@ class ExecuteRankedChoiceSignupService < CivilService::Service
     @actual_bucket ||=
       begin
         run = signup_ranked_choice.target_run
-        existing_signups = run.signups.counted.occupying_slot.includes(:bucket, :requested_bucket).to_a
+        existing_signups =
+          run.signups.counted.occupying_slot.includes(:user_con_profile, :bucket, :requested_bucket).to_a
         bucket_finder =
           SignupBucketFinder.new(run.registration_policy, signup_ranked_choice.requested_bucket_key, existing_signups)
         if convention.signup_mode == "moderated"

--- a/test/liquid_drops/event_drop_test.rb
+++ b/test/liquid_drops/event_drop_test.rb
@@ -1,28 +1,56 @@
-require 'test_helper'
+# frozen_string_literal: true
+require "test_helper"
 
 describe EventDrop do
   let(:event) { create(:event) }
   let(:event_drop) { EventDrop.new(event) }
 
-  it 'returns the title of the event' do
+  it "returns the title of the event" do
     assert_equal event.title, event_drop.title
   end
 
-  it 'returns the team member name of the event category' do
+  it "returns the team member name of the event category" do
     assert_equal event.event_category.team_member_name, event_drop.team_member_name
   end
 
-  describe 'with team members' do
-    let(:team_members) { 5.times.map { create(:team_member, event: event) } }
+  describe "with team members" do
+    let(:team_members) { Array.new(5) { create(:team_member, event: event) } }
 
     before { team_members }
 
-    it 'returns the user con profiles of the team members of the event' do
+    it "returns the user con profiles of the team members of the event" do
       assert_equal team_members.map(&:user_con_profile_id).sort, event_drop.team_member_user_con_profiles.map(&:id).sort
     end
   end
 
-  it 'returns the event path' do
+  it "returns the event path" do
     assert_match %r{events/#{event.id}}, event_drop.url
+  end
+
+  describe "markdown fields" do
+    let(:event) { create(:event, description: "a description", short_blurb: "a blurb") }
+
+    it "only queries image attachments once across multiple markdown fields" do
+      queries =
+        count_queries(/SELECT "active_storage_attachments"/) do
+          event_drop.description
+          event_drop.short_blurb
+        end
+      assert_operator queries, :<=, 1, "expected a constant number of image attachment queries"
+    end
+  end
+
+  private
+
+  def count_queries(pattern)
+    count = 0
+    subscriber =
+      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        count += 1 if pattern.match?(payload[:sql])
+      end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
 end

--- a/test/services/event_signup_service_test.rb
+++ b/test/services/event_signup_service_test.rb
@@ -620,6 +620,14 @@ class EventSignupServiceTest < ActiveSupport::TestCase
       queries = count_queries(/registration_policy_buckets/) { subject.call! }
       assert_operator queries, :<=, 6, "expected a constant number of bucket queries regardless of signup count"
     end
+
+    it "does not issue a user_con_profile query per existing signup" do
+      queries = count_queries(/SELECT "user_con_profiles"/) { subject.call! }
+      assert_operator queries,
+                      :<=,
+                      2,
+                      "expected a constant number of user_con_profile queries regardless of signup count"
+    end
   end
 
   describe "in a moderated-signup convention" do

--- a/test/services/execute_ranked_choice_signup_service_test.rb
+++ b/test/services/execute_ranked_choice_signup_service_test.rb
@@ -79,6 +79,33 @@ describe ExecuteRankedChoiceSignupService do
     assert_equal "waitlisted", signup_ranked_choice.state
   end
 
+  describe "with many existing signups on the run" do
+    let(:event) { create(:event, convention:) }
+    let(:the_run) { create(:run, event:) }
+
+    # Signing up itself (RankedChoiceDecision/log_signup_change!/positioned repositioning, etc.)
+    # issues a small, fixed number of user_con_profile queries regardless of how many other
+    # signups exist on the run -- what this test guards against is that count scaling up with the
+    # number of *other* signups on the run, which is what SignupBucketFinder's FakeSignup building
+    # does if the run's existing signups aren't preloaded with :user_con_profile.
+    def user_con_profile_queries_for(existing_signup_count)
+      the_run.signups.destroy_all
+      existing_signup_count.times do
+        create(:signup, user_con_profile: create(:user_con_profile, convention:), run: the_run)
+      end
+      signup_ranked_choice = create(:signup_ranked_choice, target_run: the_run)
+      count_queries(/SELECT "user_con_profiles"/) do
+        ExecuteRankedChoiceSignupService.new(signup_round:, signup_ranked_choice:, whodunit: nil).call!
+      end
+    end
+
+    it "does not scale the user_con_profile query count with the number of existing signups" do
+      baseline = user_con_profile_queries_for(1)
+      with_many_signups = user_con_profile_queries_for(20)
+      assert_equal baseline, with_many_signups, "expected the same query count regardless of existing signup count"
+    end
+  end
+
   describe "with a waitlist_position_cap" do
     let(:full_event) do
       create(
@@ -375,5 +402,19 @@ describe ExecuteRankedChoiceSignupService do
       assert_equal "confirmed", result.decision.signup.state
       assert_equal "signed_up", signup_ranked_choice.state
     end
+  end
+
+  private
+
+  def count_queries(pattern)
+    count = 0
+    subscriber =
+      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        count += 1 if pattern.match?(payload[:sql])
+      end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
   end
 end


### PR DESCRIPTION
## Summary

While chasing the bucket/registration_policy N+1s, the Sentry sweep also turned up a few other N+1 issues clearly unrelated to that work. This PR fixes the two with real scaling impact:

### 1. `active_storage_attachments` N+1 (INTERCODE-183/188)

`EventDrop`'s `description`/`short_blurb`/`content_warnings`/`age_restrictions`/`participant_communications` methods each independently called `event.images.includes(:blob)` to resolve inline image references in markdown. `.includes` always issues a fresh query regardless of Rails' association cache, so rendering N of these fields on the same event fired N separate queries -- not just one per event as it might look at a glance. Memoized the attachment lookup once per `EventDrop` instance.

### 2. `user_con_profiles` N+1 (INTERCODE-184/185)

`SignupBucketFinder::FakeSignup.from_signup` reads `signup.user_con_profile` for every existing signup on a run when building its comparison set for bucket-finding. `EventChangeRegistrationPolicyService` already preloaded `:user_con_profile` before doing this (from an earlier review pass); `EventSignupService#bucket_finder` and `ExecuteRankedChoiceSignupService#actual_bucket` didn't. Brought both in line with the existing pattern.

## Not fixed here

Also found: `cms_partials` (INTERCODE-182, single occurrence) and `deprecated_graph_ql_usages` insert (INTERCODE-181, not actually an N+1 -- Sentry's detector flagged deprecated-field-usage logging, which is intentional per-operation behavior, not a bug). Neither had enough signal or scaling impact to justify a fix; noting them here for visibility rather than silently dropping them.

## Test plan

- [x] New regression tests for both fixes, each verified to fail without the fix and pass with it:
  - `EventDrop`: 2 queries → 1, across markdown field calls on the same event
  - `ExecuteRankedChoiceSignupService`: query count no longer scales with existing-signup count (was 6→26 for 1→20 existing signups; now flat)
  - `EventSignupService`: 11 queries → 2 for 10 existing signups
- [x] Full `test/liquid_drops/`, `test/services/event_signup_service_test.rb`, `test/services/execute_ranked_choice_signup_service_test.rb` (107 tests)
- [x] rubocop / stree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
