### PR TITLE
Convert remaining registration policy bucket key dependencies to id

### DIFF
--- a/app/graphql/mutations/create_my_signup.rb
+++ b/app/graphql/mutations/create_my_signup.rb
@@ -58,6 +58,8 @@ class Mutations::CreateMySignup < Mutations::BaseMutation
   private
 
   def requested_bucket_id_from_key(args)
-    run.registration_policy.bucket_with_key(args[:requested_bucket_key])&.id
+    return nil unless args[:requested_bucket_key]
+    normalized_key = RegistrationPolicyBucket.normalize_key(args[:requested_bucket_key])
+    run.registration_policy.buckets.find { |bucket| bucket.key == normalized_key }&.id
   end
 end

--- a/app/graphql/mutations/create_signup_ranked_choice.rb
+++ b/app/graphql/mutations/create_signup_ranked_choice.rb
@@ -28,9 +28,7 @@ class Mutations::CreateSignupRankedChoice < Mutations::BaseMutation
   end
 
   def resolve(**args)
-    requested_bucket_id =
-      args[:requested_bucket_id]&.to_i ||
-        target_run.registration_policy.bucket_with_key(args[:requested_bucket_key])&.id
+    requested_bucket_id = args[:requested_bucket_id]&.to_i || requested_bucket_id_from_key(args)
 
     signup_ranked_choice =
       user_con_profile.signup_ranked_choices.create!(
@@ -42,5 +40,13 @@ class Mutations::CreateSignupRankedChoice < Mutations::BaseMutation
       )
 
     { signup_ranked_choice: }
+  end
+
+  private
+
+  def requested_bucket_id_from_key(args)
+    return nil unless args[:requested_bucket_key]
+    normalized_key = RegistrationPolicyBucket.normalize_key(args[:requested_bucket_key])
+    target_run.registration_policy.buckets.find { |bucket| bucket.key == normalized_key }&.id
   end
 end

--- a/app/graphql/mutations/create_signup_request.rb
+++ b/app/graphql/mutations/create_signup_request.rb
@@ -35,9 +35,7 @@ class Mutations::CreateSignupRequest < Mutations::BaseMutation
 
   def resolve(**args)
     replace_signup = (user_con_profile.signups.find(args[:replace_signup_id]) if args[:replace_signup_id])
-    requested_bucket_id =
-      args[:requested_bucket_id]&.to_i ||
-        target_run.registration_policy.bucket_with_key(args[:requested_bucket_key])&.id
+    requested_bucket_id = args[:requested_bucket_id]&.to_i || requested_bucket_id_from_key(args)
 
     result =
       CreateSignupRequestService.new(
@@ -49,5 +47,13 @@ class Mutations::CreateSignupRequest < Mutations::BaseMutation
       ).call!
 
     { signup_request: result.signup_request }
+  end
+
+  private
+
+  def requested_bucket_id_from_key(args)
+    return nil unless args[:requested_bucket_key]
+    normalized_key = RegistrationPolicyBucket.normalize_key(args[:requested_bucket_key])
+    target_run.registration_policy.buckets.find { |bucket| bucket.key == normalized_key }&.id
   end
 end

--- a/app/graphql/mutations/create_user_signup.rb
+++ b/app/graphql/mutations/create_user_signup.rb
@@ -77,6 +77,8 @@ class Mutations::CreateUserSignup < Mutations::BaseMutation
   private
 
   def requested_bucket_id_from_key(args)
-    run.registration_policy.bucket_with_key(args[:requested_bucket_key])&.id
+    return nil unless args[:requested_bucket_key]
+    normalized_key = RegistrationPolicyBucket.normalize_key(args[:requested_bucket_key])
+    run.registration_policy.buckets.find { |bucket| bucket.key == normalized_key }&.id
   end
 end

--- a/app/graphql/mutations/force_confirm_signup.rb
+++ b/app/graphql/mutations/force_confirm_signup.rb
@@ -28,7 +28,8 @@ class Mutations::ForceConfirmSignup < Mutations::BaseMutation
       if args[:bucket_id]
         signup.run.registration_policy.bucket_with_id(args[:bucket_id].to_i)
       else
-        signup.run.registration_policy.bucket_with_key(args[:bucket_key])
+        normalized_key = RegistrationPolicyBucket.normalize_key(args[:bucket_key])
+        signup.run.registration_policy.buckets.find { |b| b.key == normalized_key }
       end
     raise GraphQL::ExecutionError, "Bad request: bucketId or bucketKey is required" unless bucket
     bucket

--- a/app/graphql/mutations/update_signup_bucket.rb
+++ b/app/graphql/mutations/update_signup_bucket.rb
@@ -33,7 +33,8 @@ class Mutations::UpdateSignupBucket < Mutations::BaseMutation
       if args[:bucket_id]
         signup.run.registration_policy.bucket_with_id(args[:bucket_id].to_i)
       else
-        signup.run.registration_policy.bucket_with_key(args[:bucket_key])
+        normalized_key = RegistrationPolicyBucket.normalize_key(args[:bucket_key])
+        signup.run.registration_policy.buckets.find { |b| b.key == normalized_key }
       end
     raise GraphQL::ExecutionError, "Bad request: bucketId or bucketKey is required" unless bucket
     bucket.id

--- a/app/models/registration_policy.rb
+++ b/app/models/registration_policy.rb
@@ -64,11 +64,6 @@ class RegistrationPolicy < ApplicationRecord
     end
   end
 
-  def bucket_with_key(key)
-    normalized_key = RegistrationPolicyBucket.normalize_key(key)
-    buckets.find { |bucket| bucket.key == normalized_key }
-  end
-
   def bucket_with_id(id)
     buckets.find { |bucket| bucket.id == id }
   end
@@ -176,7 +171,11 @@ class RegistrationPolicy < ApplicationRecord
     return false unless freeze_no_preference_buckets? == other.freeze_no_preference_buckets?
     return false unless buckets.size == other.buckets.size
 
-    buckets.all? { |bucket| bucket.equivalent_to?(other.bucket_with_key(bucket.key)) }
+    # other is typically a detached policy (e.g. from build_from_hash) with no bucket ids yet, so
+    # key is the only identity valid on both sides here -- same structural reason sync_buckets_from_hash!
+    # falls back to key.
+    other_buckets_by_key = other.buckets.index_by(&:key)
+    buckets.all? { |bucket| bucket.equivalent_to?(other_buckets_by_key[bucket.key]) }
   end
 
   private

--- a/app/models/registration_policy_bucket.rb
+++ b/app/models/registration_policy_bucket.rb
@@ -106,17 +106,15 @@ class RegistrationPolicyBucket < ApplicationRecord
 
   # Ported verbatim from the old RegistrationPolicy::Bucket (app/models/registration_policy/bucket.rb)
   #
-  # FakeSignup always compares by key rather than bucket_id: this can be called with a candidate
-  # bucket from a detached, not-yet-persisted RegistrationPolicy (e.g. while simulating a
-  # registration policy change in EventChangeRegistrationPolicyService), which has no id yet, and
-  # FakeSignup has no persisted row of its own to key a preload off of anyway. A real Signup against
-  # a persisted bucket uses bucket_id instead -- see occupies_bucket_as_signup? below.
+  # This can be called with a candidate bucket from a detached, not-yet-persisted RegistrationPolicy
+  # (e.g. while simulating a registration policy change in EventChangeRegistrationPolicyService),
+  # which has no id yet -- see occupies_bucket_as_signup? below for how both cases are handled.
   def signup_definitely_occupies_slot_in_bucket?(signup)
     case signup
     when Signup, SignupBucketFinder::FakeSignup
       occupies_bucket_as_signup?(signup)
     when SignupRequest
-      signup.state == "pending" && signup.requested_bucket_key == key
+      signup.state == "pending" && (id ? signup.requested_bucket_id == id : signup.requested_bucket.equal?(self))
     else
       raise ArgumentError, "RegistrationPolicyBucket doesn't know how to count #{signup.class.name} objects as signups"
     end
@@ -158,14 +156,15 @@ class RegistrationPolicyBucket < ApplicationRecord
 
   private
 
-  # Fast path when signup is a persisted Signup and this bucket is persisted too: bucket_id (a
-  # plain column) can stand in for key without touching the bucket association -- this runs once
-  # per signup on every capacity check (Run#full?, the schedule grid, etc.), so an association read
-  # per call is a real N+1. Falls back to the key comparison for FakeSignup, or for a detached,
-  # not-yet-persisted candidate bucket (id is nil).
+  # Fast path when this bucket is persisted: bucket_id (a plain column, real for a Signup and an
+  # in-memory delegate to the candidate bucket's id for a FakeSignup) avoids touching the bucket
+  # association -- this runs once per signup on every capacity check (Run#full?, the schedule grid,
+  # etc.), so an association read per call on a real Signup is a real N+1. Falls back to object
+  # identity when this bucket is a detached, not-yet-persisted candidate (id is nil): only a
+  # FakeSignup can be "in" such a bucket, by holding a reference to this exact instance.
   def occupies_bucket_as_signup?(signup)
     return false unless signup.occupying_slot? && (not_counted? || signup.counted)
-    return signup.bucket_id == id if signup.is_a?(Signup) && id
-    signup.bucket_key == key
+    return signup.bucket_id == id if id
+    signup.bucket.equal?(self)
   end
 end

--- a/app/models/signup.rb
+++ b/app/models/signup.rb
@@ -83,17 +83,6 @@ class Signup < ApplicationRecord
     requested_bucket_id.nil?
   end
 
-  # Used by SignupBucketFinder and EventChangeRegistrationPolicyService's simulation, which have to
-  # compare against candidate buckets from a detached, not-yet-persisted RegistrationPolicy (no id
-  # yet) -- key is the only identity valid in both the persisted and detached cases.
-  def bucket_key
-    bucket&.key
-  end
-
-  def requested_bucket_key
-    requested_bucket&.key
-  end
-
   def to_liquid
     SignupDrop.new(self)
   end

--- a/app/models/signup_ranked_choice.rb
+++ b/app/models/signup_ranked_choice.rb
@@ -62,13 +62,6 @@ class SignupRankedChoice < ApplicationRecord
     SignupRankedChoiceDrop.new(self)
   end
 
-  # Used by SignupBucketFinder, which has to compare against candidate buckets from a detached,
-  # not-yet-persisted RegistrationPolicy (no id yet) during registration policy change simulation --
-  # key is the only identity valid in both the persisted and detached cases.
-  def requested_bucket_key
-    requested_bucket&.key
-  end
-
   private
 
   def ensure_all_fields_point_at_the_same_convention

