### PR TITLE
Fix N+1 query on convention/signup_rounds in the My Schedule widget

### DIFF
--- a/app/liquid_drops/user_con_profile_drop.rb
+++ b/app/liquid_drops/user_con_profile_drop.rb
@@ -69,7 +69,10 @@ class UserConProfileDrop < Liquid::Drop
       .includes(
         :bucket,
         :requested_bucket,
-        event: :event_category,
+        event: {
+          event_category: nil,
+          convention: :signup_rounds
+        },
         run: {
           rooms: nil,
           event: {

--- a/test/liquid_drops/user_con_profile_drop_test.rb
+++ b/test/liquid_drops/user_con_profile_drop_test.rb
@@ -74,5 +74,18 @@ describe UserConProfileDrop do
         end
       assert_operator queries, :<=, 2, "expected a constant number of bucket queries regardless of signup count"
     end
+
+    it "does not issue a convention/signup_rounds query per signup" do
+      # Mirrors what {% withdraw_user_signup_button %} does for every signup in the "My Schedule"
+      # widget: signup.event.convention.signup_rounds
+      queries =
+        count_queries(/SELECT "conventions"|SELECT "signup_rounds"/) do
+          user_con_profile_drop.signups.each { |signup| signup.event.convention.signup_rounds.to_a }
+        end
+      assert_operator queries,
+                      :<=,
+                      2,
+                      "expected a constant number of convention/signup_round queries regardless of signup count"
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes INTERCODE-17E, a `conventions` + `signup_rounds` N+1 that was explicitly left open when the `SignupCountPresenter` N+1s were fixed in #11880 -- it was a different, unfixed code path even then.

## Investigation

A scheduled Sentry check-in proposed that this was `ConventionDrop#products`/`#available_products`/`#ticket_types` calling `.convention` on each result without a preload (`product.convention.timezone` in `ProductDrop`/`TicketTypeDrop`). I wrote a test for that hypothesis first, per usual, and **it didn't hold up**: those methods all load via `has_many` associations off the single already-loaded `convention`, so Rails' automatic inverse-of association caching means `.convention` on each result is already free -- with or without an explicit `.includes`. Confirmed this and did not carry that dead-end change forward.

The actual site, found by re-checking the code that `{% withdraw_user_signup_button %}` runs (rendered once per signup in the same "My Schedule" widget already fixed once before for the bucket/requested_bucket N+1 in #11882):

```ruby
signup_rounds = signup.event.convention.signup_rounds
```

`UserConProfileDrop#signups` already preloads `event: :event_category`, but never the event's `convention` -- so each signup's `event` is cached, but `.convention` on it isn't, and `.signup_rounds` on that freshly-loaded (per-signup) `Convention` instance re-queries too. Added `convention: :signup_rounds` to the existing `event:` preload.

## Test plan

- [x] New regression test in `test/liquid_drops/user_con_profile_drop_test.rb`, mirroring exactly what the Liquid tag does (`signup.event.convention.signup_rounds`) -- verified to fail without the fix (10 queries for 5 signups) and pass with it (≤2)
- [x] Full `test/liquid_drops/` suite (41 tests)
- [x] rubocop / stree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
