### PR TITLE
Fix N+1 query on event image attachments in FormResponsePresenter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -114,6 +114,7 @@ Metrics/CyclomaticComplexity:
 # Configuration parameters: Max.
 Metrics/ParameterLists:
   Exclude:
+    - 'app/presenters/form_response_presenter.rb'
     - 'app/presenters/signup_count_presenter.rb'
     - 'app/services/create_signup_request_service.rb'
     - 'app/services/event_vacancy_fill_service.rb'

--- a/app/presenters/form_response_presenter.rb
+++ b/app/presenters/form_response_presenter.rb
@@ -92,7 +92,13 @@ class FormResponsePresenter
     @local_images ||=
       case response
       when Event, EventProposal
-        response.images.includes(:blob).index_by { |image| image.filename.to_s }
+        attachments =
+          if dataloader
+            dataloader.with(Sources::ActiveStorageAttachment, response.class, :images).load(response)
+          else
+            response.images.includes(:blob)
+          end
+        attachments.index_by { |image| image.filename.to_s }
       else
         {}
       end

--- a/test/graphql/types/event_type_test.rb
+++ b/test/graphql/types/event_type_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "test_helper"
+
+describe Types::EventType do
+  let(:convention) { create(:convention) }
+  let(:user_con_profile) { create(:user_con_profile, convention:) }
+  let(:event_category) { create(:event_category, convention:) }
+
+  before do
+    section = event_category.event_form.form_sections.create!(title: "Section")
+    section.form_items.create!(
+      item_type: "free_text",
+      identifier: "description",
+      properties: {
+        "lines" => 5,
+        "caption" => "Description",
+        "format" => "markdown"
+      }
+    )
+  end
+
+  it "does not issue an image attachment query per event" do
+    Array.new(5) { create(:event, convention:, event_category:, description: "some *markdown*") }
+
+    query = <<~GRAPHQL
+      query {
+        conventionByRequestHost {
+          events {
+            id
+            form_response_attrs_json_with_rendered_markdown
+          }
+        }
+      }
+    GRAPHQL
+
+    queries = count_queries(/SELECT "active_storage_attachments"/) { execute_graphql_query(query, user_con_profile:) }
+    assert_operator queries, :<=, 1, "expected a constant number of image attachment queries regardless of event count"
+  end
+end


### PR DESCRIPTION
## Summary

After #11883 deployed (fixing the `active_storage_attachments` N+1 in `EventDrop`'s markdown fields), Sentry surfaced a new occurrence of the same query shape (INTERCODE-18B/18D) under `Event.team_members`/`Event.registration_policy`. Same underlying association (`Event#images`), different call site.

## Root cause

`FormResponsePresenter#local_images` (used to resolve inline image references when rendering markdown-formatted form fields like `description`/`short_blurb` via the `formResponseAttrsJsonWithRenderedMarkdown` GraphQL field) already memoizes correctly *within one presenter instance* -- but a fresh presenter gets constructed per `Event` when this field is requested for multiple events in one GraphQL query (e.g. a page listing several events each requesting this field), and each one called `response.images.includes(:blob)` independently with no cross-event batching.

## Fix

`FormResponsePresenter` already receives an optional `dataloader:` (only ever passed by the GraphQL-facing `FormResponseAttrsFields` concern -- Liquid/service callers don't have one). When present, route `local_images` through `Sources::ActiveStorageAttachment` -- the same dataloader source `EventType#images` already uses -- so all events resolving the field in one request get batched into a single preload. Falls back to the direct query when there's no dataloader (Liquid rendering, mutations).

## Also investigated, not fixed

`INTERCODE-18A` (`registration_policy_buckets` by id) is a straggler from *before* the UserConProfileDrop fix deployed (release tag confirms it predates #11882) -- resolving it in Sentry as already fixed, not a new bug.

`INTERCODE-18C` (`cms_partials` N+1, same shape as the earlier `INTERCODE-182`) traces to `Cadmus::PartialFileSystem#read_template_file` (in the third-party `cadmus` gem) doing an uncached `find_by!` on every `{% render "name" %}` Liquid tag. The app already builds a `cached_partials` preload hash for exactly this (`CmsRenderingContext#preload_page_content`), but Cadmus's file system never consults it -- and the cache stores parsed `Liquid::Template` objects while the file-system contract needs raw content strings, so it's not a drop-in fix. Given the low/ambiguous signal (single occurrences, no "repeated N times" breakdown from Sentry -- could just be two different partials on one page) and the blast radius of changing the global Liquid rendering pipeline used by every convention site, deliberately leaving this one alone rather than rushing a fix to a third-party integration point.

## Test plan

- [x] New test (`test/graphql/types/event_type_test.rb`) executing a real GraphQL query for 5 events, verified to fail without the fix (5 queries) and pass with it (1 query)
- [x] Full `test/liquid_drops/`, `test/services/event_signup_service_test.rb`, `test/services/execute_ranked_choice_signup_service_test.rb`, `test/models/run_test.rb`, `test/presenters/signup_count_presenter_test.rb` (98 tests)
- [x] rubocop / stree clean (pre-existing `Metrics/ParameterLists` offense on this file's 7-arg constructor added to `.rubocop_todo.yml`, matching existing entries for other presenters/services with the same debt -- not something this fix should refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