--- a/app/models/signup_request.rb
+++ b/app/models/signup_request.rb
@@ -56,13 +56,6 @@ class SignupRequest < ApplicationRecord
     SignupRequestDrop.new(self)
   end
 
-  # Used by SignupBucketFinder, which has to compare against candidate buckets from a detached,
-  # not-yet-persisted RegistrationPolicy (no id yet) during registration policy change simulation --
-  # key is the only identity valid in both the persisted and detached cases.
-  def requested_bucket_key
-    requested_bucket&.key
-  end
-
   private
 
   def ensure_all_fields_point_at_the_same_convention

--- a/app/services/event_change_registration_policy_service.rb
+++ b/app/services/event_change_registration_policy_service.rb
@@ -5,11 +5,13 @@ class EventChangeRegistrationPolicyService < CivilService::Service
   end
   self.result_class = Result
 
-  # Deliberately key-based throughout: registration_policy here is new_registration_policy, a
-  # detached policy built via RegistrationPolicy.build_from_hash that hasn't been persisted yet, so
-  # its candidate buckets have no id (existing keys will get their old, stable id back once
-  # update_from! persists them in place; genuinely new keys get an id for the first time). Key is
-  # the only identity valid on both real signups and these not-yet-persisted candidate buckets.
+  # registration_policy here is new_registration_policy, a detached policy built via
+  # RegistrationPolicy.build_from_hash that hasn't been persisted yet, so its candidate buckets have
+  # no id (existing keys will get their old, stable id back once update_from! persists them in
+  # place; genuinely new keys get an id for the first time). candidate_bucket_for bridges a real
+  # signup's persisted bucket to its candidate counterpart by key, since key is the only identity
+  # valid on both sides pre-persist -- everywhere else in this class works with the resolved bucket
+  # objects (id or object identity, per SignupBucketFinder).
   class SignupSimulator
     attr_reader :registration_policy, :immovable_signups, :new_signups_by_signup_id
     attr_accessor :logger
@@ -26,32 +28,32 @@ class EventChangeRegistrationPolicyService < CivilService::Service
       @new_signups_by_signup_id = {}
     end
 
-    def simulate_signups(signups, requested_key_overrides: {})
+    def simulate_signups(signups, requested_bucket_overrides: {})
       # Signups that are occupying a slot with no bucket can't possibly be affected by a registration
       # policy change; just put them right into the signup list without simulating anything
-      to_keep, to_place = signups.partition { |signup| signup.occupying_slot? && !signup.bucket_key }
+      to_keep, to_place = signups.partition { |signup| signup.occupying_slot? && !signup.bucket }
 
       to_keep.each { |signup| new_signups_by_signup_id[signup.id] = signup }
 
       to_place.each do |signup|
-        override = requested_key_overrides.key?(signup.id) ? requested_key_overrides[signup.id] : NO_OVERRIDE
+        override = requested_bucket_overrides.key?(signup.id) ? requested_bucket_overrides[signup.id] : NO_OVERRIDE
         simulate_signup(signup, override)
       end
     end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
-    def simulate_signup(signup, requested_key_override = NO_OVERRIDE)
-      requested_key = requested_key_override == NO_OVERRIDE ? signup.requested_bucket_key : requested_key_override
+    # rubocop:disable Metrics/MethodLength
+    def simulate_signup(signup, requested_bucket_override = NO_OVERRIDE)
+      requested_bucket = resolve_requested_bucket(signup, requested_bucket_override)
       bucket_finder =
         SignupBucketFinder.new(
           registration_policy,
-          requested_key,
+          requested_bucket,
           new_signups_by_signup_id.values,
           allow_movement: true
         )
 
       # Try to put them in the bucket they're already in if possible
