### PR TITLE
DRY up duplicated count_queries test helper

### DIFF
--- a/test/liquid_drops/event_drop_test.rb
+++ b/test/liquid_drops/event_drop_test.rb
@@ -39,18 +39,4 @@ describe EventDrop do
       assert_operator queries, :<=, 1, "expected a constant number of image attachment queries"
     end
   end
-
-  private
-
-  def count_queries(pattern)
-    count = 0
-    subscriber =
-      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-        count += 1 if pattern.match?(payload[:sql])
-      end
-    yield
-    count
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-  end
 end

--- a/test/liquid_drops/user_con_profile_drop_test.rb
+++ b/test/liquid_drops/user_con_profile_drop_test.rb
@@ -75,18 +75,4 @@ describe UserConProfileDrop do
       assert_operator queries, :<=, 2, "expected a constant number of bucket queries regardless of signup count"
     end
   end
-
-  private
-
-  def count_queries(pattern)
-    count = 0
-    subscriber =
-      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-        count += 1 if pattern.match?(payload[:sql])
-      end
-    yield
-    count
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-  end
 end

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -50,18 +50,4 @@ class RunTest < ActiveSupport::TestCase
       assert_operator queries, :<=, 2, "expected a constant number of bucket queries regardless of signup count"
     end
   end
-
-  private
-
-  def count_queries(pattern)
-    count = 0
-    subscriber =
-      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-        count += 1 if pattern.match?(payload[:sql])
-      end
-    yield
-    count
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-  end
 end

--- a/test/presenters/signup_count_presenter_test.rb
+++ b/test/presenters/signup_count_presenter_test.rb
@@ -153,18 +153,4 @@ class SignupCountPresenterTest < ActiveSupport::TestCase
       assert_operator queries, :<=, 2, "expected a constant number of registration_policy/bucket queries"
     end
   end
-
-  private
-
-  def count_queries(pattern)
-    count = 0
-    subscriber =
-      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-        count += 1 if pattern.match?(payload[:sql])
-      end
-    yield
-    count
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-  end
 end

--- a/test/services/event_signup_service_test.rb
+++ b/test/services/event_signup_service_test.rb
@@ -718,16 +718,4 @@ class EventSignupServiceTest < ActiveSupport::TestCase
       }.merge(attributes)
     )
   end
-
-  def count_queries(pattern)
-    count = 0
-    subscriber =
-      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-        count += 1 if pattern.match?(payload[:sql])
-      end
-    yield
-    count
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-  end
 end

--- a/test/services/execute_ranked_choice_signup_service_test.rb
+++ b/test/services/execute_ranked_choice_signup_service_test.rb
@@ -403,18 +403,4 @@ describe ExecuteRankedChoiceSignupService do
       assert_equal "signed_up", signup_ranked_choice.state
     end
   end
-
-  private
-
-  def count_queries(pattern)
-    count = 0
-    subscriber =
-      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-        count += 1 if pattern.match?(payload[:sql])
-      end
-    yield
-    count
-  ensure
-    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -115,6 +115,20 @@ class ActiveSupport::TestCase
     raise GraphqlTestExecutionError, result if result["errors"].present?
     result
   end
+
+  # Counts SQL queries matching pattern issued while running the block, for asserting on N+1s
+  # (e.g. assert_operator count_queries(/registration_policy_buckets/) { subject.call! }, :<=, 1).
+  def count_queries(pattern)
+    count = 0
+    subscriber =
+      ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        count += 1 if pattern.match?(payload[:sql])
+      end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
 end
 
 class ActionController::TestCase


### PR DESCRIPTION
## Summary

The N+1 query regression tests added across the last few PRs (#11880, #11882, #11883) each defined their own private `count_queries(pattern) { ... }` helper -- byte-identical in all six files. Moved it onto `ActiveSupport::TestCase` in `test_helper.rb`, next to the existing `execute_graphql_query` helper that's set up the same way, so every test file gets it for free.

`test/services/event_signup_service_test.rb`'s other private helpers (`bucket_id_for`, `create_other_signup`) are untouched.

## Test plan

- [x] Ran all six affected test files (97 tests) -- unchanged behavior, just less duplication
- [x] rubocop / stree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
