### PR TITLE
Migrate registration policy editor's internal bucket identity from key to generatedId

### DIFF
--- a/app/javascript/FormAdmin/ItemEditors/RegistrationPolicyItemEditorPresetModal.tsx
+++ b/app/javascript/FormAdmin/ItemEditors/RegistrationPolicyItemEditorPresetModal.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Modal } from 'react-bootstrap4-modal';
 
 import RegistrationPolicyEditor from '../../RegistrationPolicy/RegistrationPolicyEditor';
+import { withGeneratedBucketIds, withoutGeneratedBucketIds } from '../../RegistrationPolicy/RegistrationPolicy';
 import { RegistrationPolicyPreset } from '../FormItemUtils';
 
 export type RegistrationPolicyItemEditorPresetModalProps = {
@@ -18,19 +19,25 @@ function RegistrationPolicyItemEditorPresetModal({
   visible,
   close,
 }: RegistrationPolicyItemEditorPresetModalProps): React.JSX.Element {
-  const [preset, setPreset] = useState(initialPreset);
+  // generatedId is the editor's own client-only bookkeeping mechanism and must never be
+  // persisted as part of the preset, so it's assigned here (once, on open) and stripped again
+  // in saveClicked.
+  const [preset, setPreset] = useState(() => ({
+    ...initialPreset,
+    policy: withGeneratedBucketIds(initialPreset.policy),
+  }));
 
-  const policyChanged = (policy: RegistrationPolicyPreset['policy']) => {
+  const policyChanged = (policy: typeof preset.policy) => {
     setPreset((prevPreset) => ({ ...prevPreset, policy }));
   };
 
   const cancelClicked = () => {
-    setPreset(initialPreset);
+    setPreset({ ...initialPreset, policy: withGeneratedBucketIds(initialPreset.policy) });
     close();
   };
 
   const saveClicked = () => {
-    onChange(preset);
+    onChange({ ...preset, policy: withoutGeneratedBucketIds(preset.policy) });
     close();
   };
 

--- a/app/javascript/FormPresenter/ItemInputs/RegistrationPolicyItemInput.tsx
+++ b/app/javascript/FormPresenter/ItemInputs/RegistrationPolicyItemInput.tsx
@@ -1,12 +1,20 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import RegistrationPolicyEditor from '../../RegistrationPolicy/RegistrationPolicyEditor';
+import { withGeneratedBucketIds, withoutGeneratedBucketIds } from '../../RegistrationPolicy/RegistrationPolicy';
 import { CommonFormItemInputProps } from './CommonFormItemInputProps';
 import { RegistrationPolicyFormItem } from '../../FormAdmin/FormItemUtils';
 import { RegistrationPolicy } from '../../graphqlTypes.generated';
 import { VisibilityDisclosureCard } from './PermissionDisclosures';
 
 export type RegistrationPolicyItemInputProps = CommonFormItemInputProps<RegistrationPolicyFormItem>;
+
+const EMPTY_REGISTRATION_POLICY: RegistrationPolicy = {
+  __typename: 'RegistrationPolicy',
+  buckets: [],
+  freeze_no_preference_buckets: false,
+  prevent_no_preference_signups: false,
+};
 
 function RegistrationPolicyItemInput({
   formItem,
@@ -26,9 +34,17 @@ function RegistrationPolicyItemInput({
 
   const effectiveValue = !value || value.buckets.length === 0 ? defaultValue : value;
 
-  const valueChanged = (newValue: RegistrationPolicy) => {
+  // generatedId is the editor's own client-only bookkeeping mechanism and must never leak into
+  // the form response sent to the server, so it's assigned here (once, on first load) and
+  // stripped again in valueChanged before the value is handed back up.
+  const [editingPolicy, setEditingPolicy] = useState(() =>
+    withGeneratedBucketIds(effectiveValue ?? EMPTY_REGISTRATION_POLICY),
+  );
+
+  const valueChanged = (newValue: typeof editingPolicy) => {
     onInteract(formItem.identifier);
-    onChange(newValue);
+    setEditingPolicy(newValue);
+    onChange(withoutGeneratedBucketIds(newValue));
   };
 
   return (
@@ -41,7 +57,7 @@ function RegistrationPolicyItemInput({
           })}
         >
           <RegistrationPolicyEditor
-            registrationPolicy={effectiveValue ?? undefined}
+            registrationPolicy={editingPolicy}
             onChange={valueChanged}
             presets={formItem.rendered_properties.presets}
             allowCustom={formItem.rendered_properties.allow_custom}

--- a/app/javascript/RegistrationPolicy/RegistrationBucketRow.tsx
+++ b/app/javascript/RegistrationPolicy/RegistrationBucketRow.tsx
@@ -30,17 +30,21 @@ export type EditingRegistrationBucket = Pick<
   // loaded from the server. Threaded through so RegistrationPolicy#sync_buckets_from_hash! can
   // correlate edited buckets by id instead of falling back to key.
   id?: RegistrationPolicyBucket['id'];
+  // Client-only identity for the editor's own bookkeeping (React keys, change/delete handlers).
+  // Assigned to every bucket the moment it enters the editor's state, regardless of whether it
+  // has a real id yet; never sent to the server.
+  generatedId: string;
 };
 
 export type RegistrationBucketRowProps<T extends EditingRegistrationBucket> = {
   registrationBucket: T;
-  onChange: (key: string, bucket: T) => void;
+  onChange: (generatedId: string, bucket: T) => void;
   lockLimited?: boolean;
   lockCounts?: boolean;
   lockNameAndDescription?: boolean;
   lockDelete?: boolean;
   validateComplete?: boolean;
-  onDelete: (key: string) => void;
+  onDelete: (generatedId: string) => void;
 };
 
 function RegistrationBucketRow<T extends EditingRegistrationBucket>({
@@ -54,8 +58,8 @@ function RegistrationBucketRow<T extends EditingRegistrationBucket>({
   onDelete,
 }: RegistrationBucketRowProps<T>): React.JSX.Element {
   const updateBucket = useCallback(
-    (newValue: T) => onChange(registrationBucket.key, newValue),
-    [registrationBucket.key, onChange],
+    (newValue: T) => onChange(registrationBucket.generatedId, newValue),
+    [registrationBucket.generatedId, onChange],
   );
   const setBucket = useFunctionalStateUpdater(registrationBucket, updateBucket);
   const [
@@ -268,7 +272,7 @@ function RegistrationBucketRow<T extends EditingRegistrationBucket>({
           onClick={() =>
             confirm({
               prompt: 'Are you sure you wish to delete this registration bucket?',
-              action: () => onDelete(registrationBucket.key),
+              action: () => onDelete(registrationBucket.generatedId),
             })
           }
         >

--- a/app/javascript/RegistrationPolicy/RegistrationPolicy.ts
+++ b/app/javascript/RegistrationPolicy/RegistrationPolicy.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid';
 import { RegistrationPolicy, RegistrationPolicyBucket } from '../graphqlTypes.generated';
 
 export type BucketForRegistrationPolicyUtils = Pick<
@@ -15,6 +16,8 @@ export type BucketForRegistrationPolicyUtils = Pick<
 > & {
   // Absent for a bucket added in the current edit session; see EditingRegistrationBucket.
   id?: RegistrationPolicyBucket['id'];
+  // Only present for buckets belonging to an in-progress edit session; see EditingRegistrationBucket.
+  generatedId?: string;
 };
 
 export type RegistrationPolicyForRegistrationPolicyUtils = Pick<RegistrationPolicy, 'prevent_no_preference_signups'> & {
@@ -48,49 +51,49 @@ export function getRegistrationPolicySlotsLimited(
 
 export function getRegistrationPolicyBucket(
   registrationPolicy: RegistrationPolicyForRegistrationPolicyUtils,
-  key: string,
+  generatedId: string,
 ): BucketForRegistrationPolicyUtils | undefined {
-  return (registrationPolicy.buckets ?? []).find((bucket) => bucket.key === key);
+  return (registrationPolicy.buckets ?? []).find((bucket) => bucket.generatedId === generatedId);
 }
 
 export function addRegistrationPolicyBucket<T extends RegistrationPolicyForRegistrationPolicyUtils>(
   registrationPolicy: T,
-  key: string,
-  bucket: Omit<T['buckets'][0], 'key'>,
+  generatedId: string,
+  bucket: Omit<T['buckets'][0], 'generatedId'>,
 ): T {
-  if (getRegistrationPolicyBucket(registrationPolicy, key)) {
-    throw new Error(`Bucket with key ${key} already exists in registration policy`);
+  if (getRegistrationPolicyBucket(registrationPolicy, generatedId)) {
+    throw new Error(`Bucket with generatedId ${generatedId} already exists in registration policy`);
   }
 
   return {
     ...registrationPolicy,
-    buckets: [...(registrationPolicy.buckets ?? []), { key, ...bucket }],
+    buckets: [...(registrationPolicy.buckets ?? []), { generatedId, ...bucket }],
   };
 }
 
 export function removeRegistrationPolicyBucket<T extends RegistrationPolicyForRegistrationPolicyUtils>(
   registrationPolicy: T,
-  key: string,
+  generatedId: string,
 ): T {
   return {
     ...registrationPolicy,
-    buckets: (registrationPolicy.buckets ?? []).filter((bucket) => bucket.key !== key),
+    buckets: (registrationPolicy.buckets ?? []).filter((bucket) => bucket.generatedId !== generatedId),
   };
 }
 
 export function updateRegistrationPolicyBucket<T extends RegistrationPolicyForRegistrationPolicyUtils>(
   registrationPolicy: T,
-  key: string,
-  newBucket: Omit<T['buckets'][0], 'key'>,
+  generatedId: string,
+  newBucket: Omit<T['buckets'][0], 'generatedId'>,
 ): T {
-  const index = (registrationPolicy.buckets ?? []).findIndex((bucket) => bucket.key === key);
+  const index = (registrationPolicy.buckets ?? []).findIndex((bucket) => bucket.generatedId === generatedId);
 
   if (index === -1) {
-    return addRegistrationPolicyBucket(registrationPolicy, key, newBucket);
+    return addRegistrationPolicyBucket(registrationPolicy, generatedId, newBucket);
   }
 
   const newBuckets = [...(registrationPolicy.buckets ?? [])];
-  newBuckets.splice(index, 1, { key, ...newBucket });
+  newBuckets.splice(index, 1, { generatedId, ...newBucket });
 
   return {
     ...registrationPolicy,
@@ -102,4 +105,35 @@ export function getRegistrationPolicyAnythingBucket<T extends RegistrationPolicy
   registrationPolicy: T,
 ): BucketForRegistrationPolicyUtils | undefined {
   return (registrationPolicy.buckets ?? []).find((bucket) => bucket.anything);
+}
+
+export type RegistrationPolicyBucketWithGeneratedId = RegistrationPolicyBucket & { generatedId: string };
+export type RegistrationPolicyWithGeneratedBucketIds = Omit<RegistrationPolicy, 'buckets'> & {
+  buckets: RegistrationPolicyBucketWithGeneratedId[];
+};
+
+// Tags every bucket entering an editing session with a stable, client-only generatedId, so the
+// editor never has to rely on key (which won't always be present) or id (which new buckets don't
+// have yet) for its own bookkeeping.
+export function withGeneratedBucketIds(
+  registrationPolicy: RegistrationPolicy,
+): RegistrationPolicyWithGeneratedBucketIds {
+  return {
+    ...registrationPolicy,
+    buckets: registrationPolicy.buckets.map((bucket) => ({
+      ...bucket,
+      generatedId: (bucket as RegistrationPolicyBucketWithGeneratedId).generatedId ?? uuidv4(),
+    })),
+  };
+}
+
+// The inverse of withGeneratedBucketIds -- generatedId must never be sent to the server, so this
+// is applied before a registration policy leaves the editor for good.
+export function withoutGeneratedBucketIds(
+  registrationPolicy: RegistrationPolicyWithGeneratedBucketIds,
+): RegistrationPolicy {
+  return {
+    ...registrationPolicy,
+    buckets: registrationPolicy.buckets.map(({ generatedId, ...bucket }) => bucket),
+  };
 }

--- a/app/javascript/RegistrationPolicy/RegistrationPolicyEditor.tsx
+++ b/app/javascript/RegistrationPolicy/RegistrationPolicyEditor.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import * as React from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 import { bucketSortCompare, findPreset } from './RegistrationPolicyUtils';
 import RegistrationBucketRow, { EditingRegistrationBucket } from './RegistrationBucketRow';
@@ -70,40 +71,35 @@ function RegistrationPolicyEditor<
   const addBucketClicked = (event: React.MouseEvent) => {
     event.preventDefault();
 
-    const customBucketKeyNumbers = (registrationPolicy.buckets || [])
-      .map((bucket) => bucket.key)
-      .filter((key) => key.match(/^custom_\d+$/))
-      .map((key) => Number.parseInt(key.replace('custom_', ''), 10));
-
-    const maxBucketKeyNumber = customBucketKeyNumbers.length > 0 ? Math.max(...customBucketKeyNumbers) : 0;
-
-    const customBucketNumber = maxBucketKeyNumber + 1;
+    const customBucketNumber = (registrationPolicy.buckets || []).length + 1;
 
     onChange(
-      addRegistrationPolicyBucket(registrationPolicy, `custom_${customBucketNumber}`, {
+      addRegistrationPolicyBucket(registrationPolicy, uuidv4(), {
+        key: `custom_${customBucketNumber}`,
         name: `Custom ${customBucketNumber}`,
         anything: false,
         slots_limited: true,
         not_counted: false,
         expose_attendees: false,
-      } as Omit<BucketType, 'key'>),
+      } as Omit<BucketType, 'generatedId'>),
     );
   };
 
   const addFlexBucketClicked = (event: React.MouseEvent) => {
     event.preventDefault();
     onChange(
-      addRegistrationPolicyBucket(registrationPolicy, 'flex', {
+      addRegistrationPolicyBucket(registrationPolicy, uuidv4(), {
+        key: 'flex',
         name: 'Flex',
         description: 'Characters that can be in any other limited bucket',
         slots_limited: true,
         anything: true,
-      } as Omit<BucketType, 'key'>),
+      } as Omit<BucketType, 'generatedId'>),
     );
   };
 
-  const bucketChanged = (key: string, newBucket: BucketType) => {
-    onChange(updateRegistrationPolicyBucket(registrationPolicy, key, newBucket));
+  const bucketChanged = (generatedId: string, newBucket: BucketType) => {
+    onChange(updateRegistrationPolicyBucket(registrationPolicy, generatedId, newBucket));
   };
 
   const preventNoPreferenceSignupsChanged = (newValue: string) => {
@@ -113,8 +109,8 @@ function RegistrationPolicyEditor<
     });
   };
 
-  const deleteBucket = (key: string) => {
-    onChange(removeRegistrationPolicyBucket(registrationPolicy, key));
+  const deleteBucket = (generatedId: string) => {
+    onChange(removeRegistrationPolicyBucket(registrationPolicy, generatedId));
   };
 
   const presetSelected = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -173,7 +169,7 @@ function RegistrationPolicyEditor<
 
     return (
       <RegistrationBucketRow
-        key={bucket.key}
+        key={bucket.generatedId}
         registrationBucket={bucket}
         onChange={bucketChanged}
         onDelete={deleteBucket}

--- a/app/javascript/RegistrationPolicy/RegistrationPolicyPreview.tsx
+++ b/app/javascript/RegistrationPolicy/RegistrationPolicyPreview.tsx
@@ -20,10 +20,12 @@ function RegistrationPolicyPreview({ registrationPolicy }: RegistrationPolicyPre
       buckets: buckets.map((bucket) => ({
         __typename: 'RegistrationPolicyBucket' as const,
         ...bucket,
-        // A bucket added in the current edit session has no id yet; fall back to its (always
-        // present, locally-unique) key as a placeholder so this preview-only object still has
-        // some stable identity to key React lists off of.
-        id: bucket.id ?? bucket.key,
+        // A bucket added in the current edit session has no id yet; fall back to its
+        // generatedId (present for any bucket coming from the editor) or, failing that, its key
+        // (present for a real, already-persisted bucket rendered outside the editor, e.g. in
+        // RegistrationPolicyDisplay), so this preview-only object always has some stable
+        // identity to key React lists off of.
+        id: bucket.id ?? bucket.generatedId ?? bucket.key,
         description: bucket.description ?? null,
         minimum_slots: bucket.minimum_slots ?? null,
         preferred_slots: bucket.preferred_slots ?? null,

--- a/app/javascript/RegistrationPolicy/RegistrationPolicyUtils.ts
+++ b/app/javascript/RegistrationPolicy/RegistrationPolicyUtils.ts
@@ -1,9 +1,5 @@
 import { RegistrationPolicyPreset } from '../FormAdmin/FormItemUtils';
-import {
-  BucketForRegistrationPolicyUtils,
-  getRegistrationPolicyBucket,
-  RegistrationPolicyForRegistrationPolicyUtils,
-} from './RegistrationPolicy';
+import { BucketForRegistrationPolicyUtils, RegistrationPolicyForRegistrationPolicyUtils } from './RegistrationPolicy';
 
 export function presetMatchesPolicy(
   registrationPolicy: RegistrationPolicyForRegistrationPolicyUtils,
@@ -15,8 +11,12 @@ export function presetMatchesPolicy(
     return false;
   }
 
+  // Presets are admin-authored fixture data with no id/generatedId concept, so this match (and
+  // bucketInPreset in RegistrationPolicyEditor) stays key-based permanently.
   const allKeysMatch = preset.policy.buckets.every(
-    (bucket) => typeof bucket.key === 'string' && getRegistrationPolicyBucket(registrationPolicy, bucket.key),
+    (bucket) =>
+      typeof bucket.key === 'string' &&
+      (registrationPolicy.buckets ?? []).some((policyBucket) => policyBucket.key === bucket.key),
   );
   if (!allKeysMatch) {
     return false;

--- a/test/javascript/RegistrationPolicy/RegistrationBucketRow.test.tsx
+++ b/test/javascript/RegistrationPolicy/RegistrationBucketRow.test.tsx
@@ -8,6 +8,7 @@ describe('RegistrationBucketRow', () => {
 
   const defaultRegistrationBucketProps = {
     key: 'testBucket',
+    generatedId: 'testGeneratedId',
     name: 'test',
     description: 'a bucket for testing',
     total_slots: 10,
@@ -80,7 +81,7 @@ describe('RegistrationBucketRow', () => {
     const { getByLabelText } = await renderRegistrationBucketRow();
     fireEvent.focus(getByLabelText('Bucket name'));
     fireEvent.change(getByLabelText('Bucket name'), { target: { value: 'new name' } });
-    expect(onChange.mock.calls[0][0]).toEqual('testBucket');
+    expect(onChange.mock.calls[0][0]).toEqual('testGeneratedId');
     expect(onChange.mock.calls[0][1].name).toEqual('new name');
     expect(onChange.mock.calls[0][1].key).toEqual('testBucket');
   });
@@ -91,42 +92,42 @@ describe('RegistrationBucketRow', () => {
     fireEvent.change(getByLabelText('Bucket description'), {
       target: { value: 'a new description' },
     });
-    expect(onChange.mock.calls[0][0]).toEqual('testBucket');
+    expect(onChange.mock.calls[0][0]).toEqual('testGeneratedId');
     expect(onChange.mock.calls[0][1].description).toEqual('a new description');
   });
 
   test('changing unlimited checkbox', async () => {
     const { getByLabelText } = await renderRegistrationBucketRow();
     fireEvent.click(getByLabelText('Unlimited?'));
-    expect(onChange.mock.calls[0][0]).toEqual('testBucket');
+    expect(onChange.mock.calls[0][0]).toEqual('testGeneratedId');
     expect(onChange.mock.calls[0][1].slots_limited).toEqual(false);
   });
 
   test('changing counted checkbox', async () => {
     const { getByLabelText } = await renderRegistrationBucketRow();
     fireEvent.click(getByLabelText('Counted for signups?'));
-    expect(onChange.mock.calls[0][0]).toEqual('testBucket');
+    expect(onChange.mock.calls[0][0]).toEqual('testGeneratedId');
     expect(onChange.mock.calls[0][1].not_counted).toEqual(true);
   });
 
   test('changing minimumSlots', async () => {
     const { getByLabelText } = await renderRegistrationBucketRow();
     fireEvent.change(getByLabelText('Min'), { target: { value: '4' } });
-    expect(onChange.mock.calls[0][0]).toEqual('testBucket');
+    expect(onChange.mock.calls[0][0]).toEqual('testGeneratedId');
     expect(onChange.mock.calls[0][1].minimum_slots).toEqual(4);
   });
 
   test('changing preferredSlots', async () => {
     const { getByLabelText } = await renderRegistrationBucketRow();
     fireEvent.change(getByLabelText('Pref'), { target: { value: '6' } });
-    expect(onChange.mock.calls[0][0]).toEqual('testBucket');
+    expect(onChange.mock.calls[0][0]).toEqual('testGeneratedId');
     expect(onChange.mock.calls[0][1].preferred_slots).toEqual(6);
   });
 
   test('changing totalSlots', async () => {
     const { getByLabelText } = await renderRegistrationBucketRow();
     fireEvent.change(getByLabelText('Max'), { target: { value: '55' } });
-    expect(onChange.mock.calls[0][0]).toEqual('testBucket');
+    expect(onChange.mock.calls[0][0]).toEqual('testGeneratedId');
     expect(onChange.mock.calls[0][1].total_slots).toEqual(55);
   });
 
@@ -136,7 +137,7 @@ describe('RegistrationBucketRow', () => {
     await waitFor(() => expect(getByText('OK')).toBeVisible());
     fireEvent.click(getByText('OK'));
     await waitFor(() => expect(getByText('OK')).not.toBeVisible());
-    expect(onDelete.mock.calls[0][0]).toEqual('testBucket');
+    expect(onDelete.mock.calls[0][0]).toEqual('testGeneratedId');
   });
 
   test('canceling delete', async () => {

--- a/test/javascript/RegistrationPolicy/RegistrationPolicyEditor.test.tsx
+++ b/test/javascript/RegistrationPolicy/RegistrationPolicyEditor.test.tsx
@@ -12,10 +12,11 @@ describe('RegistrationPolicyEditor', () => {
   const onChange = vi.fn<(rp: EditingRegistrationPolicy<EditingRegistrationBucket>) => void>();
   beforeEach(onChange.mockReset);
 
-  const defaultRegistrationPolicyBucket: RegistrationPolicyBucket = {
+  const defaultRegistrationPolicyBucket: RegistrationPolicyBucket & Pick<EditingRegistrationBucket, 'generatedId'> = {
     __typename: 'RegistrationPolicyBucket',
     id: 'testBucket',
     key: 'testBucket',
+    generatedId: 'testBucket',
     name: 'test',
     description: 'a bucket for testing',
     total_slots: 10,
@@ -31,7 +32,7 @@ describe('RegistrationPolicyEditor', () => {
     props?: Partial<
       RegistrationPolicyEditorProps<EditingRegistrationBucket, EditingRegistrationPolicy<EditingRegistrationBucket>>
     >,
-    buckets: RegistrationPolicyBucket[] = [defaultRegistrationPolicyBucket],
+    buckets: EditingRegistrationBucket[] = [defaultRegistrationPolicyBucket],
     preventNoPreferenceSignups = false,
   ) => {
     return await render(
@@ -126,6 +127,7 @@ describe('RegistrationPolicyEditor', () => {
       ...defaultRegistrationPolicyBucket,
       ...presetBucket,
       id: presetBucket.key,
+      generatedId: presetBucket.key,
     }));
 
     test('renders the selector by default', async () => {


### PR DESCRIPTION
Fixes #11904

## Summary

`RegistrationBucketRow`/`RegistrationPolicyEditor`/`RegistrationPolicy.ts` indexed every bucket in an in-progress edit session by `key` (onChange/onDelete handlers, React list keys, the add/remove/update helpers, and `addBucketClicked`'s "next custom number" scan). That's about to break once #11898 drops `key` from `RegistrationPolicyBucket#as_json`'s output, since buckets loaded from the server will have no `key` field to index by at all.

- Added a client-only `generatedId: string` (via `uuidv4()`, mirroring `ChangeSet`'s existing pattern) to `EditingRegistrationBucket`, and switched all internal indexing (`RegistrationBucketRow`'s `onChange`/`onDelete`, `RegistrationPolicy.ts`'s `get/add/remove/updateRegistrationPolicyBucket`, `RegistrationPolicyEditor`'s handlers and React list key) to use it instead of `key`.
- `generatedId` is assigned once per bucket as it enters an editing session and stripped again before the value leaves the editor for good, so it never reaches the server: `RegistrationPolicyItemInput` (event/event-proposal forms) and `RegistrationPolicyItemEditorPresetModal` (admin preset editor) each tag on the way in and strip on the way out.
- `presetMatchesPolicy` (in `RegistrationPolicyUtils.ts`) stays purely key-based, since presets are admin-authored fixture data with no id/generatedId concept — it no longer reuses `getRegistrationPolicyBucket` now that that helper is generatedId-based, and instead does its own inline key lookup.
- Replaced `addBucketClicked`'s key-scanning "next available custom bucket number" logic with a simple bucket count, since it can no longer assume prior buckets' keys are inspectable.
- Updated `RegistrationPolicyPreview.tsx`'s synthetic React-key fallback from `bucket.id ?? bucket.key` to `bucket.id ?? bucket.generatedId ?? bucket.key` (the extra `key` fallback covers `RegistrationPolicyDisplay`'s read-only, non-editing usage of the same preview component, where buckets have a real `id` but no `generatedId`).

## Test plan

- [x] `yarn run tsc --noEmit` passes
- [x] `yarn vitest run test/javascript/RegistrationPolicy` passes (30 tests, including updated fixtures/assertions in `RegistrationBucketRow.test.tsx` and `RegistrationPolicyEditor.test.tsx`)
- [x] `bin/rails test test/models/registration_policy_test.rb` passes (unaffected, frontend-only change)
- [x] `yarn eslint` on changed files — no new errors (pre-existing i18next literal-string warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)