-      current_bucket = (signup.bucket_key ? registration_policy.bucket_with_key(signup.bucket_key) : nil)
+      current_bucket = candidate_bucket_for(signup.bucket)
       destination_bucket =
         (
           if current_bucket && !current_bucket.full?(new_signups_by_signup_id.values)
@@ -71,9 +73,23 @@ class EventChangeRegistrationPolicyService < CivilService::Service
       log_bucket_counts
     end
 
-    # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/MethodLength
 
     private
+
+    def resolve_requested_bucket(signup, requested_bucket_override)
+      return requested_bucket_override unless requested_bucket_override == NO_OVERRIDE
+      candidate_bucket_for(signup.requested_bucket)
+    end
+
+    def candidate_bucket_for(bucket)
+      return nil unless bucket
+      candidate_buckets_by_key[bucket.key]
+    end
+
+    def candidate_buckets_by_key
+      @candidate_buckets_by_key ||= registration_policy.buckets.index_by(&:key)
+    end
 
     def place_signup(signup, bucket_finder, destination_bucket)
       if destination_bucket&.full?(new_signups_by_signup_id.values)
@@ -81,11 +97,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
       end
 
       new_signup = SignupBucketFinder::FakeSignup.from_signup(signup)
-      new_signup.assign_attributes(
-        bucket_key: destination_bucket.key,
-        state: "confirmed",
-        counted: destination_bucket.counted?
-      )
+      new_signup.assign_attributes(bucket: destination_bucket, state: "confirmed", counted: destination_bucket.counted?)
       new_signups_by_signup_id[signup.id] = new_signup
       log_signup_placement(signup, destination_bucket)
     end
@@ -97,7 +109,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
       log "Moving signup for #{movable_signup.user_con_profile.name_without_nickname} to
 #{destination_bucket.key}"
 
-      movable_signup.bucket_key = destination_bucket.key
+      movable_signup.bucket = destination_bucket
       movable_signup
     end
 
@@ -108,18 +120,18 @@ class EventChangeRegistrationPolicyService < CivilService::Service
     def log_immovable_signup(signup)
       return unless logger
       log "Signup for #{signup.user_con_profile.name_without_nickname} \
-(#{signup.requested_bucket_key}) is immovable"
+(#{signup.requested_bucket&.key}) is immovable"
     end
 
     def log_signup_placement(signup, destination_bucket)
       return unless logger
 
-      if destination_bucket.key == signup.bucket_key
+      if destination_bucket.equal?(candidate_bucket_for(signup.bucket))
         log "Signup for #{signup.user_con_profile.name_without_nickname} remains in
 #{destination_bucket.key}"
       else
         log "Signup for #{signup.user_con_profile.name_without_nickname} placed in
-#{destination_bucket.key} (was #{signup.bucket_key})"
+#{destination_bucket.key} (was #{signup.bucket&.key})"
       end
     end
 
@@ -129,7 +141,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
       bucket_counts =
         registration_policy.buckets.map do |bucket|
           signup_count =
-            new_signups_by_signup_id.values.count { |signup| signup.bucket_key == bucket.key && signup.counted? }
+            new_signups_by_signup_id.values.count { |signup| signup.bucket.equal?(bucket) && signup.counted? }
           "#{bucket.key}: #{signup_count}/#{bucket.total_slots}"
         end
       log "Counts: [#{bucket_counts.join(" | ")}]"
@@ -139,17 +151,37 @@ class EventChangeRegistrationPolicyService < CivilService::Service
 
   include SkippableAdvisoryLock
 
-  attr_reader :event, :new_registration_policy, :whodunit, :bucket_key_mappings, :move_results
+  attr_reader :event, :new_registration_policy, :whodunit, :bucket_id_mappings, :move_results
 
   def initialize(event, new_registration_policy, whodunit, bucket_key_mappings = nil)
     @event = event
     @new_registration_policy = new_registration_policy
     @whodunit = whodunit
-    @bucket_key_mappings = (bucket_key_mappings || []).index_by { |mapping| mapping[:from_key] }
+
+    # Resolved once, up front, while event.registration_policy.buckets still reflects the pre-edit
+    # state -- from_key always names a currently-persisted (about-to-be-removed-or-not) bucket, so it
+    # has a real id already. to_key is kept as a string: it may name a bucket that's brand new in
+    # this same edit, which has no id until update_from! persists it further down the line.
+    @bucket_mappings =
+      (bucket_key_mappings || []).filter_map do |mapping|
+        from_bucket = current_buckets_by_key[normalize_key(mapping[:from_key])]
+        next unless from_bucket
+
+        { from_bucket_id: from_bucket.id, from_key: from_bucket.key, to_key: mapping[:to_key] }
+      end
+    @bucket_id_mappings = @bucket_mappings.to_h { |mapping| [mapping[:from_bucket_id], mapping[:to_key]] }
     @move_results = []
   end
 
   private
+
+  def normalize_key(key)
+    RegistrationPolicyBucket.normalize_key(key)
+  end
+
+  def current_buckets_by_key
+    @current_buckets_by_key ||= event.registration_policy.buckets.index_by(&:key)
+  end
 
   def inner_call
     lock_all_runs do
@@ -195,7 +227,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
       simulator = SignupSimulator.new(new_registration_policy)
       simulator.simulate_signups(
         signups_by_run_id[run.id] || [],
-        requested_key_overrides: pending_requested_key_overrides
+        requested_bucket_overrides: pending_requested_bucket_overrides
       )
 
       new_signups_by_signup_id.update(simulator.new_signups_by_signup_id)
@@ -209,7 +241,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
     signups_by_id = all_signups.index_by(&:id)
     new_signups_by_signup_id.each do |signup_id, new_signup|
       signup = signups_by_id[signup_id]
-      new_bucket_id = new_signup.bucket_key ? event.registration_policy.bucket_with_key(new_signup.bucket_key)&.id : nil
+      new_bucket_id = new_signup.bucket ? real_buckets_by_key[new_signup.bucket.key]&.id : nil
       check_for_move signup, new_signup, new_bucket_id
       apply_changes_for_signup signup, new_signup, new_bucket_id
     end
@@ -225,22 +257,33 @@ class EventChangeRegistrationPolicyService < CivilService::Service
     signup.update_columns(state: new_signup.state, bucket_id: new_bucket_id, counted: new_signup.counted)
   end
 
+  # The still-persisted buckets, freshly resolved after update_from! has created/updated them -- the
+  # only point at which a bucket that was brand new in this edit finally has a real id. Bridges the
+  # candidate buckets used throughout simulation (see SignupSimulator#candidate_bucket_for) and the
+  # admin-supplied to_key mappings (see apply_bucket_key_mappings) back to real, persisted rows.
+  def real_buckets_by_key
+    @real_buckets_by_key ||= event.registration_policy.buckets.index_by(&:key)
+  end
+
+  def new_registration_policy_buckets_by_key
+    @new_registration_policy_buckets_by_key ||= new_registration_policy.buckets.index_by(&:key)
+  end
+
   # Signups whose *requested* (not current) bucket is being removed, with an admin-supplied mapping
   # to a surviving or new bucket, need that preference fed into the simulation as an override --
   # their real requested_bucket_id can't be updated yet if the mapping targets a brand new bucket,
   # since that bucket has no id until update_from! persists it below.
-  def pending_requested_key_overrides
-    @pending_requested_key_overrides ||=
+  def pending_requested_bucket_overrides
+    @pending_requested_bucket_overrides ||=
       all_signups.each_with_object({}) do |signup, hash|
         next unless removed_bucket_ids.include?(signup.requested_bucket_id)
+        next unless bucket_id_mappings.key?(signup.requested_bucket_id)
 
-        old_bucket = removed_buckets_by_id[signup.requested_bucket_id]
-        next unless bucket_key_mappings.key?(old_bucket.key)
-
-        # The mapping may point to a surviving/new bucket (to_key present) or explicitly clear the
-        # preference (to_key nil/absent) -- either way, its mere presence here means "don't fall back
-        # to the signup's own requested_bucket_key", which would otherwise leak the removed bucket.
-        hash[signup.id] = bucket_key_mappings[old_bucket.key][:to_key]
+        # The mapping may point to a surviving/new candidate bucket (to_key present) or explicitly
+        # clear the preference (to_key nil/absent) -- either way, its mere presence here means "don't
+        # fall back to the signup's own requested bucket", which would otherwise leak the removed one.
+        to_key = bucket_id_mappings[signup.requested_bucket_id]
+        hash[signup.id] = to_key ? new_registration_policy_buckets_by_key[normalize_key(to_key)] : nil
       end
   end
 
@@ -291,7 +334,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
       to_key = mapped_key_for_removed_bucket(signup.requested_bucket_id)
       next unless to_key
 
-      signup.update_columns(requested_bucket_id: event.registration_policy.bucket_with_key(to_key)&.id)
+      signup.update_columns(requested_bucket_id: real_buckets_by_key[normalize_key(to_key)]&.id)
     end
   end
 
@@ -300,7 +343,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
       to_key = mapped_key_for_removed_bucket(request.requested_bucket_id)
       next unless to_key
 
-      request.update_columns(requested_bucket_id: event.registration_policy.bucket_with_key(to_key)&.id)
+      request.update_columns(requested_bucket_id: real_buckets_by_key[normalize_key(to_key)]&.id)
     end
   end
 
@@ -309,7 +352,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
       to_key = mapped_key_for_removed_bucket(choice.requested_bucket_id)
       next unless to_key
 
-      choice.update_columns(requested_bucket_id: event.registration_policy.bucket_with_key(to_key)&.id)
+      choice.update_columns(requested_bucket_id: real_buckets_by_key[normalize_key(to_key)]&.id)
     end
   end
 
@@ -329,9 +372,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
 
   def mapped_key_for_removed_bucket(bucket_id)
     return nil unless bucket_id && removed_bucket_ids.include?(bucket_id)
-
-    old_bucket = removed_buckets.find { |bucket| bucket.id == bucket_id }
-    bucket_key_mappings[old_bucket.key]&.fetch(:to_key, nil)
+    bucket_id_mappings[bucket_id]
   end
 
   def bucket_key_mapping_errors
@@ -353,7 +394,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
   def invalid_no_preference_mapping_errors
     return errors unless new_registration_policy.prevent_no_preference_signups?
 
-    bucket_key_mappings.each_value do |mapping|
+    @bucket_mappings.each do |mapping|
       next if mapping[:to_key]
 
       errors.add(
@@ -378,7 +419,7 @@ class EventChangeRegistrationPolicyService < CivilService::Service
       ).map(&:requested_bucket_id).uniq
 
     removed_buckets.select do |bucket|
-      referenced_removed_bucket_ids.include?(bucket.id) && !bucket_key_mappings.key?(bucket.key)
+      referenced_removed_bucket_ids.include?(bucket.id) && !bucket_id_mappings.key?(bucket.id)
     end
   end
 

--- a/app/services/event_signup_service.rb
+++ b/app/services/event_signup_service.rb
@@ -188,7 +188,7 @@ class EventSignupService < CivilService::Service
     @bucket_finder ||=
       SignupBucketFinder.new(
         run.registration_policy,
-        requested_bucket&.key,
+        requested_bucket,
         run.signups.includes(:user_con_profile, :bucket, :requested_bucket).to_a
       )
   end

--- a/app/services/execute_ranked_choice_signup_service.rb
+++ b/app/services/execute_ranked_choice_signup_service.rb
@@ -120,7 +120,7 @@ class ExecuteRankedChoiceSignupService < CivilService::Service
         existing_signups =
           run.signups.counted.occupying_slot.includes(:user_con_profile, :bucket, :requested_bucket).to_a
         bucket_finder =
-          SignupBucketFinder.new(run.registration_policy, signup_ranked_choice.requested_bucket_key, existing_signups)
+          SignupBucketFinder.new(run.registration_policy, signup_ranked_choice.requested_bucket, existing_signups)
         if convention.signup_mode == "moderated"
           run
             .signup_requests

--- a/app/services/import_convention_data_service.rb
+++ b/app/services/import_convention_data_service.rb
@@ -414,7 +414,9 @@ class ImportConventionDataService < CivilService::Service
   end
 
   def bucket_id_for(run, bucket_key)
-    run.registration_policy.bucket_with_key(bucket_key)&.id
+    return nil unless bucket_key
+    normalized_key = RegistrationPolicyBucket.normalize_key(bucket_key)
+    run.registration_policy.buckets.find { |bucket| bucket.key == normalized_key }&.id
   end
 
   def import_tickets(convention, event_map, user_con_profile_map)

--- a/app/services/signup_bucket_finder.rb
+++ b/app/services/signup_bucket_finder.rb
@@ -1,25 +1,28 @@
 # frozen_string_literal: true
-# Deliberately key-based rather than bucket_id-based: registration_policy here may be a detached,
-# not-yet-persisted policy (e.g. while EventChangeRegistrationPolicyService is simulating a
-# registration policy change), whose candidate buckets have no id yet. Key is the only identity
-# that's valid for both persisted and detached buckets.
+# registration_policy here may be a detached, not-yet-persisted policy (e.g. while
+# EventChangeRegistrationPolicyService is simulating a registration policy change), whose candidate
+# buckets have no id yet. Bucket comparisons throughout this class go through id when both sides are
+# persisted, and object identity otherwise -- see RegistrationPolicyBucket#occupies_bucket_as_signup?
+# and #same_bucket? below.
 class SignupBucketFinder
   class FakeSignup
     include ActiveModel::Model
 
-    attr_accessor :id, :state, :run, :bucket_key, :requested_bucket_key, :user_con_profile, :counted
+    attr_accessor :id, :state, :run, :bucket, :requested_bucket, :user_con_profile, :counted
 
     def self.from_signup(signup)
       attrs =
-        %i[id state run bucket_key requested_bucket_key user_con_profile counted].index_with do |attr|
-          signup.public_send(attr)
-        end
+        %i[id state run bucket requested_bucket user_con_profile counted].index_with { |attr| signup.public_send(attr) }
 
       new(attrs)
     end
 
     def attributes
-      { id:, state:, run:, bucket_key:, requested_bucket_key:, user_con_profile:, counted: }
+      { id:, state:, run:, bucket:, requested_bucket:, user_con_profile:, counted: }
+    end
+
+    def bucket_id
+      bucket&.id
     end
 
     def occupying_slot?
@@ -27,11 +30,11 @@ class SignupBucketFinder
     end
   end
 
-  attr_reader :registration_policy, :other_signups, :requested_bucket_key, :allow_movement
+  attr_reader :registration_policy, :other_signups, :requested_bucket, :allow_movement
 
-  def initialize(registration_policy, requested_bucket_key, other_signups, allow_movement: true)
+  def initialize(registration_policy, requested_bucket, other_signups, allow_movement: true)
     @registration_policy = registration_policy
-    @requested_bucket_key = requested_bucket_key
+    @requested_bucket = requested_bucket
     @allow_movement = allow_movement
     @original_other_signups_by_id = other_signups.index_by(&:id)
     @other_signups = other_signups.map { |signup| FakeSignup.from_signup(signup) }
@@ -39,7 +42,7 @@ class SignupBucketFinder
 
   def simulate_accepting_signup_request(signup_request)
     accept_finder =
-      SignupBucketFinder.new(registration_policy, signup_request.requested_bucket_key, @other_signups, allow_movement:)
+      SignupBucketFinder.new(registration_policy, signup_request.requested_bucket, @other_signups, allow_movement:)
     actual_bucket = accept_finder.find_bucket
 
     if actual_bucket
@@ -47,7 +50,7 @@ class SignupBucketFinder
         movable_signup = accept_finder.movable_signups_for_bucket(actual_bucket).first
         destination_bucket =
           accept_finder.no_preference_bucket_finder.prioritized_buckets_with_capacity_except(actual_bucket).first
-        movable_signup.bucket_key = destination_bucket.key
+        movable_signup.bucket = destination_bucket
       end
 
       simulate_confirmed_signup(signup_request, actual_bucket)
@@ -60,9 +63,9 @@ class SignupBucketFinder
     @other_signups << FakeSignup.new(
       run: signup_request.target_run,
       state: "confirmed",
-      bucket_key: actual_bucket.key,
+      bucket: actual_bucket,
       user_con_profile: signup_request.user_con_profile,
-      requested_bucket_key: signup_request.requested_bucket_key,
+      requested_bucket: signup_request.requested_bucket,
       counted: actual_bucket.counted?
     )
   end
@@ -71,9 +74,9 @@ class SignupBucketFinder
     @other_signups << FakeSignup.new(
       run: signup_request.target_run,
       state: "waitlisted",
-      bucket_key: nil,
+      bucket: nil,
       user_con_profile: signup_request.user_con_profile,
-      requested_bucket_key: signup_request.requested_bucket_key,
+      requested_bucket: signup_request.requested_bucket,
       counted: false
     )
   end
@@ -90,17 +93,13 @@ class SignupBucketFinder
     return [] unless allow_movement
     return [] unless no_preference_bucket_finder.prioritized_buckets_with_capacity.any?
 
-    fake_signups =
-      other_signups.select do |signup|
-        signup.respond_to?(:bucket_key) && signup.bucket_key == bucket.key &&
-          !(signup.respond_to?(:requested_bucket_key) && signup.requested_bucket_key)
-      end
+    fake_signups = other_signups.select { |signup| same_bucket?(signup.bucket, bucket) && !signup.requested_bucket }
     fake_signups.filter_map { |fake_signup| @original_other_signups_by_id[fake_signup.id] }
   end
 
   def prioritized_buckets
     @prioritized_buckets ||=
-      requested_bucket_key ? prioritized_buckets_with_requested_bucket : prioritized_buckets_without_requested_bucket
+      requested_bucket ? prioritized_buckets_with_requested_bucket : prioritized_buckets_without_requested_bucket
   end
 
   def prioritized_buckets_with_capacity
@@ -108,8 +107,7 @@ class SignupBucketFinder
   end
 
   def prioritized_buckets_with_capacity_except(*buckets)
-    bucket_keys = buckets.map(&:key)
-    prioritized_buckets_with_capacity.reject { |bucket| bucket_keys.include?(bucket.key) }
+    prioritized_buckets_with_capacity.reject { |candidate| buckets.any? { |bucket| same_bucket?(candidate, bucket) } }
   end
 
   def no_preference_bucket_finder
@@ -118,8 +116,12 @@ class SignupBucketFinder
 
   private
 
-  def requested_bucket
-    @requested_bucket ||= registration_policy.bucket_with_key(requested_bucket_key)
+  # Compares by id when both buckets are persisted, object identity otherwise -- mirrors
+  # RegistrationPolicyBucket#occupies_bucket_as_signup?, since a detached candidate bucket has no id
+  # to compare and only object identity can tell it apart from another detached candidate.
+  def same_bucket?(bucket_a, bucket_b)
+    return false if bucket_a.nil? || bucket_b.nil?
+    bucket_a.id && bucket_b.id ? bucket_a.id == bucket_b.id : bucket_a.equal?(bucket_b)
   end
 
   def prioritized_buckets_with_requested_bucket

--- a/test/graphql/mutations/force_confirm_signup_test.rb
+++ b/test/graphql/mutations/force_confirm_signup_test.rb
@@ -21,7 +21,7 @@ class Mutations::ForceConfirmSignupTest < ActiveSupport::TestCase
   GRAPHQL
 
   it "confirms the signup into the given bucket" do
-    dogs_bucket = registration_policy.bucket_with_key("dogs")
+    dogs_bucket = bucket_with_key(registration_policy, "dogs")
 
     execute_graphql_query(
       MUTATION,

--- a/test/graphql/mutations/update_signup_bucket_test.rb
+++ b/test/graphql/mutations/update_signup_bucket_test.rb
@@ -15,7 +15,7 @@ class Mutations::UpdateSignupBucketTest < ActiveSupport::TestCase
   let(:event) { create(:event, convention:, registration_policy:) }
   let(:the_run) { create(:run, event:) }
   let(:admin_user_con_profile) { create(:user_con_profile, convention:, user: create(:site_admin)) }
-  let(:signup) { create(:signup, run: the_run, bucket_id: registration_policy.bucket_with_key("dogs").id) }
+  let(:signup) { create(:signup, run: the_run, bucket_id: bucket_with_key(registration_policy, "dogs").id) }
 
   MUTATION = <<~GRAPHQL
     mutation TestUpdateSignupBucket($id: ID!, $bucketId: ID, $bucketKey: String) {
@@ -26,7 +26,7 @@ class Mutations::UpdateSignupBucketTest < ActiveSupport::TestCase
   GRAPHQL
 
   it "moves the signup into the given bucket" do
-    cats_bucket = registration_policy.bucket_with_key("cats")
+    cats_bucket = bucket_with_key(registration_policy, "cats")
 
     execute_graphql_query(
       MUTATION,
@@ -47,7 +47,7 @@ class Mutations::UpdateSignupBucketTest < ActiveSupport::TestCase
         buckets: [{ key: "foxes", name: "Foxes", slots_limited: true, total_slots: 10 }]
       )
     other_event = create(:event, convention:, registration_policy: other_registration_policy)
-    foreign_bucket_id = other_registration_policy.bucket_with_key("foxes").id
+    foreign_bucket_id = bucket_with_key(other_registration_policy, "foxes").id
     original_bucket_id = signup.bucket_id
 
     error =

--- a/test/liquid_drops/user_con_profile_drop_test.rb
+++ b/test/liquid_drops/user_con_profile_drop_test.rb
@@ -27,7 +27,7 @@ describe UserConProfileDrop do
     let(:runs) { events.map { |event| create(:run, event: event) } }
     let(:confirmed_signups) do
       runs.map do |run|
-        unlimited_bucket_id = run.event.registration_policy.bucket_with_key("unlimited").id
+        unlimited_bucket_id = bucket_with_key(run.event.registration_policy, "unlimited").id
         create(
           :signup,
           user_con_profile: user_con_profile,
@@ -39,7 +39,7 @@ describe UserConProfileDrop do
     end
     let(:withdrawn_signups) do
       runs.map do |run|
-        unlimited_bucket_id = run.event.registration_policy.bucket_with_key("unlimited").id
+        unlimited_bucket_id = bucket_with_key(run.event.registration_policy, "unlimited").id
         create(
           :signup,
           user_con_profile: user_con_profile,

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -81,31 +81,31 @@ class EventTest < ActiveSupport::TestCase
     end
 
     it "includes requested_bucket_key from active signups" do
-      dogs_id = event.registration_policy.bucket_with_key("dogs").id
+      dogs_id = bucket_with_key(event.registration_policy, "dogs").id
       create(:signup, run: the_run, requested_bucket_id: dogs_id, bucket_id: dogs_id)
       assert_includes event.bucket_keys_with_pending_signups_or_requests, "dogs"
     end
 
     it "excludes withdrawn signups" do
-      dogs_id = event.registration_policy.bucket_with_key("dogs").id
+      dogs_id = bucket_with_key(event.registration_policy, "dogs").id
       create(:signup, run: the_run, requested_bucket_id: dogs_id, state: "withdrawn")
       assert_equal [], event.bucket_keys_with_pending_signups_or_requests
     end
 
     it "includes requested_bucket_key from pending signup requests" do
-      cats_id = event.registration_policy.bucket_with_key("cats").id
+      cats_id = bucket_with_key(event.registration_policy, "cats").id
       create(:signup_request, target_run: the_run, requested_bucket_id: cats_id)
       assert_includes event.bucket_keys_with_pending_signups_or_requests, "cats"
     end
 
     it "includes requested_bucket_key from signup ranked choices" do
-      anything_id = event.registration_policy.bucket_with_key("anything").id
+      anything_id = bucket_with_key(event.registration_policy, "anything").id
       create(:signup_ranked_choice, target_run: the_run, requested_bucket_id: anything_id)
       assert_includes event.bucket_keys_with_pending_signups_or_requests, "anything"
     end
 
     it "deduplicates keys across all three sources" do
-      dogs_id = event.registration_policy.bucket_with_key("dogs").id
+      dogs_id = bucket_with_key(event.registration_policy, "dogs").id
       create(:signup, run: the_run, requested_bucket_id: dogs_id, bucket_id: dogs_id)
       create(:signup_request, target_run: the_run, requested_bucket_id: dogs_id)
       assert_equal ["dogs"], event.bucket_keys_with_pending_signups_or_requests

--- a/test/models/registration_policy_bucket_test.rb
+++ b/test/models/registration_policy_bucket_test.rb
@@ -113,41 +113,40 @@ class RegistrationPolicyBucketTest < ActiveSupport::TestCase
   end
 
   describe "#signup_definitely_occupies_slot_in_bucket?" do
-    let(:bucket) { build(:registration_policy_bucket, key: "pcs") }
+    # Persisted (not built) so comparisons below exercise the real, id-based fast path -- see
+    # RegistrationPolicyBucket#occupies_bucket_as_signup?.
+    let(:bucket) { create(:registration_policy_bucket, key: "pcs") }
 
-    it "returns true for a confirmed Signup with a matching bucket_key" do
-      signup = build(:signup, state: "confirmed", bucket: build(:registration_policy_bucket, key: "pcs"), counted: true)
+    it "returns true for a confirmed Signup in this bucket" do
+      signup = build(:signup, state: "confirmed", bucket:, counted: true)
       assert bucket.signup_definitely_occupies_slot_in_bucket?(signup)
     end
 
     it "returns false for a Signup that isn't occupying a slot" do
-      signup = build(:signup, state: "withdrawn", bucket: build(:registration_policy_bucket, key: "pcs"), counted: true)
+      signup = build(:signup, state: "withdrawn", bucket:, counted: true)
       assert_not bucket.signup_definitely_occupies_slot_in_bucket?(signup)
     end
 
     it "excludes an uncounted signup from a counted bucket, but not_counted buckets count everyone" do
-      counted_bucket = build(:registration_policy_bucket, key: "pcs", not_counted: false)
-      not_counted_bucket = build(:registration_policy_bucket, key: "pcs", not_counted: true)
-      counted_signup =
-        build(:signup, state: "confirmed", bucket: build(:registration_policy_bucket, key: "pcs"), counted: true)
-      uncounted_signup =
-        build(:signup, state: "confirmed", bucket: build(:registration_policy_bucket, key: "pcs"), counted: false)
+      counted_signup = build(:signup, state: "confirmed", bucket:, counted: true)
+      uncounted_signup = build(:signup, state: "confirmed", bucket:, counted: false)
 
-      assert counted_bucket.signup_definitely_occupies_slot_in_bucket?(counted_signup)
-      assert_not counted_bucket.signup_definitely_occupies_slot_in_bucket?(uncounted_signup)
-      assert not_counted_bucket.signup_definitely_occupies_slot_in_bucket?(counted_signup)
-      assert not_counted_bucket.signup_definitely_occupies_slot_in_bucket?(uncounted_signup)
+      assert bucket.signup_definitely_occupies_slot_in_bucket?(counted_signup)
+      assert_not bucket.signup_definitely_occupies_slot_in_bucket?(uncounted_signup)
+
+      bucket.not_counted = true
+      assert bucket.signup_definitely_occupies_slot_in_bucket?(counted_signup)
+      assert bucket.signup_definitely_occupies_slot_in_bucket?(uncounted_signup)
     end
 
-    it "returns true for a FakeSignup that occupies a slot with a matching bucket_key" do
-      fake_signup = SignupBucketFinder::FakeSignup.new(state: "confirmed", bucket_key: "pcs", counted: true)
+    it "returns true for a FakeSignup that occupies a slot in this bucket" do
+      fake_signup = SignupBucketFinder::FakeSignup.new(state: "confirmed", bucket:, counted: true)
       assert bucket.signup_definitely_occupies_slot_in_bucket?(fake_signup)
     end
 
-    it "checks state and requested_bucket_key for a SignupRequest" do
-      pcs_bucket = create(:registration_policy_bucket, key: "pcs")
-      pending_request = build(:signup_request, state: "pending", requested_bucket: pcs_bucket)
-      other_state_request = build(:signup_request, state: "withdrawn", requested_bucket: pcs_bucket)
+    it "checks state and requested_bucket for a SignupRequest" do
+      pending_request = build(:signup_request, state: "pending", requested_bucket: bucket)
+      other_state_request = build(:signup_request, state: "withdrawn", requested_bucket: bucket)
 
       assert bucket.signup_definitely_occupies_slot_in_bucket?(pending_request)
       assert_not bucket.signup_definitely_occupies_slot_in_bucket?(other_state_request)

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -35,7 +35,7 @@ class RunTest < ActiveSupport::TestCase
   end
   let(:event) { create(:event, convention:, registration_policy:) }
   let(:the_run) { create(:run, event:) }
-  let(:dogs_bucket_id) { registration_policy.bucket_with_key("dogs").id }
+  let(:dogs_bucket_id) { bucket_with_key(registration_policy, "dogs").id }
 
   describe "capacity checks over many signups" do
     before { 10.times { create(:signup, run: the_run, bucket_id: dogs_bucket_id) } }

--- a/test/notifiers/notifier_preview_factory_test.rb
+++ b/test/notifiers/notifier_preview_factory_test.rb
@@ -8,7 +8,7 @@ class NotifierPreviewFactoryTest < ActiveSupport::TestCase
   end
   let(:event) { create(:event, convention:, registration_policy:) }
   let(:the_run) { create(:run, event:) }
-  let(:signup) { create(:signup, run: the_run, bucket_id: registration_policy.bucket_with_key("dogs").id) }
+  let(:signup) { create(:signup, run: the_run, bucket_id: bucket_with_key(registration_policy, "dogs").id) }
 
   before { signup }
 

--- a/test/presenters/signup_count_presenter_test.rb
+++ b/test/presenters/signup_count_presenter_test.rb
@@ -29,7 +29,7 @@ class SignupCountPresenterTest < ActiveSupport::TestCase
     end
 
     describe "#waitlist_count" do
-      let(:attendees_bucket_id) { registration_policy.bucket_with_key("attendees").id }
+      let(:attendees_bucket_id) { bucket_with_key(registration_policy, "attendees").id }
 
       it "counts waitlisted signups" do
         create(:signup, run: the_run, state: "waitlisted", counted: false, requested_bucket_id: attendees_bucket_id)
@@ -45,7 +45,7 @@ class SignupCountPresenterTest < ActiveSupport::TestCase
     end
 
     describe "#has_waitlist?" do
-      let(:attendees_bucket_id) { registration_policy.bucket_with_key("attendees").id }
+      let(:attendees_bucket_id) { bucket_with_key(registration_policy, "attendees").id }
 
       it "returns true when there are waitlisted signups" do
         create(:signup, run: the_run, state: "waitlisted", counted: false, requested_bucket_id: attendees_bucket_id)
@@ -59,7 +59,7 @@ class SignupCountPresenterTest < ActiveSupport::TestCase
     end
 
     describe "#signups_description" do
-      let(:attendees_bucket_id) { registration_policy.bucket_with_key("attendees").id }
+      let(:attendees_bucket_id) { bucket_with_key(registration_policy, "attendees").id }
 
       it "reports confirmed count" do
         create(:signup, run: the_run)
@@ -95,8 +95,8 @@ class SignupCountPresenterTest < ActiveSupport::TestCase
     let(:event) { create(:event, convention:, registration_policy:) }
     let(:the_run) { create(:run, event:) }
     let(:presenter) { SignupCountPresenter.new(the_run) }
-    let(:dogs_bucket_id) { registration_policy.bucket_with_key("dogs").id }
-    let(:cats_bucket_id) { registration_policy.bucket_with_key("cats").id }
+    let(:dogs_bucket_id) { bucket_with_key(registration_policy, "dogs").id }
+    let(:cats_bucket_id) { bucket_with_key(registration_policy, "cats").id }
 
     describe "#signups_description" do
       it "shows per-bucket confirmed counts" do

--- a/test/presenters/tables/signups_table_results_presenter_test.rb
+++ b/test/presenters/tables/signups_table_results_presenter_test.rb
@@ -14,8 +14,8 @@ class Tables::SignupsTableResultsPresenterTest < ActiveSupport::TestCase
   end
   let(:event) { create(:event, convention:, registration_policy:) }
   let(:the_run) { create(:run, event:) }
-  let(:zebras_bucket) { registration_policy.bucket_with_key("zebras") }
-  let(:aardvarks_bucket) { registration_policy.bucket_with_key("aardvarks") }
+  let(:zebras_bucket) { bucket_with_key(registration_policy, "zebras") }
+  let(:aardvarks_bucket) { bucket_with_key(registration_policy, "aardvarks") }
 
   def presenter_for(filters: {}, sort: [])
     Tables::SignupsTableResultsPresenter.for_run(the_run, site_admin, filters, sort)

--- a/test/services/create_signup_request_service_test.rb
+++ b/test/services/create_signup_request_service_test.rb
@@ -10,7 +10,7 @@ class CreateSignupRequestServiceTest < ActiveSupport::TestCase
   let(:user) { user_con_profile.user }
   let(:ticket_type) { create(:free_ticket_type, convention:) }
   let(:ticket) { create(:ticket, ticket_type:, user_con_profile:) }
-  let(:requested_bucket_id) { event.registration_policy.bucket_with_key("unlimited").id }
+  let(:requested_bucket_id) { bucket_with_key(event.registration_policy, "unlimited").id }
 
   subject do
     CreateSignupRequestService.new(user_con_profile:, target_run: the_run, requested_bucket_id:, whodunit: user)

--- a/test/services/create_team_member_service_test.rb
+++ b/test/services/create_team_member_service_test.rb
@@ -48,7 +48,7 @@ class CreateTeamMemberServiceTest < ActiveSupport::TestCase
         run: the_run,
         user_con_profile: user_con_profile,
         state: "confirmed",
-        bucket_id: event.registration_policy.bucket_with_key("unlimited").id,
+        bucket_id: bucket_with_key(event.registration_policy, "unlimited").id,
         counted: true
       )
     end
@@ -61,7 +61,7 @@ class CreateTeamMemberServiceTest < ActiveSupport::TestCase
 
       assert_equal [signup], result.converted_signups
       assert_not signup.counted?
-      assert_nil signup.bucket_key
+      assert_nil signup.bucket&.key
       assert_equal "confirmed", signup.state
     end
 
@@ -88,7 +88,7 @@ class CreateTeamMemberServiceTest < ActiveSupport::TestCase
             run: the_run,
             user_con_profile: user_con_profile,
             state: "waitlisted",
-            requested_bucket_id: event.registration_policy.bucket_with_key("dogs").id,
+            requested_bucket_id: bucket_with_key(event.registration_policy, "dogs").id,
             counted: false
           )
         end
@@ -99,13 +99,13 @@ class CreateTeamMemberServiceTest < ActiveSupport::TestCase
 
           assert_equal [signup], result.converted_signups
           assert_not signup.counted?
-          assert_nil signup.bucket_key
+          assert_nil signup.bucket&.key
           assert_equal "confirmed", signup.state
         end
       end
 
       describe "blocking someone in the waitlist" do
-        let(:dogs_bucket_id) { event.registration_policy.bucket_with_key("dogs").id }
+        let(:dogs_bucket_id) { bucket_with_key(event.registration_policy, "dogs").id }
         let(:signup) do
           create(
             :signup,
@@ -143,7 +143,7 @@ class CreateTeamMemberServiceTest < ActiveSupport::TestCase
           assert_equal [signup], result.converted_signups
           assert_equal [waitlist_signup], result.move_results.map(&:signup)
           assert waitlist_signup.counted?
-          assert_equal "dogs", waitlist_signup.bucket_key
+          assert_equal "dogs", waitlist_signup.bucket&.key
           assert_equal "confirmed", waitlist_signup.state
         end
       end

--- a/test/services/event_change_registration_policy_service_test.rb
+++ b/test/services/event_change_registration_policy_service_test.rb
@@ -83,8 +83,8 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       create(
         :signup,
         user_con_profile: user_con_profile,
-        requested_bucket_id: event.registration_policy.bucket_with_key("unlimited").id,
-        bucket_id: event.registration_policy.bucket_with_key("unlimited").id,
+        requested_bucket_id: bucket_with_key(event.registration_policy, "unlimited").id,
+        bucket_id: bucket_with_key(event.registration_policy, "unlimited").id,
         run: the_run
       )
     end
@@ -95,7 +95,7 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       # The "unlimited" bucket is being removed by this policy change, so it will be destroyed by
       # the time the service returns; capture its id up front since SignupMoveResult#prev_bucket
       # can no longer resolve a full bucket object for a bucket that no longer exists.
-      unlimited_bucket_id = event.registration_policy.bucket_with_key("unlimited").id
+      unlimited_bucket_id = bucket_with_key(event.registration_policy, "unlimited").id
 
       result = subject.call
 
@@ -108,7 +108,7 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       assert_equal "Signups", result.move_results.first.prev_bucket_name
       assert_equal "confirmed", result.move_results.first.state
       assert_equal "confirmed", result.move_results.first.prev_state
-      assert_equal "anything", signup.reload.bucket_key
+      assert_equal "anything", signup.reload.bucket&.key
     end
 
     it "emails the team members" do
@@ -145,8 +145,8 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       create(
         :signup,
         user_con_profile: user_con_profile1,
-        requested_bucket_id: event.registration_policy.bucket_with_key("dogs").id,
-        bucket_id: event.registration_policy.bucket_with_key("dogs").id,
+        requested_bucket_id: bucket_with_key(event.registration_policy, "dogs").id,
+        bucket_id: bucket_with_key(event.registration_policy, "dogs").id,
         run: the_run
       )
     end
@@ -154,8 +154,8 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       create(
         :signup,
         user_con_profile: user_con_profile2,
-        requested_bucket_id: event.registration_policy.bucket_with_key("dogs").id,
-        bucket_id: event.registration_policy.bucket_with_key("dogs").id,
+        requested_bucket_id: bucket_with_key(event.registration_policy, "dogs").id,
+        bucket_id: bucket_with_key(event.registration_policy, "dogs").id,
         run: the_run
       )
     end
@@ -176,8 +176,8 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       assert_equal "confirmed", result.move_results.first.state
       assert_equal "confirmed", result.move_results.first.prev_state
 
-      assert_equal "dogs", signup1.reload.bucket_key
-      assert_equal "anything", signup2.reload.bucket_key
+      assert_equal "dogs", signup1.reload.bucket&.key
+      assert_equal "anything", signup2.reload.bucket&.key
     end
 
     it "emails the team members" do
@@ -196,7 +196,7 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
           :signup,
           user_con_profile: user_con_profile2,
           requested_bucket_id: nil,
-          bucket_id: event.registration_policy.bucket_with_key("anything").id,
+          bucket_id: bucket_with_key(event.registration_policy, "anything").id,
           run: the_run
         )
       end
@@ -207,7 +207,7 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
           :signup,
           user_con_profile: user_con_profile3,
           requested_bucket_id: nil,
-          bucket_id: event.registration_policy.bucket_with_key("dogs").id,
+          bucket_id: bucket_with_key(event.registration_policy, "dogs").id,
           run: the_run
         )
       end
@@ -229,9 +229,9 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
         assert_equal "confirmed", result.move_results.first.state
         assert_equal "confirmed", result.move_results.first.prev_state
 
-        assert_equal "dogs", signup1.reload.bucket_key
-        assert_equal "anything", signup2.reload.bucket_key
-        assert_equal "cats", signup3.reload.bucket_key
+        assert_equal "dogs", signup1.reload.bucket&.key
+        assert_equal "anything", signup2.reload.bucket&.key
+        assert_equal "cats", signup3.reload.bucket&.key
       end
 
       it "emails the team members" do
@@ -251,8 +251,8 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
         create(
           :signup,
           user_con_profile: user_con_profile3,
-          requested_bucket_id: event.registration_policy.bucket_with_key("dogs").id,
-          bucket_id: event.registration_policy.bucket_with_key("anything").id,
+          requested_bucket_id: bucket_with_key(event.registration_policy, "dogs").id,
+          bucket_id: bucket_with_key(event.registration_policy, "anything").id,
           run: the_run
         )
       end
@@ -271,9 +271,9 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
           /\ASignup for #{user_con_profile3.name_without_nickname} would no longer fit/,
           result.errors.full_messages.join("\n")
         )
-        assert_equal "dogs", signup1.reload.bucket_key
-        assert_equal "dogs", signup2.reload.bucket_key
-        assert_equal "anything", signup3.reload.bucket_key
+        assert_equal "dogs", signup1.reload.bucket&.key
+        assert_equal "dogs", signup2.reload.bucket&.key
+        assert_equal "anything", signup3.reload.bucket&.key
         assert_not event.reload.registration_policy.equivalent_to?(new_registration_policy)
       end
     end
@@ -312,8 +312,8 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       create(
         :signup,
         user_con_profile: user_con_profile,
-        requested_bucket_id: event.registration_policy.bucket_with_key("unlimited").id,
-        bucket_id: event.registration_policy.bucket_with_key("unlimited").id,
+        requested_bucket_id: bucket_with_key(event.registration_policy, "unlimited").id,
+        bucket_id: bucket_with_key(event.registration_policy, "unlimited").id,
         run: the_run
       )
     end
@@ -324,8 +324,8 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       result = subject.call
 
       assert result.success?
-      assert_equal "dogs", signup.reload.bucket_key
-      assert_nil signup.reload.requested_bucket_key
+      assert_equal "dogs", signup.reload.bucket&.key
+      assert_nil signup.reload.requested_bucket&.key
     end
   end
 
@@ -349,8 +349,8 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       create(
         :signup,
         user_con_profile: user_con_profile,
-        requested_bucket_id: event.registration_policy.bucket_with_key("unlimited").id,
-        bucket_id: event.registration_policy.bucket_with_key("unlimited").id,
+        requested_bucket_id: bucket_with_key(event.registration_policy, "unlimited").id,
+        bucket_id: bucket_with_key(event.registration_policy, "unlimited").id,
         run: the_run
       )
     end
@@ -360,7 +360,7 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       create(
         :signup_request,
         user_con_profile: signup_request_user_con_profile,
-        requested_bucket_id: event.registration_policy.bucket_with_key("unlimited").id,
+        requested_bucket_id: bucket_with_key(event.registration_policy, "unlimited").id,
         target_run: the_run
       )
     end
@@ -370,7 +370,7 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       create(
         :signup_ranked_choice,
         user_con_profile: ranked_choice_user_con_profile,
-        requested_bucket_id: event.registration_policy.bucket_with_key("unlimited").id,
+        requested_bucket_id: bucket_with_key(event.registration_policy, "unlimited").id,
         target_run: the_run
       )
     end
@@ -390,9 +390,9 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
           /\ABucket key "unlimited" was removed but no mapping was provided/,
           result.errors.full_messages.join("\n")
         )
-        assert_equal "unlimited", signup.reload.requested_bucket_key
-        assert_equal "unlimited", signup_request.reload.requested_bucket_key
-        assert_equal "unlimited", signup_ranked_choice.reload.requested_bucket_key
+        assert_equal "unlimited", signup.reload.requested_bucket&.key
+        assert_equal "unlimited", signup_request.reload.requested_bucket&.key
+        assert_equal "unlimited", signup_ranked_choice.reload.requested_bucket&.key
       end
     end
 
@@ -409,9 +409,9 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       it "updates requested_bucket_key on affected records to the mapped bucket" do
         subject.call!
 
-        assert_equal "dogs", signup.reload.requested_bucket_key
-        assert_equal "dogs", signup_request.reload.requested_bucket_key
-        assert_equal "dogs", signup_ranked_choice.reload.requested_bucket_key
+        assert_equal "dogs", signup.reload.requested_bucket&.key
+        assert_equal "dogs", signup_request.reload.requested_bucket&.key
+        assert_equal "dogs", signup_ranked_choice.reload.requested_bucket&.key
       end
     end
 
@@ -428,9 +428,9 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       it "sets requested_bucket_key to nil on affected records" do
         subject.call!
 
-        assert_nil signup.reload.requested_bucket_key
-        assert_nil signup_request.reload.requested_bucket_key
-        assert_nil signup_ranked_choice.reload.requested_bucket_key
+        assert_nil signup.reload.requested_bucket&.key
+        assert_nil signup_request.reload.requested_bucket&.key
+        assert_nil signup_ranked_choice.reload.requested_bucket&.key
       end
     end
 
@@ -463,9 +463,9 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
           /\ABucket key "unlimited" cannot be mapped to "no preference"/,
           result.errors.full_messages.join("\n")
         )
-        assert_equal "unlimited", signup.reload.requested_bucket_key
-        assert_equal "unlimited", signup_request.reload.requested_bucket_key
-        assert_equal "unlimited", signup_ranked_choice.reload.requested_bucket_key
+        assert_equal "unlimited", signup.reload.requested_bucket&.key
+        assert_equal "unlimited", signup_request.reload.requested_bucket&.key
+        assert_equal "unlimited", signup_ranked_choice.reload.requested_bucket&.key
       end
     end
   end
@@ -493,8 +493,8 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       create(
         :signup,
         user_con_profile: user_con_profile1,
-        requested_bucket_id: event.registration_policy.bucket_with_key("dogs").id,
-        bucket_id: event.registration_policy.bucket_with_key("anything").id,
+        requested_bucket_id: bucket_with_key(event.registration_policy, "dogs").id,
+        bucket_id: bucket_with_key(event.registration_policy, "anything").id,
         run: the_run
       )
     end
@@ -503,7 +503,7 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
         :signup,
         user_con_profile: user_con_profile2,
         state: "waitlisted",
-        requested_bucket_id: event.registration_policy.bucket_with_key("dogs").id,
+        requested_bucket_id: bucket_with_key(event.registration_policy, "dogs").id,
         bucket_id: nil,
         run: the_run
       )
@@ -518,14 +518,14 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
       result = subject.call
 
       assert result.success?
-      assert_equal "anything", signup1.reload.bucket_key
+      assert_equal "anything", signup1.reload.bucket&.key
     end
 
     it "pulls in waitlisted signups" do
       result = subject.call
 
       assert result.success?
-      assert_equal "dogs", signup2.reload.bucket_key
+      assert_equal "dogs", signup2.reload.bucket&.key
       assert_equal "confirmed", signup2.reload.state
     end
 

--- a/test/services/event_freeze_bucket_assignments_service_test.rb
+++ b/test/services/event_freeze_bucket_assignments_service_test.rb
@@ -26,8 +26,8 @@ class EventFreezeBucketAssignmentsServiceTest < ActiveSupport::TestCase
     create(:signup, user_con_profile:, run: the_run, **attrs)
   end
 
-  let(:dogs_bucket_id) { event.registration_policy.bucket_with_key("dogs").id }
-  let(:anything_bucket_id) { event.registration_policy.bucket_with_key("anything").id }
+  let(:dogs_bucket_id) { bucket_with_key(event.registration_policy, "dogs").id }
+  let(:anything_bucket_id) { bucket_with_key(event.registration_policy, "anything").id }
 
   let(:anything_signup) do
     create_signup(state: "confirmed", bucket_id: anything_bucket_id, requested_bucket_id: dogs_bucket_id)
@@ -51,10 +51,10 @@ class EventFreezeBucketAssignmentsServiceTest < ActiveSupport::TestCase
     anything_signup.reload
 
     assert_equal [anything_signup], result.anything_signups_with_preference
-    assert_equal "dogs", anything_signup.bucket_key
-    assert_equal 2, event.registration_policy.bucket_with_key("dogs").total_slots
-    assert_equal 1, event.registration_policy.bucket_with_key("cats").total_slots
-    assert_equal 0, event.registration_policy.bucket_with_key("anything").total_slots
+    assert_equal "dogs", anything_signup.bucket&.key
+    assert_equal 2, bucket_with_key(event.registration_policy, "dogs").total_slots
+    assert_equal 1, bucket_with_key(event.registration_policy, "cats").total_slots
+    assert_equal 0, bucket_with_key(event.registration_policy, "anything").total_slots
     assert event.registration_policy.freeze_no_preference_buckets?
 
     # Regression guard: this used to reconstruct the whole bucket set via `.dup` (which silently

--- a/test/services/event_signup_service_test.rb
+++ b/test/services/event_signup_service_test.rb
@@ -133,8 +133,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
         assert result.success?
         assert result.signup.confirmed?
         assert_not result.signup.counted?
-        assert_nil result.signup.bucket_key
-        assert_nil result.signup.requested_bucket_key
+        assert_nil result.signup.bucket&.key
+        assert_nil result.signup.requested_bucket&.key
       end
 
       it "does not care whether signups are open yet" do
@@ -329,8 +329,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
         result = subject.call!
         assert result.success?
         assert result.signup.confirmed?
-        assert_equal "cats", result.signup.bucket_key
-        assert_equal "cats", result.signup.requested_bucket_key
+        assert_equal "cats", result.signup.bucket&.key
+        assert_equal "cats", result.signup.requested_bucket&.key
       end
 
       it "will fall back to the anything bucket if necessary" do
@@ -339,8 +339,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
         result = subject.call!
         assert result.success?
         assert result.signup.confirmed?
-        assert_equal "anything", result.signup.bucket_key
-        assert_equal "cats", result.signup.requested_bucket_key
+        assert_equal "anything", result.signup.bucket&.key
+        assert_equal "cats", result.signup.requested_bucket&.key
       end
 
       it "will go to the waitlist if necessary" do
@@ -350,8 +350,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
         result = subject.call
         assert result.success?
         assert result.signup.waitlisted?
-        assert result.signup.bucket_key.nil?
-        assert_equal "cats", result.signup.requested_bucket_key
+        assert result.signup.bucket&.key.nil?
+        assert_equal "cats", result.signup.requested_bucket&.key
       end
 
       it "will go to the waitlist even if the other signups are ticket_purchase_hold" do
@@ -361,8 +361,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
         result = subject.call
         assert result.success?
         assert result.signup.waitlisted?
-        assert result.signup.bucket_key.nil?
-        assert_equal "cats", result.signup.requested_bucket_key
+        assert result.signup.bucket&.key.nil?
+        assert_equal "cats", result.signup.requested_bucket&.key
       end
 
       it "emails only the team members who have requested waitlist emails" do
@@ -423,8 +423,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
           result = subject.call
           assert result.success?
           assert result.signup.confirmed?
-          assert_nil result.signup.requested_bucket_key
-          assert_equal "anything", result.signup.bucket_key
+          assert_nil result.signup.requested_bucket&.key
+          assert_equal "anything", result.signup.bucket&.key
         end
 
         it "puts you into some other bucket if anything is full" do
@@ -433,8 +433,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
           result = subject.call
           assert result.success?
           assert result.signup.confirmed?
-          assert_nil result.signup.requested_bucket_key
-          assert_not_equal "anything", result.signup.bucket_key
+          assert_nil result.signup.requested_bucket&.key
+          assert_not_equal "anything", result.signup.bucket&.key
         end
 
         describe "but the registration policy does not allow it" do
@@ -475,12 +475,12 @@ class EventSignupServiceTest < ActiveSupport::TestCase
           result = subject.call!
           assert result.success?
           assert result.signup.confirmed?
-          assert_equal "cats", result.signup.requested_bucket_key
-          assert_equal "anything", result.signup.bucket_key
+          assert_equal "cats", result.signup.requested_bucket&.key
+          assert_equal "anything", result.signup.bucket&.key
 
           movable_signup.reload
-          assert_equal "cats", movable_signup.bucket_key
-          assert_nil movable_signup.requested_bucket_key
+          assert_equal "cats", movable_signup.bucket&.key
+          assert_nil movable_signup.requested_bucket&.key
         end
 
         it "moves them into a different bucket if the flex bucket is not possible" do
@@ -491,12 +491,12 @@ class EventSignupServiceTest < ActiveSupport::TestCase
           result = subject.call!
           assert result.success?
           assert result.signup.confirmed?
-          assert_equal "cats", result.signup.requested_bucket_key
-          assert_equal "cats", result.signup.bucket_key
+          assert_equal "cats", result.signup.requested_bucket&.key
+          assert_equal "cats", result.signup.bucket&.key
 
           movable_signup.reload
-          assert_equal "dogs", movable_signup.bucket_key
-          assert_nil movable_signup.requested_bucket_key
+          assert_equal "dogs", movable_signup.bucket&.key
+          assert_nil movable_signup.requested_bucket&.key
         end
 
         it "waitlists you if not possible" do
@@ -508,12 +508,12 @@ class EventSignupServiceTest < ActiveSupport::TestCase
           result = subject.call!
           assert result.success?
           assert result.signup.waitlisted?
-          assert_equal "cats", result.signup.requested_bucket_key
-          assert_nil result.signup.bucket_key
+          assert_equal "cats", result.signup.requested_bucket&.key
+          assert_nil result.signup.bucket&.key
 
           movable_signup.reload
-          assert_equal "cats", movable_signup.bucket_key
-          assert_nil movable_signup.requested_bucket_key
+          assert_equal "cats", movable_signup.bucket&.key
+          assert_nil movable_signup.requested_bucket&.key
         end
       end
 
@@ -526,7 +526,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase
 
           assert result.success?
           assert result.signup.confirmed?
-          assert_equal "cats", result.signup.bucket_key
+          assert_equal "cats", result.signup.bucket&.key
         end
 
         it "lets people waitlist" do
@@ -538,8 +538,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
 
           assert result.success?
           assert result.signup.waitlisted?
-          assert_equal "cats", result.signup.requested_bucket_key
-          assert_nil result.signup.bucket_key
+          assert_equal "cats", result.signup.requested_bucket&.key
+          assert_nil result.signup.bucket&.key
         end
       end
     end
@@ -569,8 +569,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
         assert result.success?
         assert result.signup.confirmed?
         assert_not result.signup.counted?
-        assert_equal "npc", result.signup.bucket_key
-        assert_equal "npc", result.signup.requested_bucket_key
+        assert_equal "npc", result.signup.bucket&.key
+        assert_equal "npc", result.signup.requested_bucket&.key
       end
 
       it "will not use anything buckets" do
@@ -578,8 +578,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
         result = subject.call!
         assert result.success?
         assert result.signup.waitlisted?
-        assert_nil result.signup.bucket_key
-        assert_equal "npc", result.signup.requested_bucket_key
+        assert_nil result.signup.bucket&.key
+        assert_equal "npc", result.signup.requested_bucket&.key
       end
 
       it "will still sign the user up if the run is otherwise full" do
@@ -589,8 +589,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
         assert result.success?
         assert result.signup.confirmed?
         assert_not result.signup.counted?
-        assert_equal "npc", result.signup.bucket_key
-        assert_equal "npc", result.signup.requested_bucket_key
+        assert_equal "npc", result.signup.bucket&.key
+        assert_equal "npc", result.signup.requested_bucket&.key
       end
 
       describe "no-preference signups" do
@@ -601,8 +601,8 @@ class EventSignupServiceTest < ActiveSupport::TestCase
           result = subject.call!
           assert result.success?
           assert result.signup.waitlisted?
-          assert_nil result.signup.bucket_key
-          assert_nil result.signup.requested_bucket_key
+          assert_nil result.signup.bucket&.key
+          assert_nil result.signup.requested_bucket&.key
         end
       end
     end
@@ -701,7 +701,7 @@ class EventSignupServiceTest < ActiveSupport::TestCase
   # doesn't match any bucket, so callers can still exercise "invalid bucket requested" behavior.
   def bucket_id_for(run, key)
     return nil if key.nil?
-    run.registration_policy.bucket_with_key(key)&.id || -1
+    bucket_with_key(run.registration_policy, key)&.id || -1
   end
 
   def create_other_signup(bucket_key, **attributes)

--- a/test/services/event_vacancy_fill_service_test.rb
+++ b/test/services/event_vacancy_fill_service_test.rb
@@ -25,7 +25,7 @@ class EventVacancyFillServiceTest < ActiveSupport::TestCase
 
   def bucket_id_for(key)
     return nil if key.nil?
-    event.registration_policy.bucket_with_key(key).id
+    bucket_with_key(event.registration_policy, key).id
   end
 
   def create_signup(bucket_key: nil, requested_bucket_key: nil, **attrs)
@@ -62,7 +62,7 @@ class EventVacancyFillServiceTest < ActiveSupport::TestCase
     assert_equal "confirmed", move_result.prev_state
     assert_equal "anything", move_result.prev_bucket.key
 
-    assert_equal bucket_key, anything_signup.reload.bucket_key
+    assert_equal bucket_key, anything_signup.reload.bucket&.key
   end
 
   it "moves a waitlist signup into the vacancy" do
@@ -77,7 +77,7 @@ class EventVacancyFillServiceTest < ActiveSupport::TestCase
     assert_equal "waitlisted", move_result.prev_state
     assert_nil move_result.prev_bucket
 
-    assert_equal bucket_key, waitlist_signup.reload.bucket_key
+    assert_equal bucket_key, waitlist_signup.reload.bucket&.key
   end
 
   it "moves a no-preference signup out of the way in order to fill a vacancy" do
@@ -99,11 +99,11 @@ class EventVacancyFillServiceTest < ActiveSupport::TestCase
     assert_equal "waitlisted", waitlist_move_result.prev_state
     assert_nil waitlist_move_result.prev_bucket
 
-    assert_equal "dogs", waitlist_signup.reload.bucket_key
-    assert_equal "cats", no_pref_signup.reload.bucket_key
+    assert_equal "dogs", waitlist_signup.reload.bucket&.key
+    assert_equal "cats", no_pref_signup.reload.bucket&.key
 
     # shouldn't have moved the signup that's already in flex
-    assert_equal "anything", anything_signup.reload.bucket_key
+    assert_equal "anything", anything_signup.reload.bucket&.key
   end
 
   it "does not move no-preference signups if the registration policy does not allow it" do
@@ -133,7 +133,7 @@ class EventVacancyFillServiceTest < ActiveSupport::TestCase
     assert_equal "waitlisted", waitlist_move_result.prev_state
     assert_nil waitlist_move_result.prev_bucket
 
-    assert_equal "dogs", waitlist_no_pref_signup.reload.bucket_key
+    assert_equal "dogs", waitlist_no_pref_signup.reload.bucket&.key
   end
 
   it "handles waitlisted signups in strictly chronological order, regardless of no-pref status" do
@@ -152,7 +152,7 @@ class EventVacancyFillServiceTest < ActiveSupport::TestCase
     assert_equal "confirmed", waitlist_no_pref_move_result.state
     assert_equal "anything", waitlist_no_pref_move_result.bucket.key
 
-    assert_equal "anything", waitlist_no_pref_signup.reload.bucket_key
+    assert_equal "anything", waitlist_no_pref_signup.reload.bucket&.key
   end
 
   it "breaks ties correctly in sub-second differences" do
@@ -191,7 +191,7 @@ class EventVacancyFillServiceTest < ActiveSupport::TestCase
     assert_equal "confirmed", move_result.state
     assert_equal "anything", move_result.bucket.key
 
-    assert_equal "anything", waitlist_signup.reload.bucket_key
+    assert_equal "anything", waitlist_signup.reload.bucket&.key
   end
 
   it "does not move confirmed signups if not necessary" do
@@ -208,8 +208,8 @@ class EventVacancyFillServiceTest < ActiveSupport::TestCase
     assert_equal "waitlisted", waitlist_move_result.prev_state
     assert waitlist_move_result.prev_bucket.nil?
 
-    assert_equal "anything", anything_signup.reload.bucket_key
-    assert_equal bucket_key, waitlist_signup.reload.bucket_key
+    assert_equal "anything", anything_signup.reload.bucket&.key
+    assert_equal bucket_key, waitlist_signup.reload.bucket&.key
   end
 
   it "notifies moved users who were waitlisted" do
@@ -278,7 +278,7 @@ class EventVacancyFillServiceTest < ActiveSupport::TestCase
         assert_equal "waitlisted", move_result.prev_state
         assert_nil move_result.prev_bucket
 
-        assert_equal bucket_key, waitlist_signup.reload.bucket_key
+        assert_equal bucket_key, waitlist_signup.reload.bucket&.key
       end
 
       it "will not fill in drops with no-preference signups" do
@@ -338,9 +338,9 @@ class EventVacancyFillServiceTest < ActiveSupport::TestCase
           assert_equal 2, result.move_results.size
           assert_equal green_confirmed.reload, result.move_results[0].signup
           assert_equal green_waitlist.reload, result.move_results[1].signup
-          assert_equal "blue", green_confirmed.bucket_key
+          assert_equal "blue", green_confirmed.bucket&.key
           assert_equal "confirmed", green_waitlist.state
-          assert_equal "green", green_waitlist.bucket_key
+          assert_equal "green", green_waitlist.bucket&.key
           assert_equal "waitlisted", no_pref_waitlist.state
         end
       end

--- a/test/services/event_withdraw_service_test.rb
+++ b/test/services/event_withdraw_service_test.rb
@@ -10,7 +10,7 @@ class EventWithdrawServiceTest < ActiveSupport::TestCase
   let(:user) { user_con_profile.user }
   let(:bucket_key) { "unlimited" }
   let(:signup_state) { "confirmed" }
-  let(:bucket_id) { event.registration_policy.bucket_with_key(bucket_key).id }
+  let(:bucket_id) { bucket_with_key(event.registration_policy, bucket_key).id }
   let(:signup) do
     create(:signup, user_con_profile:, run: the_run, state: signup_state, bucket_id:, requested_bucket_id: bucket_id)
   end
@@ -92,7 +92,7 @@ class EventWithdrawServiceTest < ActiveSupport::TestCase
         user_con_profile: anything_user_con_profile,
         run: the_run,
         state: "confirmed",
-        bucket_id: event.registration_policy.bucket_with_key("anything").id,
+        bucket_id: bucket_with_key(event.registration_policy, "anything").id,
         requested_bucket_id: bucket_id
       )
     end
@@ -117,7 +117,7 @@ class EventWithdrawServiceTest < ActiveSupport::TestCase
 
       assert_equal 1, result.move_results.size
 
-      assert_equal bucket_key, anything_signup.reload.bucket_key
+      assert_equal bucket_key, anything_signup.reload.bucket&.key
     end
 
     it "moves a waitlist signup into the vacancy" do
@@ -129,7 +129,7 @@ class EventWithdrawServiceTest < ActiveSupport::TestCase
 
       assert_equal 1, result.move_results.size
 
-      assert_equal bucket_key, waitlist_signup.reload.bucket_key
+      assert_equal bucket_key, waitlist_signup.reload.bucket&.key
     end
 
     it "does not try to fill an overfilled bucket" do
@@ -142,8 +142,8 @@ class EventWithdrawServiceTest < ActiveSupport::TestCase
 
       assert_equal 0, result.move_results.size
 
-      assert_nil waitlist_signup.reload.bucket_key
-      assert_equal bucket_key, extra_signup.reload.bucket_key
+      assert_nil waitlist_signup.reload.bucket&.key
+      assert_equal bucket_key, extra_signup.reload.bucket&.key
     end
 
     it "does not move confirmed signups unless necessary" do
@@ -156,8 +156,8 @@ class EventWithdrawServiceTest < ActiveSupport::TestCase
 
       assert_equal 1, result.move_results.size
 
-      assert_equal "anything", anything_signup.reload.bucket_key
-      assert_equal bucket_key, waitlist_signup.reload.bucket_key
+      assert_equal "anything", anything_signup.reload.bucket&.key
+      assert_equal bucket_key, waitlist_signup.reload.bucket&.key
     end
 
     it "notifies team members who have requested it" do

--- a/test/services/import_convention_data_service_test.rb
+++ b/test/services/import_convention_data_service_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 require "base64"
 
-# rubocop:disable Metrics/ClassLength, Metrics/BlockLength
 class ImportConventionDataServiceTest < ActiveSupport::TestCase
   # Minimal valid export with no external dependencies (no CMS content set, no event categories)
   let(:base_data) do
@@ -495,7 +494,7 @@ class ImportConventionDataServiceTest < ActiveSupport::TestCase
     it "creates the registration policy with buckets" do
       convention = Convention.find_by!(domain: "importtest.example.com")
       event = convention.events.find_by!(title: "A Great LARP")
-      bucket = event.registration_policy.bucket_with_key("players")
+      bucket = bucket_with_key(event.registration_policy, "players")
       assert bucket
       assert_equal 10, bucket.total_slots
       assert bucket.slots_limited?
@@ -621,7 +620,7 @@ class ImportConventionDataServiceTest < ActiveSupport::TestCase
       convention = Convention.find_by!(domain: "importtest.example.com")
       event = convention.events.find_by!(title: "Signup Test LARP")
       signup = event.runs.first.signups.first
-      assert_equal "players", signup.bucket_key
+      assert_equal "players", signup.bucket&.key
       assert signup.counted
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -116,6 +116,14 @@ class ActiveSupport::TestCase
     result
   end
 
+  # Test-only convenience: production code identifies buckets by id (or, during registration policy
+  # simulation, object identity), not key -- see #11892. Tests still often only know a bucket by the
+  # key its factory/fixture was created with.
+  def bucket_with_key(registration_policy, key)
+    normalized_key = RegistrationPolicyBucket.normalize_key(key)
+    registration_policy.buckets.find { |bucket| bucket.key == normalized_key }
+  end
+
   # Counts SQL queries matching pattern issued while running the block, for asserting on N+1s
   # (e.g. assert_operator count_queries(/registration_policy_buckets/) { subject.call! }, :<=, 1).
   def count_queries(pattern)


### PR DESCRIPTION
Fixes #11892

## Summary

Follow-up to #11870/#11891, which handled bucket key/id correlation only for editing an existing registration policy. This converts the remaining internal identity uses of `RegistrationPolicyBucket#key` — in `SignupBucketFinder`, `RegistrationPolicyBucket`'s occupancy checks, and `EventChangeRegistrationPolicyService`'s simulation/removed-bucket logic — to use `id` for persisted buckets, or object identity for not-yet-persisted candidate buckets during registration policy simulation (a bucket being added in the same edit has no real id until the edit is persisted, so key is the only identity that predates the object entirely disappearing — object identity replaces it everywhere it's actually needed).

- `RegistrationPolicyBucket#occupies_bucket_as_signup?`/`#signup_definitely_occupies_slot_in_bucket?`: single id-or-object-identity comparison, key-based fallback removed.
- `SignupBucketFinder`/`FakeSignup`: track bucket **objects** (`bucket`/`requested_bucket`) instead of key strings.
- `EventChangeRegistrationPolicyService`: `bucket_key_mappings` resolves to id (`bucket_id_mappings`) up front instead of round-tripping through a removed bucket's key at every use site; the simulation bridges a real signup's persisted bucket to its detached candidate counterpart via one clearly-commented key lookup (structurally required — see comments), instead of using key everywhere.
- Removed `RegistrationPolicy#bucket_with_key` and the `bucket_key`/`requested_bucket_key` readers on `Signup`/`SignupRequest`/`SignupRankedChoice`, since `SignupBucketFinder` was meant to be their only caller. Turned out there were a handful of other legitimate callers (deprecated GraphQL `bucketKey`/`requestedBucketKey` mutation arguments, and `import_convention_data_service.rb`) — those got an inlined equivalent lookup rather than resurrecting the shared method.
- `sync_buckets_from_hash!`'s key-based fallback (from #11870) is untouched, as planned — dropping the `key` column is tracked separately.

## No GraphQL/frontend changes

`update_event`'s `bucket_key_mappings` argument, `BucketKeyMappingInputType`, and the frontend bucket remapping UI are unchanged. The registration policy editor never has real bucket ids for candidate buckets (confirmed via `RegistrationPolicy#as_json`/`RegistrationPolicyBucket#as_json`, which deliberately omit `id`), so `to_key` must stay key-based — it can name a bucket being created in the very same edit.

## Test plan

- [x] `bin/rubocop` clean on all changed files
- [x] Full affected model/service/graphql test suites pass (274 tests, 0 failures)
- [x] Reviewed diff manually for the trickier identity-comparison edge cases (detached candidate buckets, FakeSignup wiring, `RegistrationPolicyBucketTest#signup_definitely_occupies_slot_in_bucket?`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)