### PR TITLE
QA hardening for the bucket key->id migration epic: fix signup-orphaning bug, fill test gaps

### DIFF
--- a/app/javascript/SignupModeration/SignupModerationQueue.tsx
+++ b/app/javascript/SignupModeration/SignupModerationQueue.tsx
@@ -64,13 +64,16 @@ function signupRequestStateBadgeClass(state: SignupRequestState) {
 }
 
 function describeRequestedBucket(signupRequest: SignupModerationSignupRequestFieldsFragment, t: TFunction) {
-  return signupRequest.requested_bucket
-    ? (
-        signupRequest.target_run.event.registration_policy?.buckets.find(
-          (bucket) => bucket.id === signupRequest.requested_bucket?.id,
-        ) || {}
-      ).name
-    : t('signups.noPreference');
+  const bucket = signupRequest.requested_bucket
+    ? signupRequest.target_run.event.registration_policy?.buckets.find(
+        (b) => b.id === signupRequest.requested_bucket?.id,
+      )
+    : undefined;
+
+  // A requested_bucket that no longer resolves to any of the run's current buckets (e.g. removed
+  // or renamed since this request was made) used to fall through to `undefined`, rendering blank
+  // instead of falling back to "no preference" the way every other bucket display in this app does.
+  return bucket ? bucket.name : t('signups.noPreference');
 }
 
 type SignupModerationRunDetailsRun = NonNullable<

--- a/app/services/event_change_registration_policy_service.rb
+++ b/app/services/event_change_registration_policy_service.rb
@@ -359,12 +359,16 @@ class EventChangeRegistrationPolicyService < CivilService::Service
   end
 
   # The still-persisted buckets (with their real, stable ids) that the incoming new_registration_policy
-  # doesn't have a matching key for. Computed once, before update_from! destroys them.
+  # doesn't have a matching candidate for. Computed once, before update_from! destroys them. Matched
+  # by id, not key: a bucket whose key changes mid-edit is still the same bucket (sync_buckets_from_hash!
+  # matches it by id too, see #11892), so key-based matching here would wrongly treat every rename as
+  # a remove-and-recreate, silently orphaning that bucket's signups when clear_references_to_removed_buckets
+  # nulls their bucket_id/requested_bucket_id out from under them.
   def removed_buckets
     @removed_buckets ||=
       begin
-        new_keys = new_registration_policy.buckets.to_set(&:key)
-        event.registration_policy.buckets.reject { |bucket| new_keys.include?(bucket.key) }
+        new_bucket_ids = new_registration_policy.buckets.filter_map(&:id).to_set
+        event.registration_policy.buckets.reject { |bucket| new_bucket_ids.include?(bucket.id) }
       end
   end
 

--- a/app/views/reports/_per_event_single.html.erb
+++ b/app/views/reports/_per_event_single.html.erb
@@ -68,14 +68,14 @@
             <li>
               <%= signup.user_con_profile.name_inverted %>
               <% if event.registration_policy.buckets.size > 0 %>
-                (<%= event.registration_policy.bucket_with_key(signup.requested_bucket_key)&.name || signup.requested_bucket_key %>)
+                (<%= signup.requested_bucket&.name %>)
               <% end %>
             </li>
           <% end %>
         </ol>
       </section>
     <% end %>
-    <% available_slots = run.available_slots_by_bucket_key.values.compact.sum %>
+    <% available_slots = run.available_slots_by_bucket_id.values.compact.sum %>
     <% if available_slots > 0 %>
       <section>
         <p class="fw-bold">

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class ReportsControllerTest < ActionDispatch::IntegrationTest
+  let(:convention) { create(:convention) }
+  let(:con_admin_staff_position) { create(:admin_staff_position, convention: convention) }
+  let(:con_admin_profile) do
+    profile = create(:user_con_profile, convention: convention)
+    con_admin_staff_position.user_con_profiles << profile
+    profile
+  end
+  let(:con_admin) { con_admin_profile.user }
+
+  let(:event) do
+    create(
+      :event,
+      convention: convention,
+      registration_policy:
+        RegistrationPolicy.build_from_hash(
+          buckets: [
+            { key: "dogs", name: "Dogs", slots_limited: true, total_slots: 1 },
+            { key: "cats", name: "Cats", slots_limited: true, total_slots: 1 }
+          ]
+        )
+    )
+  end
+  let(:event_run) { create(:run, event: event) }
+
+  setup do
+    host! convention.domain
+    sign_in con_admin
+  end
+
+  describe "GET per_event" do
+    it "renders without error for an event with a waitlisted signup requesting a bucket" do
+      dogs_bucket = bucket_with_key(event.registration_policy, "dogs")
+      create(:signup, run: event_run, bucket_id: dogs_bucket.id, state: "confirmed")
+      create(:signup, run: event_run, state: "waitlisted", requested_bucket_id: dogs_bucket.id, bucket_id: nil)
+
+      get reports_per_event_path
+
+      assert_response :ok
+      assert_includes response.body, "Dogs"
+    end
+
+    it "renders without error for an event with no waitlisted signups" do
+      create(:signup, run: event_run, bucket_id: bucket_with_key(event.registration_policy, "dogs").id)
+
+      get reports_per_event_path
+
+      assert_response :ok
+    end
+  end
+
+  describe "GET single_user_printable" do
+    it "renders without error for a user with a waitlisted signup requesting a bucket" do
+      dogs_bucket = bucket_with_key(event.registration_policy, "dogs")
+      team_member_profile = create(:user_con_profile, convention: convention)
+      create(:team_member, event: event, user_con_profile: team_member_profile)
+      create(
+        :signup,
+        run: event_run,
+        user_con_profile: team_member_profile,
+        state: "waitlisted",
+        requested_bucket_id: dogs_bucket.id,
+        bucket_id: nil
+      )
+
+      get reports_path(user_con_profile_id: team_member_profile.id)
+
+      assert_response :ok
+      assert_includes response.body, "Dogs"
+    end
+  end
+end

--- a/test/graphql/mutations/update_event_test.rb
+++ b/test/graphql/mutations/update_event_test.rb
@@ -30,6 +30,23 @@ class Mutations::UpdateEventTest < ActiveSupport::TestCase
     }
   GRAPHQL
 
+  UPDATE_EVENT_WITH_BUCKET_KEY_MAPPINGS_MUTATION = <<~GRAPHQL
+    mutation TestUpdateEventWithBucketKeyMappings(
+      $id: ID!
+      $formResponseAttrsJson: String!
+      $bucketKeyMappings: [BucketKeyMappingInput!]
+    ) {
+      updateEvent(
+        input: {
+          id: $id
+          event: { form_response_attrs_json: $formResponseAttrsJson, bucket_key_mappings: $bucketKeyMappings }
+        }
+      ) {
+        event { id }
+      }
+    }
+  GRAPHQL
+
   describe "updating registration_policy" do
     before do
       execute_graphql_query(
@@ -65,6 +82,35 @@ class Mutations::UpdateEventTest < ActiveSupport::TestCase
     it "stores different previous_value and new_value" do
       change = FormResponseChange.find_by!(response: event, field_identifier: "registration_policy")
       assert_not_equal change.previous_value, change.new_value
+    end
+  end
+
+  describe "with bucket_key_mappings remapping a removed bucket's signups" do
+    let(:the_run) { create(:run, event:) }
+    let(:unlimited_bucket_id) { bucket_with_key(event.registration_policy, "unlimited").id }
+    let(:signup) do
+      create(:signup, run: the_run, bucket_id: unlimited_bucket_id, requested_bucket_id: unlimited_bucket_id)
+    end
+
+    before { signup }
+
+    # Exercises both sides of resolve_bucket_key_mapping: from_bucket_id (the "unlimited" bucket
+    # being removed, which already has a real id) and to_key (the "anything" bucket, which is being
+    # newly created in this same edit and so has no id yet for to_bucket_id to reference).
+    it "moves the signup into the bucket named by to_key, resolving from_bucket_id to the removed bucket" do
+      execute_graphql_query(
+        UPDATE_EVENT_WITH_BUCKET_KEY_MAPPINGS_MUTATION,
+        user_con_profile: admin_profile,
+        variables: {
+          "id" => event.id.to_s,
+          "formResponseAttrsJson" => { "registration_policy" => new_registration_policy.as_json }.to_json,
+          "bucketKeyMappings" => [{ "fromBucketId" => unlimited_bucket_id.to_s, "to_key" => "anything" }]
+        }
+      )
+
+      signup.reload
+      assert_equal "anything", signup.bucket&.key
+      assert_equal "anything", signup.requested_bucket&.key
     end
   end
 

--- a/test/javascript/EventAdmin/useBucketKeyRemapping.test.tsx
+++ b/test/javascript/EventAdmin/useBucketKeyRemapping.test.tsx
@@ -1,0 +1,114 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import useBucketKeyRemapping from '../../../app/javascript/EventAdmin/useBucketKeyRemapping';
+import { BucketKeyMappingInput } from '../../../app/javascript/graphqlTypes.generated';
+
+type Bucket = { key: string; id?: string; name?: string };
+
+describe('useBucketKeyRemapping', () => {
+  const buildEvent = (buckets: Bucket[]) => ({
+    form_response_attrs: {
+      registration_policy: { buckets, prevent_no_preference_signups: false },
+    },
+  });
+
+  const buildInitialEvent = (buckets: Bucket[], bucketKeysWithPendingSignupsOrRequests: string[]) => ({
+    ...buildEvent(buckets),
+    bucket_keys_with_pending_signups_or_requests: bucketKeysWithPendingSignupsOrRequests,
+  });
+
+  const renderUseBucketKeyRemapping = (
+    event: ReturnType<typeof buildEvent>,
+    initialEvent: ReturnType<typeof buildInitialEvent>,
+    onSubmit: (mappings?: BucketKeyMappingInput[]) => Promise<void>,
+  ) => renderHook(() => useBucketKeyRemapping({ event, initialEvent, onSubmit }));
+
+  it('submits immediately when no buckets were removed', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const initialEvent = buildInitialEvent([{ key: 'dogs', id: '1' }], []);
+    const event = buildEvent([{ key: 'dogs' }]);
+    const { result } = renderUseBucketKeyRemapping(event, initialEvent, onSubmit);
+
+    await act(async () => {
+      await result.current.updateEvent();
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith();
+    expect(result.current.remappingModalProps.visible).toBe(false);
+  });
+
+  it('submits immediately when a removed bucket has no pending signups or requests', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const initialEvent = buildInitialEvent([{ key: 'dogs', id: '1' }], []);
+    const event = buildEvent([{ key: 'cats' }]);
+    const { result } = renderUseBucketKeyRemapping(event, initialEvent, onSubmit);
+
+    await act(async () => {
+      await result.current.updateEvent();
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith();
+    expect(result.current.remappingModalProps.visible).toBe(false);
+  });
+
+  it('shows the remapping modal, carrying the removed bucket’s real id, when it has pending records', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const initialEvent = buildInitialEvent([{ key: 'dogs', id: '1', name: 'Dogs' }], ['dogs']);
+    const event = buildEvent([{ key: 'cats' }]);
+    const { result } = renderUseBucketKeyRemapping(event, initialEvent, onSubmit);
+
+    act(() => {
+      void result.current.updateEvent();
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(result.current.remappingModalProps.visible).toBe(true);
+    expect(result.current.remappingModalProps.removedBuckets).toEqual([{ key: 'dogs', id: '1', name: 'Dogs' }]);
+  });
+
+  it('submits with the confirmed mappings and hides the modal on confirm', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const initialEvent = buildInitialEvent([{ key: 'dogs', id: '1', name: 'Dogs' }], ['dogs']);
+    const event = buildEvent([{ key: 'cats' }]);
+    const { result } = renderUseBucketKeyRemapping(event, initialEvent, onSubmit);
+
+    let updatePromise: Promise<void> | undefined;
+    act(() => {
+      updatePromise = result.current.updateEvent();
+    });
+
+    const mappings = [{ from_bucket_id: '1', to_key: 'cats' }];
+    await act(async () => {
+      await result.current.remappingModalProps.onConfirm(mappings);
+    });
+    await act(async () => {
+      await updatePromise;
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(mappings);
+    expect(result.current.remappingModalProps.visible).toBe(false);
+  });
+
+  it('does not submit, but still resolves the pending update, on cancel', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const initialEvent = buildInitialEvent([{ key: 'dogs', id: '1', name: 'Dogs' }], ['dogs']);
+    const event = buildEvent([{ key: 'cats' }]);
+    const { result } = renderUseBucketKeyRemapping(event, initialEvent, onSubmit);
+
+    let updatePromise: Promise<void> | undefined;
+    act(() => {
+      updatePromise = result.current.updateEvent();
+    });
+
+    act(() => {
+      result.current.remappingModalProps.onCancel();
+    });
+    await act(async () => {
+      await updatePromise;
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(result.current.remappingModalProps.visible).toBe(false);
+  });
+});

--- a/test/javascript/EventsApp/MySignupQueue/UserSignupQueueItem.test.tsx
+++ b/test/javascript/EventsApp/MySignupQueue/UserSignupQueueItem.test.tsx
@@ -1,0 +1,89 @@
+import { render } from '../../testUtils';
+import UserSignupQueueItem from '../../../../app/javascript/EventsApp/MySignupQueue/UserSignupQueueItem';
+import { UserConProfileRankedChoiceQueueFieldsFragment } from '../../../../app/javascript/EventsApp/MySignupQueue/queries.generated';
+import { RankedChoiceFallbackAction, SignupRankedChoiceState } from '../../../../app/javascript/graphqlTypes.generated';
+
+describe('UserSignupQueueItem', () => {
+  const buildUserConProfile = (
+    requestedBucket: { id: string } | null,
+  ): UserConProfileRankedChoiceQueueFieldsFragment => ({
+    __typename: 'UserConProfile',
+    id: '1',
+    ranked_choice_fallback_action: RankedChoiceFallbackAction.Waitlist,
+    ranked_choice_user_constraints: [],
+    ticket: null,
+    signups: [],
+    signup_ranked_choices: [
+      {
+        __typename: 'SignupRankedChoice',
+        id: '1',
+        state: SignupRankedChoiceState.Pending,
+        prioritize_waitlist: false,
+        waitlist_position_cap: null,
+        priority: 1,
+        requested_bucket: requestedBucket && { __typename: 'RegistrationPolicyBucket', id: requestedBucket.id },
+        simulated_skip_reason: null,
+        target_run: {
+          __typename: 'Run',
+          id: '1',
+          title_suffix: null,
+          starts_at: '2025-01-01T19:00:00Z',
+          event: {
+            __typename: 'Event',
+            id: '1',
+            title: 'Test Event',
+            length_seconds: 14400,
+            event_category: { __typename: 'EventCategory', id: '1', name: 'Games' },
+            registration_policy: {
+              __typename: 'RegistrationPolicy',
+              buckets: [
+                {
+                  __typename: 'RegistrationPolicyBucket',
+                  id: '1',
+                  key: 'player',
+                  name: 'Player',
+                  description: null,
+                },
+                { __typename: 'RegistrationPolicyBucket', id: '2', key: 'gm', name: 'GM', description: null },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  const renderQueueItem = async (userConProfile: UserConProfileRankedChoiceQueueFieldsFragment) =>
+    render(
+      <ul>
+        <UserSignupQueueItem
+          userConProfile={userConProfile}
+          index={0}
+          refetchQueries={[]}
+          readOnly={false}
+          loading={false}
+          enableDragDrop={false}
+        />
+      </ul>,
+    );
+
+  it("shows the requested bucket's name, matched by id, when one is present", async () => {
+    // key intentionally does not equal any of this event's actual bucket keys, to confirm the
+    // match happens by id, not by any key-based coincidence.
+    const { container } = await renderQueueItem(buildUserConProfile({ id: '2' }));
+
+    expect(container.textContent).toContain('GM');
+  });
+
+  it('shows "No preference" when there is no requested bucket', async () => {
+    const { getByText } = await renderQueueItem(buildUserConProfile(null));
+
+    expect(getByText(/No preference/)).toBeTruthy();
+  });
+
+  it('shows "No preference" when the requested bucket id does not match any of the run’s buckets', async () => {
+    const { getByText } = await renderQueueItem(buildUserConProfile({ id: 'removed-bucket' }));
+
+    expect(getByText(/No preference/)).toBeTruthy();
+  });
+});

--- a/test/javascript/EventsApp/ScheduleGrid/AvailabilityUtils.test.tsx
+++ b/test/javascript/EventsApp/ScheduleGrid/AvailabilityUtils.test.tsx
@@ -1,0 +1,128 @@
+import { calculateAvailability } from '../../../../app/javascript/EventsApp/ScheduleGrid/AvailabilityUtils';
+import SignupCountData from '../../../../app/javascript/EventsApp/SignupCountData';
+import { ScheduleEvent } from '../../../../app/javascript/EventsApp/ScheduleGrid/Schedule';
+import { SignupState } from '../../../../app/javascript/graphqlTypes.generated';
+
+// calculateAvailability only ever reads event.registration_policy -- ScheduleEvent is a much wider
+// fragment type (event_category, runs, etc.) that isn't relevant here, so this builds just the
+// slice the function actually touches rather than a full fixture for the whole fragment.
+function buildEvent(registrationPolicy: ScheduleEvent['registration_policy']): ScheduleEvent {
+  return { registration_policy: registrationPolicy } as unknown as ScheduleEvent;
+}
+
+describe('calculateAvailability', () => {
+  it('sums confirmed signups in limited buckets when the policy has an overall total_slots', () => {
+    const event = buildEvent({
+      slots_limited: true,
+      only_uncounted: false,
+      total_slots: 10,
+      total_slots_including_not_counted: 10,
+      buckets: [
+        {
+          __typename: 'RegistrationPolicyBucket' as const,
+          id: '1',
+          key: 'player',
+          not_counted: false,
+          total_slots: 6,
+          slots_limited: true,
+        },
+        {
+          __typename: 'RegistrationPolicyBucket' as const,
+          id: '2',
+          key: 'gm',
+          not_counted: false,
+          total_slots: 4,
+          slots_limited: true,
+        },
+      ],
+    });
+    const signupCountData = new SignupCountData([
+      { bucket_id: '1', count: 3, counted: true, state: SignupState.Confirmed, team_member: false },
+      { bucket_id: '2', count: 1, counted: true, state: SignupState.Confirmed, team_member: false },
+      // A bucket with a different id must not be counted towards this event's availability, even
+      // if some other bug caused it to share data with one of the buckets above.
+      { bucket_id: 'other-event-bucket', count: 100, counted: true, state: SignupState.Confirmed, team_member: false },
+    ]);
+
+    const availability = calculateAvailability(event, signupCountData);
+
+    expect(availability.totalSlots).toEqual(10);
+    expect(availability.signupCount).toEqual(4);
+    expect(availability.remainingCapacity).toEqual(6);
+    expect(availability.unlimited).toBe(false);
+  });
+
+  it('only sums the limited buckets when only_uncounted and some buckets are unlimited', () => {
+    const event = buildEvent({
+      slots_limited: true,
+      only_uncounted: true,
+      total_slots: null,
+      total_slots_including_not_counted: 5,
+      buckets: [
+        {
+          __typename: 'RegistrationPolicyBucket' as const,
+          id: '1',
+          key: 'limited',
+          not_counted: true,
+          total_slots: 5,
+          slots_limited: true,
+        },
+        {
+          __typename: 'RegistrationPolicyBucket' as const,
+          id: '2',
+          key: 'unlimited',
+          not_counted: true,
+          total_slots: null,
+          slots_limited: false,
+        },
+      ],
+    });
+    const signupCountData = new SignupCountData([
+      { bucket_id: '1', count: 2, counted: true, state: SignupState.Confirmed, team_member: false },
+      { bucket_id: '2', count: 40, counted: true, state: SignupState.Confirmed, team_member: false },
+    ]);
+
+    const availability = calculateAvailability(event, signupCountData);
+
+    expect(availability.totalSlots).toEqual(5);
+    expect(availability.signupCount).toEqual(2);
+  });
+
+  it('is unlimited when the registration policy is not slots_limited', () => {
+    const event = buildEvent({
+      slots_limited: false,
+      only_uncounted: false,
+      total_slots: null,
+      total_slots_including_not_counted: null,
+      buckets: [],
+    });
+    const availability = calculateAvailability(event, new SignupCountData([]));
+
+    expect(availability.unlimited).toBe(true);
+  });
+
+  it('reports the waitlist count regardless of bucket', () => {
+    const event = buildEvent({
+      slots_limited: true,
+      only_uncounted: false,
+      total_slots: 1,
+      total_slots_including_not_counted: 1,
+      buckets: [
+        {
+          __typename: 'RegistrationPolicyBucket' as const,
+          id: '1',
+          key: 'player',
+          not_counted: false,
+          total_slots: 1,
+          slots_limited: true,
+        },
+      ],
+    });
+    const signupCountData = new SignupCountData([
+      { bucket_id: '1', count: 1, counted: true, state: SignupState.Confirmed, team_member: false },
+      { bucket_id: null, count: 3, counted: false, state: SignupState.Waitlisted, team_member: false },
+    ]);
+
+    expect(calculateAvailability(event, signupCountData).waitlistCount).toEqual(3);
+  });
+});

--- a/test/javascript/EventsApp/SignupAdmin/$id/change_bucket.test.tsx
+++ b/test/javascript/EventsApp/SignupAdmin/$id/change_bucket.test.tsx
@@ -1,0 +1,194 @@
+import { Outlet } from 'react-router';
+import { MockLink } from '@apollo/client/testing';
+import { fireEvent } from '@testing-library/react';
+
+import { renderRoute, waitFor } from '../../../testUtils';
+import {
+  Component as ChangeBucketModal,
+  action as changeBucketAction,
+} from '../../../../../app/javascript/EventsApp/SignupAdmin/$id/change_bucket';
+import { singleSignupLoader } from '../../../../../app/javascript/EventsApp/SignupAdmin/loaders';
+import {
+  AdminSignupQueryData,
+  AdminSignupQueryDocument,
+} from '../../../../../app/javascript/EventsApp/SignupAdmin/queries.generated';
+import {
+  ChangeSignupBucketDocument,
+  ChangeSignupBucketMutationData,
+} from '../../../../../app/javascript/EventsApp/SignupAdmin/mutations.generated';
+import {
+  SignupAutomationMode,
+  SignupMode,
+  SignupState,
+  SiteMode,
+  TicketMode,
+  TimezoneMode,
+} from '../../../../../app/javascript/graphqlTypes.generated';
+import { NamedRoute } from '../../../../../app/javascript/AppRouter';
+
+describe('ChangeBucketModal', () => {
+  type Signup = AdminSignupQueryData['convention']['signup'];
+
+  const buildSignup = (overrides: Partial<Signup> = {}): Signup => ({
+    __typename: 'Signup',
+    id: '1',
+    state: SignupState.Confirmed,
+    counted: true,
+    bucket: { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player' },
+    requested_bucket: null,
+    run: {
+      __typename: 'Run',
+      id: '1',
+      title_suffix: null,
+      starts_at: '2025-01-01T19:00:00Z',
+      ends_at: '2025-01-01T23:00:00Z',
+      rooms: [],
+      event: {
+        __typename: 'Event',
+        id: '1',
+        title: 'Test Event',
+        event_category: { __typename: 'EventCategory', id: '1', team_member_name: 'GM', teamMemberNamePlural: 'GMs' },
+        registration_policy: {
+          __typename: 'RegistrationPolicy',
+          buckets: [
+            { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player', name: 'Player', anything: false },
+            { __typename: 'RegistrationPolicyBucket', id: '2', key: 'gm', name: 'GM', anything: false },
+          ],
+        },
+        team_members: [],
+      },
+    },
+    user_con_profile: {
+      __typename: 'UserConProfile',
+      id: '1',
+      name_without_nickname: 'Test User',
+      nickname: null,
+      birth_date: null,
+      email: null,
+      address: null,
+      city: null,
+      state: null,
+      zipcode: null,
+      country: null,
+      mobile_phone: null,
+      gravatar_enabled: false,
+      gravatar_url: '',
+    },
+    ...overrides,
+  });
+
+  const buildLoaderData = (signup: Signup): AdminSignupQueryData => ({
+    __typename: 'Query',
+    currentAbility: {
+      __typename: 'Ability',
+      can_update_bucket_signup: true,
+      can_force_confirm_signup: true,
+      can_update_counted_signup: true,
+    },
+    convention: {
+      __typename: 'Convention',
+      id: '1',
+      name: 'Test Convention',
+      starts_at: null,
+      ends_at: null,
+      signup_mode: SignupMode.Moderated,
+      signup_automation_mode: SignupAutomationMode.RankedChoice,
+      site_mode: SiteMode.Convention,
+      timezone_name: 'America/New_York',
+      timezone_mode: TimezoneMode.ConventionLocal,
+      ticket_name: 'ticket',
+      ticket_mode: TicketMode.Disabled,
+      event_categories: [],
+      signup,
+    },
+  });
+
+  const buildMutationData = (
+    signup: Signup,
+    newBucket: { id: string; key: string },
+  ): ChangeSignupBucketMutationData => ({
+    __typename: 'Mutation',
+    updateSignupBucket: {
+      __typename: 'UpdateSignupBucketPayload',
+      signup: {
+        __typename: 'Signup',
+        id: signup.id,
+        state: signup.state,
+        counted: signup.counted,
+        bucket: { __typename: 'RegistrationPolicyBucket', id: newBucket.id, key: newBucket.key },
+        requested_bucket: signup.requested_bucket,
+        user_con_profile: signup.user_con_profile,
+        run: {
+          __typename: 'Run',
+          id: signup.run.id,
+          title_suffix: signup.run.title_suffix,
+          starts_at: signup.run.starts_at,
+          ends_at: signup.run.ends_at,
+          current_ability_can_signup_summary_run: false,
+          rooms: [],
+          event: signup.run.event,
+          grouped_signup_counts: [],
+          my_signups: [],
+          my_signup_requests: [],
+          my_signup_ranked_choices: [],
+        },
+      },
+    },
+  });
+
+  const renderChangeBucketModal = async (signup: Signup, mocks: MockLink.MockedResponse[] = []) => {
+    const allMocks: MockLink.MockedResponse[] = [
+      {
+        request: { query: AdminSignupQueryDocument, variables: { id: '1' } },
+        result: { data: buildLoaderData(signup) },
+      },
+      ...mocks,
+    ];
+
+    const result = await renderRoute(
+      [
+        {
+          path: '/events/:eventId/runs/:runId/admin_signups/:id',
+          id: NamedRoute.EditSignup,
+          loader: singleSignupLoader,
+          Component: () => <Outlet />,
+          children: [{ path: 'change_bucket', action: changeBucketAction, Component: ChangeBucketModal }],
+        },
+      ],
+      { apolloMocks: allMocks, initialEntries: ['/events/1/runs/1/admin_signups/1/change_bucket'] },
+    );
+
+    await waitFor(() => expect(result.getByRole('button', { name: 'OK' })).toBeTruthy());
+    return result;
+  };
+
+  it("pre-selects the signup's current bucket by key, not id", async () => {
+    const { getByLabelText } = await renderChangeBucketModal(
+      buildSignup({ bucket: { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player' } }),
+    );
+
+    expect((getByLabelText('Player (current)') as HTMLInputElement).checked).toBe(true);
+    expect((getByLabelText('GM') as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('submits the newly selected bucket key when confirmed', async () => {
+    const signup = buildSignup({ bucket: { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player' } });
+    const mutationMock: MockLink.MockedResponse<ChangeSignupBucketMutationData> = {
+      request: {
+        query: ChangeSignupBucketDocument,
+        variables: { signupId: '1', bucketKey: 'gm' },
+      },
+      result: { data: buildMutationData(signup, { id: '2', key: 'gm' }) },
+    };
+
+    const { getByLabelText, getByRole, queryByRole } = await renderChangeBucketModal(signup, [mutationMock]);
+
+    fireEvent.click(getByLabelText('GM'));
+    fireEvent.click(getByRole('button', { name: 'OK' }));
+
+    // A successful submit navigates away, unmounting the modal's OK button -- if the fetcher had
+    // instead submitted a mismatched bucketKey (e.g. an id instead of a key), MockLink would have
+    // no matching mock, the action would return an error, and the button would stay put.
+    await waitFor(() => expect(queryByRole('button', { name: 'OK' })).toBeFalsy());
+  });
+});

--- a/test/javascript/EventsApp/SignupAdmin/$id/route.test.tsx
+++ b/test/javascript/EventsApp/SignupAdmin/$id/route.test.tsx
@@ -1,0 +1,166 @@
+import { MockLink } from '@apollo/client/testing';
+
+import { renderRoute, waitFor } from '../../../testUtils';
+import { Component as EditSignup } from '../../../../../app/javascript/EventsApp/SignupAdmin/$id/route';
+import { singleSignupLoader } from '../../../../../app/javascript/EventsApp/SignupAdmin/loaders';
+import {
+  AdminSignupQueryData,
+  AdminSignupQueryDocument,
+} from '../../../../../app/javascript/EventsApp/SignupAdmin/queries.generated';
+import {
+  SignupAutomationMode,
+  SignupMode,
+  SignupState,
+  SiteMode,
+  TicketMode,
+  TimezoneMode,
+} from '../../../../../app/javascript/graphqlTypes.generated';
+import { NamedRoute } from '../../../../../app/javascript/AppRouter';
+
+describe('EditSignup', () => {
+  type Signup = AdminSignupQueryData['convention']['signup'];
+
+  const buildSignup = (overrides: Partial<Signup> = {}): Signup => ({
+    __typename: 'Signup',
+    id: '1',
+    state: SignupState.Confirmed,
+    counted: true,
+    bucket: { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player' },
+    requested_bucket: { __typename: 'RegistrationPolicyBucket', id: '1' },
+    run: {
+      __typename: 'Run',
+      id: '1',
+      title_suffix: null,
+      starts_at: '2025-01-01T19:00:00Z',
+      ends_at: '2025-01-01T23:00:00Z',
+      rooms: [],
+      event: {
+        __typename: 'Event',
+        id: '1',
+        title: 'Test Event',
+        event_category: { __typename: 'EventCategory', id: '1', team_member_name: 'GM', teamMemberNamePlural: 'GMs' },
+        registration_policy: {
+          __typename: 'RegistrationPolicy',
+          buckets: [
+            { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player', name: 'Player', anything: false },
+            { __typename: 'RegistrationPolicyBucket', id: '2', key: 'gm', name: 'GM', anything: false },
+          ],
+        },
+        team_members: [],
+      },
+    },
+    user_con_profile: {
+      __typename: 'UserConProfile',
+      id: '1',
+      name_without_nickname: 'Test User',
+      nickname: null,
+      birth_date: null,
+      email: null,
+      address: null,
+      city: null,
+      state: null,
+      zipcode: null,
+      country: null,
+      mobile_phone: null,
+      gravatar_enabled: false,
+      gravatar_url: '',
+    },
+    ...overrides,
+  });
+
+  const buildQueryData = (signup: Signup): AdminSignupQueryData => ({
+    __typename: 'Query',
+    currentAbility: {
+      __typename: 'Ability',
+      can_update_bucket_signup: true,
+      can_force_confirm_signup: true,
+      can_update_counted_signup: true,
+    },
+    convention: {
+      __typename: 'Convention',
+      id: '1',
+      name: 'Test Convention',
+      starts_at: null,
+      ends_at: null,
+      signup_mode: SignupMode.Moderated,
+      signup_automation_mode: SignupAutomationMode.RankedChoice,
+      site_mode: SiteMode.Convention,
+      timezone_name: 'America/New_York',
+      timezone_mode: TimezoneMode.ConventionLocal,
+      ticket_name: 'ticket',
+      ticket_mode: TicketMode.Disabled,
+      event_categories: [],
+      signup: signup,
+    },
+  });
+
+  const renderEditSignup = async (signup: Signup) => {
+    const mocks: MockLink.MockedResponse<AdminSignupQueryData>[] = [
+      {
+        request: { query: AdminSignupQueryDocument, variables: { id: '1' } },
+        result: { data: buildQueryData(signup) },
+      },
+    ];
+
+    const result = await renderRoute(
+      [
+        {
+          path: '/events/:eventId/runs/:runId/admin_signups/:id',
+          id: NamedRoute.EditSignup,
+          loader: singleSignupLoader,
+          Component: EditSignup,
+        },
+      ],
+      { apolloMocks: mocks, initialEntries: ['/events/1/runs/1/admin_signups/1'] },
+    );
+
+    await waitFor(() => expect(result.getByText(/Signup bucket:/)).toBeTruthy());
+    return result;
+  };
+
+  it('shows just the bucket name when the current and requested buckets match by id', async () => {
+    const { container } = await renderEditSignup(
+      buildSignup({
+        bucket: { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player' },
+        requested_bucket: { __typename: 'RegistrationPolicyBucket', id: '1' },
+      }),
+    );
+
+    expect(container.textContent).toContain('Signup bucket: Player');
+    expect(container.textContent).not.toContain('requested');
+  });
+
+  it('shows the requested bucket name when it differs from the current bucket, matched by id', async () => {
+    const { container } = await renderEditSignup(
+      buildSignup({
+        bucket: { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player' },
+        requested_bucket: { __typename: 'RegistrationPolicyBucket', id: '2' },
+      }),
+    );
+
+    expect(container.textContent).toContain('Signup bucket: Player (requested GM)');
+  });
+
+  it('shows no preference when there is no current or requested bucket and no team member', async () => {
+    const { container } = await renderEditSignup(
+      buildSignup({
+        bucket: null,
+        requested_bucket: null,
+      }),
+    );
+
+    expect(container.textContent).toContain('Signup bucket: none (no preference)');
+  });
+
+  it('shows the change-bucket link for a confirmed signup when the ability allows it', async () => {
+    const { getByLabelText } = await renderEditSignup(buildSignup({ state: SignupState.Confirmed }));
+
+    expect(getByLabelText('Change signup bucket')).toBeTruthy();
+  });
+
+  it('does not show the change-bucket link for a waitlisted signup', async () => {
+    const { queryByLabelText } = await renderEditSignup(buildSignup({ state: SignupState.Waitlisted }));
+
+    expect(queryByLabelText('Change signup bucket')).toBeFalsy();
+  });
+});

--- a/test/javascript/EventsApp/SignupAdmin/BucketInput.test.tsx
+++ b/test/javascript/EventsApp/SignupAdmin/BucketInput.test.tsx
@@ -1,0 +1,107 @@
+import { vi } from 'vitest';
+
+import { render } from '../../testUtils';
+import BucketInput from '../../../../app/javascript/EventsApp/SignupAdmin/BucketInput';
+import { SignupFieldsFragment } from '../../../../app/javascript/EventsApp/SignupAdmin/queries.generated';
+import { SignupState } from '../../../../app/javascript/graphqlTypes.generated';
+
+describe('BucketInput', () => {
+  const buildSignup = (overrides: Partial<SignupFieldsFragment> = {}): SignupFieldsFragment => ({
+    __typename: 'Signup',
+    id: '1',
+    state: SignupState.Confirmed,
+    counted: true,
+    bucket: { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player' },
+    requested_bucket: { __typename: 'RegistrationPolicyBucket', id: '1' },
+    run: {
+      __typename: 'Run',
+      id: '1',
+      title_suffix: null,
+      starts_at: '2025-01-01T19:00:00Z',
+      ends_at: '2025-01-01T23:00:00Z',
+      rooms: [],
+      event: {
+        __typename: 'Event',
+        id: '1',
+        title: 'Test Event',
+        event_category: { __typename: 'EventCategory', id: '1', team_member_name: 'GM', teamMemberNamePlural: 'GMs' },
+        registration_policy: {
+          __typename: 'RegistrationPolicy',
+          buckets: [
+            { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player', name: 'Player', anything: false },
+            { __typename: 'RegistrationPolicyBucket', id: '2', key: 'gm', name: 'GM', anything: false },
+            { __typename: 'RegistrationPolicyBucket', id: '3', key: 'flex', name: 'Flex', anything: true },
+          ],
+        },
+        team_members: [],
+      },
+    },
+    user_con_profile: {
+      __typename: 'UserConProfile',
+      id: '1',
+      name_without_nickname: 'Test User',
+      nickname: null,
+      birth_date: null,
+      email: null,
+      address: null,
+      city: null,
+      state: null,
+      zipcode: null,
+      country: null,
+      mobile_phone: null,
+      gravatar_enabled: false,
+      gravatar_url: '',
+    },
+    ...overrides,
+  });
+
+  it('labels the bucket the signup currently occupies and the one it requested, matching by id', async () => {
+    // bucket.key ("player") intentionally does not match requested_bucket's id (1) by key, to
+    // confirm this matches by id and not by any key-based coincidence.
+    const signup = buildSignup({
+      bucket: { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player' },
+      requested_bucket: { __typename: 'RegistrationPolicyBucket', id: '2' },
+    });
+    const { getByLabelText } = await render(
+      <BucketInput signup={signup} value={null} onChange={vi.fn()} caption="Bucket" />,
+    );
+
+    expect(getByLabelText('Player (current)')).toBeTruthy();
+    expect(getByLabelText('GM (user requested)')).toBeTruthy();
+    expect(getByLabelText('Flex')).toBeTruthy();
+  });
+
+  it('disables the bucket the signup already occupies', async () => {
+    const signup = buildSignup({
+      bucket: { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player' },
+      requested_bucket: null,
+    });
+    const { getByLabelText } = await render(
+      <BucketInput signup={signup} value={null} onChange={vi.fn()} caption="Bucket" />,
+    );
+
+    expect(getByLabelText('Player (current)')).toBeDisabled();
+    expect(getByLabelText('GM')).not.toBeDisabled();
+  });
+
+  it('disables the anything bucket once the signup is already in any bucket', async () => {
+    const signup = buildSignup({
+      bucket: { __typename: 'RegistrationPolicyBucket', id: '2', key: 'gm' },
+      requested_bucket: null,
+    });
+    const { getByLabelText } = await render(
+      <BucketInput signup={signup} value={null} onChange={vi.fn()} caption="Bucket" />,
+    );
+
+    expect(getByLabelText('Flex')).toBeDisabled();
+  });
+
+  it('does not disable the anything bucket for a signup with no current bucket', async () => {
+    const signup = buildSignup({ bucket: null, requested_bucket: null });
+    const { getByLabelText } = await render(
+      <BucketInput signup={signup} value={null} onChange={vi.fn()} caption="Bucket" />,
+    );
+
+    expect(getByLabelText('Flex')).not.toBeDisabled();
+  });
+});

--- a/test/javascript/EventsApp/SignupAdmin/RunEmailList.test.tsx
+++ b/test/javascript/EventsApp/SignupAdmin/RunEmailList.test.tsx
@@ -1,0 +1,154 @@
+import { MockLink } from '@apollo/client/testing';
+
+import { renderRoute, waitFor } from '../../testUtils';
+import { Component as RunEmailList, loader } from '../../../../app/javascript/EventsApp/SignupAdmin/RunEmailList';
+import {
+  RunSignupsTableSignupsQueryData,
+  RunSignupsTableSignupsQueryDocument,
+} from '../../../../app/javascript/EventsApp/SignupAdmin/queries.generated';
+import { SignupState } from '../../../../app/javascript/graphqlTypes.generated';
+
+describe('RunEmailList', () => {
+  type Entry = RunSignupsTableSignupsQueryData['convention']['event']['run']['signups_paginated']['entries'][number];
+
+  const buildSignup = (overrides: Partial<Entry>): Entry => ({
+    __typename: 'Signup',
+    id: '1',
+    state: SignupState.Confirmed,
+    counted: true,
+    age_restrictions_check: 'OK',
+    bucket: null,
+    requested_bucket: null,
+    run: { __typename: 'Run', id: '1', starts_at: '2025-01-01T19:00:00Z' },
+    user_con_profile: {
+      __typename: 'UserConProfile',
+      id: '1',
+      name_inverted: 'One, Player',
+      name_without_nickname: 'Player One',
+      gravatar_enabled: false,
+      gravatar_url: '',
+      email: 'player-one@example.com',
+      birth_date: null,
+    },
+    ...overrides,
+  });
+
+  const buildQueryData = (entries: Entry[]): RunSignupsTableSignupsQueryData => ({
+    __typename: 'Query',
+    convention: {
+      __typename: 'Convention',
+      id: '1',
+      name: 'Test Convention',
+      event: {
+        __typename: 'Event',
+        id: '1',
+        title: 'Test Event',
+        event_category: { __typename: 'EventCategory', id: '1', team_member_name: 'GM', teamMemberNamePlural: 'GMs' },
+        team_members: [],
+        registration_policy: {
+          __typename: 'RegistrationPolicy',
+          buckets: [{ __typename: 'RegistrationPolicyBucket', id: '1', key: 'player', name: 'Player' }],
+        },
+        run: {
+          __typename: 'Run',
+          id: '1',
+          signups_paginated: {
+            __typename: 'SignupsPagination',
+            total_entries: entries.length,
+            total_pages: 1,
+            current_page: 1,
+            per_page: 100,
+            entries,
+          },
+        },
+      },
+    },
+  });
+
+  const renderRunEmailList = async (entries: Entry[]) => {
+    const mocks: MockLink.MockedResponse<RunSignupsTableSignupsQueryData>[] = [
+      {
+        request: {
+          query: RunSignupsTableSignupsQueryDocument,
+          variables: {
+            eventId: '1',
+            runId: '1',
+            filters: { state: ['confirmed', 'waitlisted'] },
+            sort: [{ field: 'id', desc: false }],
+            perPage: 100,
+          },
+        },
+        result: { data: buildQueryData(entries) },
+      },
+    ];
+
+    const result = await renderRoute(
+      [
+        {
+          path: '/events/:eventId/runs/:runId/emails/:separator',
+          loader,
+          Component: RunEmailList,
+        },
+      ],
+      { apolloMocks: mocks, initialEntries: ['/events/1/runs/1/emails/comma'] },
+    );
+
+    await waitFor(() => expect(result.getByLabelText('Email addresses')).toBeTruthy());
+    return result;
+  };
+
+  it('includes a confirmed signup whose bucket id matches a bucket in the registration policy', async () => {
+    const { getByLabelText } = await renderRunEmailList([
+      buildSignup({ bucket: { __typename: 'RegistrationPolicyBucket', id: '1' } }),
+    ]);
+
+    expect((getByLabelText('Email addresses') as HTMLTextAreaElement).value).toContain('player-one@example.com');
+  });
+
+  it('excludes a confirmed signup whose bucket id does not match any known bucket', async () => {
+    const { getByLabelText } = await renderRunEmailList([
+      buildSignup({ bucket: { __typename: 'RegistrationPolicyBucket', id: 'unknown-bucket' } }),
+    ]);
+
+    expect((getByLabelText('Email addresses') as HTMLTextAreaElement).value).not.toContain('player-one@example.com');
+  });
+
+  it('excludes a non-team-member waitlisted signup by default', async () => {
+    const { getByLabelText } = await renderRunEmailList([buildSignup({ state: SignupState.Waitlisted, bucket: null })]);
+
+    expect((getByLabelText('Email addresses') as HTMLTextAreaElement).value).not.toContain('player-one@example.com');
+  });
+
+  it('includes a team member regardless of bucket', async () => {
+    const data = buildQueryData([
+      buildSignup({ bucket: { __typename: 'RegistrationPolicyBucket', id: 'unknown-bucket' } }),
+    ]);
+    data.convention.event.team_members = [
+      { __typename: 'TeamMember', id: '1', user_con_profile: { __typename: 'UserConProfile', id: '1' } },
+    ];
+
+    const mocks: MockLink.MockedResponse<RunSignupsTableSignupsQueryData>[] = [
+      {
+        request: {
+          query: RunSignupsTableSignupsQueryDocument,
+          variables: {
+            eventId: '1',
+            runId: '1',
+            filters: { state: ['confirmed', 'waitlisted'] },
+            sort: [{ field: 'id', desc: false }],
+            perPage: 100,
+          },
+        },
+        result: { data },
+      },
+    ];
+
+    const result = await renderRoute(
+      [{ path: '/events/:eventId/runs/:runId/emails/:separator', loader, Component: RunEmailList }],
+      { apolloMocks: mocks, initialEntries: ['/events/1/runs/1/emails/comma'] },
+    );
+    await waitFor(() => expect(result.getByLabelText('Email addresses')).toBeTruthy());
+
+    expect((result.getByLabelText('Email addresses') as HTMLTextAreaElement).value).toContain('player-one@example.com');
+  });
+});

--- a/test/javascript/EventsApp/SignupAdmin/RunSignupSummary.test.tsx
+++ b/test/javascript/EventsApp/SignupAdmin/RunSignupSummary.test.tsx
@@ -1,0 +1,147 @@
+import { MockLink } from '@apollo/client/testing';
+
+import { renderRoute, waitFor } from '../../testUtils';
+import {
+  Component as RunSignupSummary,
+  loader,
+} from '../../../../app/javascript/EventsApp/SignupAdmin/RunSignupSummary';
+import {
+  RunSignupSummaryQueryData,
+  RunSignupSummaryQueryDocument,
+} from '../../../../app/javascript/EventsApp/SignupAdmin/queries.generated';
+import {
+  SignupAutomationMode,
+  SignupMode,
+  SignupState,
+  SiteMode,
+  TicketMode,
+  TimezoneMode,
+} from '../../../../app/javascript/graphqlTypes.generated';
+
+describe('RunSignupSummary', () => {
+  const buildQueryData = (
+    entries: RunSignupSummaryQueryData['convention']['event']['run']['signups_paginated']['entries'],
+  ): RunSignupSummaryQueryData => ({
+    __typename: 'Query',
+    currentAbility: { __typename: 'Ability', can_read_schedule: true },
+    convention: {
+      __typename: 'Convention',
+      id: '1',
+      name: 'Test Convention',
+      starts_at: null,
+      ends_at: null,
+      signup_mode: SignupMode.Moderated,
+      signup_automation_mode: SignupAutomationMode.RankedChoice,
+      site_mode: SiteMode.Convention,
+      timezone_name: 'America/New_York',
+      timezone_mode: TimezoneMode.ConventionLocal,
+      ticket_name: 'ticket',
+      ticket_mode: TicketMode.Disabled,
+      event_categories: [],
+      event: {
+        __typename: 'Event',
+        id: '1',
+        title: 'Test Event',
+        event_category: { __typename: 'EventCategory', id: '1', team_member_name: 'GM' },
+        registration_policy: {
+          __typename: 'RegistrationPolicy',
+          buckets: [
+            { __typename: 'RegistrationPolicyBucket', id: '1', key: 'player', name: 'Player', expose_attendees: true },
+          ],
+        },
+        team_members: [],
+        runs: [{ __typename: 'Run', id: '1', starts_at: '2025-01-01T19:00:00Z' }],
+        run: {
+          __typename: 'Run',
+          id: '1',
+          signups_paginated: { __typename: 'SignupsPagination', entries },
+        },
+      },
+    },
+  });
+
+  const renderRunSignupSummary = async (
+    entries: RunSignupSummaryQueryData['convention']['event']['run']['signups_paginated']['entries'],
+  ) => {
+    const mocks: MockLink.MockedResponse<RunSignupSummaryQueryData>[] = [
+      {
+        request: { query: RunSignupSummaryQueryDocument, variables: { eventId: '1', runId: '1' } },
+        result: { data: buildQueryData(entries) },
+      },
+    ];
+
+    const result = await renderRoute(
+      [
+        {
+          path: '/events/:eventId/runs/:runId/signup_summary',
+          loader,
+          Component: RunSignupSummary,
+        },
+      ],
+      { apolloMocks: mocks, initialEntries: ['/events/1/runs/1/signup_summary'] },
+    );
+
+    await waitFor(() => expect(result.getByRole('table')).toBeTruthy());
+    return result;
+  };
+
+  it('lists confirmed and waitlisted signups', async () => {
+    const { getByText } = await renderRunSignupSummary([
+      {
+        __typename: 'Signup',
+        id: '1',
+        state: SignupState.Confirmed,
+        waitlist_position: null,
+        bucket: { __typename: 'RegistrationPolicyBucket', id: '1' },
+        user_con_profile: {
+          __typename: 'UserConProfile',
+          id: '1',
+          name_inverted: 'One, Player',
+          gravatar_enabled: false,
+          gravatar_url: '',
+        },
+      },
+      {
+        __typename: 'Signup',
+        id: '2',
+        state: SignupState.Waitlisted,
+        waitlist_position: 1,
+        bucket: null,
+        user_con_profile: {
+          __typename: 'UserConProfile',
+          id: '2',
+          name_inverted: 'Two, Player',
+          gravatar_enabled: false,
+          gravatar_url: '',
+        },
+      },
+    ]);
+
+    expect(getByText('One, Player')).toBeTruthy();
+    expect(getByText('Two, Player')).toBeTruthy();
+    expect(getByText(/#1/)).toBeTruthy();
+  });
+
+  it('shows the bucket name suffix only for a bucket with expose_attendees, matched by id', async () => {
+    const { getByRole } = await renderRunSignupSummary([
+      {
+        __typename: 'Signup',
+        id: '1',
+        state: SignupState.Confirmed,
+        waitlist_position: null,
+        // key intentionally does not equal the registration policy's stored key, to confirm this
+        // is matched by id, not any key-based coincidence.
+        bucket: { __typename: 'RegistrationPolicyBucket', id: '1' },
+        user_con_profile: {
+          __typename: 'UserConProfile',
+          id: '1',
+          name_inverted: 'One, Player',
+          gravatar_enabled: false,
+          gravatar_url: '',
+        },
+      },
+    ]);
+
+    expect(getByRole('row', { name: /One, Player.*Confirmed \(Player\)/ })).toBeTruthy();
+  });
+});

--- a/test/javascript/EventsApp/SignupAdmin/RunSignupsTable.test.tsx
+++ b/test/javascript/EventsApp/SignupAdmin/RunSignupsTable.test.tsx
@@ -1,0 +1,138 @@
+import { Outlet } from 'react-router';
+import { MockLink } from '@apollo/client/testing';
+
+import { renderRoute, waitFor } from '../../testUtils';
+import { Component as RunSignupsTable } from '../../../../app/javascript/EventsApp/SignupAdmin/RunSignupsTable';
+import { signupAdminEventLoader } from '../../../../app/javascript/EventsApp/SignupAdmin/loaders';
+import {
+  SignupAdminEventQueryData,
+  SignupAdminEventQueryDocument,
+  RunSignupsTableSignupsQueryData,
+  RunSignupsTableSignupsQueryDocument,
+} from '../../../../app/javascript/EventsApp/SignupAdmin/queries.generated';
+import {
+  SignupAutomationMode,
+  SignupMode,
+  SignupState,
+  SiteMode,
+  TicketMode,
+  TimezoneMode,
+} from '../../../../app/javascript/graphqlTypes.generated';
+import { NamedRoute } from '../../../../app/javascript/AppRouter';
+
+describe('RunSignupsTable', () => {
+  beforeEach(() => {
+    // useLocalStorageReactTable persists pageSize across tests in the same file otherwise, making
+    // the default per_page variable non-deterministic.
+    window.localStorage.clear();
+  });
+
+  const buildEventLoaderData = (): SignupAdminEventQueryData => ({
+    __typename: 'Query',
+    convention: {
+      __typename: 'Convention',
+      id: '1',
+      name: 'Test Convention',
+      starts_at: null,
+      ends_at: null,
+      signup_mode: SignupMode.Moderated,
+      signup_automation_mode: SignupAutomationMode.RankedChoice,
+      site_mode: SiteMode.Convention,
+      timezone_name: 'America/New_York',
+      timezone_mode: TimezoneMode.ConventionLocal,
+      ticket_name: 'ticket',
+      ticket_mode: TicketMode.Disabled,
+      event_categories: [],
+      event: { __typename: 'Event', id: '1', title: 'Test Event' },
+    },
+  });
+
+  const buildSignupsQueryData = (
+    entries: RunSignupsTableSignupsQueryData['convention']['event']['run']['signups_paginated']['entries'],
+  ): RunSignupsTableSignupsQueryData => ({
+    __typename: 'Query',
+    convention: {
+      __typename: 'Convention',
+      id: '1',
+      name: 'Test Convention',
+      event: {
+        __typename: 'Event',
+        id: '1',
+        title: 'Test Event',
+        event_category: { __typename: 'EventCategory', id: '1', team_member_name: 'GM', teamMemberNamePlural: 'GMs' },
+        team_members: [],
+        registration_policy: {
+          __typename: 'RegistrationPolicy',
+          buckets: [{ __typename: 'RegistrationPolicyBucket', id: '1', key: 'player', name: 'Player' }],
+        },
+        run: {
+          __typename: 'Run',
+          id: '1',
+          signups_paginated: {
+            __typename: 'SignupsPagination',
+            total_entries: entries.length,
+            total_pages: 1,
+            current_page: 1,
+            per_page: 20,
+            entries,
+          },
+        },
+      },
+    },
+  });
+
+  it("shows a signup's bucket name, matched by id, in the default (unsorted, unfiltered) view", async () => {
+    const eventMock: MockLink.MockedResponse<SignupAdminEventQueryData> = {
+      request: { query: SignupAdminEventQueryDocument, variables: { eventId: '1' } },
+      result: { data: buildEventLoaderData() },
+    };
+    const signupsMock: MockLink.MockedResponse<RunSignupsTableSignupsQueryData> = {
+      request: {
+        query: RunSignupsTableSignupsQueryDocument,
+        variables: { eventId: '1', runId: '1', page: 1, perPage: 20, filters: {}, sort: [] },
+      },
+      result: {
+        data: buildSignupsQueryData([
+          {
+            __typename: 'Signup',
+            id: '1',
+            state: SignupState.Confirmed,
+            counted: true,
+            age_restrictions_check: 'OK',
+            // key intentionally does not match the registration policy's stored key, to confirm
+            // this is matched by id, not any key-based coincidence.
+            bucket: { __typename: 'RegistrationPolicyBucket', id: '1' },
+            requested_bucket: null,
+            run: { __typename: 'Run', id: '1', starts_at: '2025-01-01T19:00:00Z' },
+            user_con_profile: {
+              __typename: 'UserConProfile',
+              id: '1',
+              name_inverted: 'One, Player',
+              name_without_nickname: 'Player One',
+              gravatar_enabled: false,
+              gravatar_url: '',
+              email: 'player-one@example.com',
+              birth_date: '2000-01-01',
+            },
+          },
+        ]),
+      },
+    };
+
+    const result = await renderRoute(
+      [
+        {
+          path: '/events/:eventId/runs/:runId/admin_signups',
+          id: NamedRoute.SignupAdmin,
+          loader: signupAdminEventLoader,
+          Component: () => <Outlet />,
+          children: [{ index: true, Component: RunSignupsTable }],
+        },
+      ],
+      { apolloMocks: [eventMock, signupsMock], initialEntries: ['/events/1/runs/1/admin_signups'] },
+    );
+
+    await waitFor(() => expect(result.getByText('One, Player')).toBeTruthy());
+    expect(result.getByRole('row', { name: /One, Player.*Player/ })).toBeTruthy();
+  });
+});

--- a/test/javascript/EventsApp/SignupAdmin/SignupUtils.test.ts
+++ b/test/javascript/EventsApp/SignupAdmin/SignupUtils.test.ts
@@ -1,0 +1,173 @@
+import getI18n from '../../../../app/javascript/setupI18Next';
+import {
+  findBucket,
+  formatBucket,
+  formatSignupState,
+  formatSignupStatus,
+  EventForFormatBucket,
+  SignupForFormatBucket,
+} from '../../../../app/javascript/EventsApp/SignupAdmin/SignupUtils';
+import { SignupState } from '../../../../app/javascript/graphqlTypes.generated';
+import { TFunction } from 'i18next';
+
+describe('SignupUtils', () => {
+  let t: TFunction;
+
+  beforeAll(async () => {
+    t = (await getI18n()).getFixedT('en');
+  });
+
+  const playerBucket = { id: '1', name: 'Player' };
+  const gmBucket = { id: '2', name: 'GM' };
+
+  const registrationPolicy = { buckets: [playerBucket, gmBucket] };
+
+  const defaultEvent: EventForFormatBucket = {
+    event_category: { team_member_name: 'GM' },
+    registration_policy: registrationPolicy,
+    team_members: [],
+  };
+
+  const defaultSignup: SignupForFormatBucket = {
+    counted: true,
+    state: SignupState.Confirmed,
+    bucket: null,
+    requested_bucket: null,
+    user_con_profile: { id: 'u1' },
+  };
+
+  describe('findBucket', () => {
+    it('finds a bucket by id', () => {
+      expect(findBucket('1', registrationPolicy)).toEqual(playerBucket);
+      expect(findBucket('2', registrationPolicy)).toEqual(gmBucket);
+    });
+
+    it('does not match a bucket with a different id, even if other buckets could be confused by name', () => {
+      // Two buckets can legitimately share a display name once matching is purely id-based (see
+      // #11892) -- this must never accidentally match the wrong one.
+      const buckets = [
+        { id: '1', name: 'Custom 1' },
+        { id: '2', name: 'Custom 1' },
+      ];
+      expect(findBucket('1', { buckets })).toBe(buckets[0]);
+      expect(findBucket('2', { buckets })).toBe(buckets[1]);
+    });
+
+    it('returns undefined for an id with no match', () => {
+      expect(findBucket('nonexistent', registrationPolicy)).toBeUndefined();
+    });
+
+    it('returns undefined for a null or undefined id', () => {
+      expect(findBucket(null, registrationPolicy)).toBeUndefined();
+      expect(findBucket(undefined, registrationPolicy)).toBeUndefined();
+    });
+  });
+
+  describe('formatBucket', () => {
+    it('shows withdrawn for a withdrawn signup, regardless of bucket', () => {
+      const signup = { ...defaultSignup, state: SignupState.Withdrawn, bucket: playerBucket };
+      expect(formatBucket(signup, defaultEvent, t)).toEqual('Withdrawn');
+    });
+
+    describe('when not counted', () => {
+      it('shows the bucket name with a not-counted suffix, when in a bucket', () => {
+        const signup = { ...defaultSignup, counted: false, bucket: { id: '1' } };
+        expect(formatBucket(signup, defaultEvent, t)).toEqual('Player (not counted)');
+      });
+
+      it('shows a team-member label for a not-counted team member with no bucket', () => {
+        const signup = { ...defaultSignup, counted: false, bucket: null, user_con_profile: { id: 'gm1' } };
+        const event: EventForFormatBucket = {
+          ...defaultEvent,
+          team_members: [{ user_con_profile: { id: 'gm1' } }],
+        };
+        expect(formatBucket(signup, event, t)).toEqual('Gm (not counted)');
+      });
+
+      it('shows the requested bucket for a not-counted waitlisted signup, when one is found by id', () => {
+        const signup = {
+          ...defaultSignup,
+          counted: false,
+          state: SignupState.Waitlisted,
+          bucket: null,
+          requested_bucket: { id: '2' },
+        };
+        expect(formatBucket(signup, defaultEvent, t)).toEqual('Waitlisted (requested GM)');
+      });
+
+      it('shows no-preference for a not-counted waitlisted signup with an unresolvable requested bucket', () => {
+        const signup = {
+          ...defaultSignup,
+          counted: false,
+          state: SignupState.Waitlisted,
+          bucket: null,
+          requested_bucket: { id: 'removed-bucket' },
+        };
+        expect(formatBucket(signup, defaultEvent, t)).toEqual('Waitlisted (no preference)');
+      });
+
+      it('falls back to a plain not-counted label otherwise', () => {
+        const signup = { ...defaultSignup, counted: false, state: SignupState.Confirmed, bucket: null };
+        expect(formatBucket(signup, defaultEvent, t)).toEqual('Not counted');
+      });
+    });
+
+    describe('when counted', () => {
+      it('shows just the bucket name when the current and requested buckets match by id', () => {
+        const signup = { ...defaultSignup, bucket: { id: '1' }, requested_bucket: { id: '1' } };
+        expect(formatBucket(signup, defaultEvent, t)).toEqual('Player');
+      });
+
+      it('shows both bucket and requested bucket when they resolve to different buckets', () => {
+        const signup = { ...defaultSignup, bucket: { id: '1' }, requested_bucket: { id: '2' } };
+        expect(formatBucket(signup, defaultEvent, t)).toEqual('Player (requested GM)');
+      });
+
+      it('shows the requested bucket alone, with a placeholder bucket name, when there is no current bucket', () => {
+        const signup = { ...defaultSignup, bucket: null, requested_bucket: { id: '2' } };
+        expect(formatBucket(signup, defaultEvent, t)).toEqual('None (requested GM)');
+      });
+
+      it('shows the bucket with a no-preference suffix when there is no requested bucket', () => {
+        const signup = { ...defaultSignup, bucket: { id: '1' }, requested_bucket: null };
+        expect(formatBucket(signup, defaultEvent, t)).toEqual('Player (no preference)');
+      });
+
+      it('shows a placeholder when neither bucket resolves', () => {
+        const signup = { ...defaultSignup, bucket: null, requested_bucket: null };
+        expect(formatBucket(signup, defaultEvent, t)).toEqual('None');
+      });
+    });
+  });
+
+  describe('formatSignupState', () => {
+    it('formats each known state', () => {
+      expect(formatSignupState(SignupState.Confirmed, t)).toEqual('Confirmed');
+      expect(formatSignupState(SignupState.Waitlisted, t)).toEqual('Waitlisted');
+      expect(formatSignupState(SignupState.Withdrawn, t)).toEqual('Withdrawn');
+      expect(formatSignupState(SignupState.TicketPurchaseHold, t)).toEqual('Held pending {{ ticketName }} purchase');
+    });
+
+    it('formats a null or undefined state as not signed up', () => {
+      expect(formatSignupState(null, t)).toEqual('Not signed up');
+      expect(formatSignupState(undefined, t)).toEqual('Not signed up');
+    });
+  });
+
+  describe('formatSignupStatus', () => {
+    it('delegates to formatBucket for a confirmed signup', () => {
+      const signup = { ...defaultSignup, state: SignupState.Confirmed, bucket: { id: '1' } };
+      expect(formatSignupStatus(signup, defaultEvent, t)).toEqual('Player (no preference)');
+    });
+
+    it('shows the state with a requested bucket, for a non-confirmed signup with one resolvable by id', () => {
+      const signup = { ...defaultSignup, state: SignupState.Waitlisted, requested_bucket: { id: '2' } };
+      expect(formatSignupStatus(signup, defaultEvent, t)).toEqual('Waitlisted (requested GM)');
+    });
+
+    it('shows just the state when the requested bucket cannot be resolved', () => {
+      const signup = { ...defaultSignup, state: SignupState.Waitlisted, requested_bucket: { id: 'removed-bucket' } };
+      expect(formatSignupStatus(signup, defaultEvent, t)).toEqual('Waitlisted');
+    });
+  });
+});

--- a/test/javascript/RegistrationPolicy/RegistrationPolicyEditor.test.tsx
+++ b/test/javascript/RegistrationPolicy/RegistrationPolicyEditor.test.tsx
@@ -90,6 +90,10 @@ describe('RegistrationPolicyEditor', () => {
     const newPolicy = onChange.mock.calls[0][0];
     expect(newPolicy.buckets.length).toEqual(2);
     expect(newPolicy.buckets.map((bucket) => bucket.anything)).toEqual([false, false]);
+    // A freshly-added bucket has no real id yet -- a fabricated one here would corrupt
+    // RegistrationPolicy#sync_buckets_from_hash!'s id-based correlation on save (see #11895/#11897).
+    expect(newPolicy.buckets[1].id).toBeUndefined();
+    expect(newPolicy.buckets[1].generatedId).toBeTruthy();
   });
 
   test('add flex bucket', async () => {
@@ -98,6 +102,8 @@ describe('RegistrationPolicyEditor', () => {
     const newPolicy = onChange.mock.calls[0][0];
     expect(newPolicy.buckets.length).toEqual(2);
     expect(newPolicy.buckets.map((bucket) => bucket.anything)).toEqual([false, true]);
+    expect(newPolicy.buckets[1].id).toBeUndefined();
+    expect(newPolicy.buckets[1].generatedId).toBeTruthy();
   });
 
   test('delete bucket', async () => {
@@ -114,6 +120,10 @@ describe('RegistrationPolicyEditor', () => {
     fireEvent.change(getByLabelText('Min'), { target: { value: '1' } });
     const newPolicy = onChange.mock.calls[0][0];
     expect(newPolicy.buckets[0].minimum_slots).toEqual(1);
+    // Editing a bucket must not lose the real id it entered the editor with -- that id is how the
+    // backend correlates this bucket back to its existing row (see #11895/#11897).
+    expect(newPolicy.buckets[0].id).toEqual('testBucket');
+    expect(newPolicy.buckets[0].generatedId).toEqual('testBucket');
   });
 
   describe('with presets', () => {

--- a/test/javascript/SignupModeration/CreateSignupRunCard.test.tsx
+++ b/test/javascript/SignupModeration/CreateSignupRunCard.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent } from '@testing-library/react';
+import { MockLink } from '@apollo/client/testing';
+import { vi } from 'vitest';
+
+import { render, waitFor } from '../testUtils';
+import CreateSignupRunCard from '../../../app/javascript/SignupModeration/CreateSignupRunCard';
+import {
+  CreateSignupRunCardQueryData,
+  CreateSignupRunCardQueryDocument,
+} from '../../../app/javascript/SignupModeration/queries.generated';
+import {
+  CreateUserSignupDocument,
+  CreateUserSignupMutationData,
+} from '../../../app/javascript/SignupModeration/mutations.generated';
+import { SignupMode } from '../../../app/javascript/graphqlTypes.generated';
+
+describe('CreateSignupRunCard', () => {
+  const buildQueryData = (): CreateSignupRunCardQueryData => ({
+    __typename: 'Query',
+    currentAbility: {
+      __typename: 'Ability',
+      can_read_schedule: true,
+      can_read_event_signups: true,
+      can_update_event: false,
+    },
+    convention: {
+      __typename: 'Convention',
+      id: '1',
+      signup_rounds: [],
+      event: {
+        __typename: 'Event',
+        id: '1',
+        title: 'Test Event',
+        length_seconds: 14400,
+        private_signup_list: false,
+        can_play_concurrently: false,
+        registration_policy: {
+          __typename: 'RegistrationPolicy',
+          slots_limited: true,
+          prevent_no_preference_signups: false,
+          total_slots_including_not_counted: 10,
+          buckets: [
+            {
+              __typename: 'RegistrationPolicyBucket',
+              id: '1',
+              key: 'player',
+              name: 'Player',
+              description: 'Regular player',
+              not_counted: false,
+              slots_limited: true,
+              anything: false,
+              minimum_slots: 0,
+              total_slots: 10,
+            },
+          ],
+        },
+        team_members: [],
+        event_category: { __typename: 'EventCategory', id: '1', team_member_name: 'GM', teamMemberNamePlural: 'GMs' },
+        runs: [
+          {
+            __typename: 'Run',
+            id: '1',
+            title_suffix: 'Friday Night',
+            starts_at: '2025-01-01T19:00:00Z',
+            current_ability_can_signup_summary_run: false,
+            grouped_signup_counts: [],
+            rooms: [],
+            my_signups: [],
+            my_signup_requests: [],
+            my_signup_ranked_choices: [],
+          },
+        ],
+        ticket_types: [],
+      },
+      user_con_profile: {
+        __typename: 'UserConProfile',
+        id: '2',
+        name_without_nickname: 'Test User',
+        signups: [],
+        signup_constraints: { __typename: 'UserSignupConstraints', at_maximum_signups: false },
+        signup_requests: [],
+      },
+    },
+  });
+
+  it('signs up for the specific bucket that was clicked, submitting its id, not its key', async () => {
+    const queryMock: MockLink.MockedResponse<CreateSignupRunCardQueryData> = {
+      request: { query: CreateSignupRunCardQueryDocument, variables: { userConProfileId: '2', eventId: '1' } },
+      result: { data: buildQueryData() },
+    };
+
+    const mutationCalled = vi.fn();
+    const createSignupMock: MockLink.MockedResponse<CreateUserSignupMutationData> = {
+      request: {
+        query: CreateUserSignupDocument,
+        variables: { runId: '1', userConProfileId: '2', requestedBucketId: '1', noRequestedBucket: false },
+      },
+      result: () => {
+        mutationCalled();
+        return {
+          data: {
+            __typename: 'Mutation',
+            createUserSignup: { __typename: 'CreateUserSignupPayload', clientMutationId: null },
+          },
+        };
+      },
+    };
+
+    // client.resetStore() after a successful signup refetches the active query.
+    const { getByRole } = await render(<CreateSignupRunCard eventId="1" runId="1" userConProfileId="2" />, {
+      apolloMocks: [queryMock, queryMock, createSignupMock],
+      appRootContextValue: { signupMode: SignupMode.Moderated },
+    });
+
+    const signupButton = await waitFor(() => getByRole('button', { name: /Sign up now/i }));
+    fireEvent.click(signupButton);
+
+    await waitFor(() => expect(mutationCalled).toHaveBeenCalledTimes(1));
+  });
+});

--- a/test/javascript/SignupModeration/SignupModerationQueue.test.tsx
+++ b/test/javascript/SignupModeration/SignupModerationQueue.test.tsx
@@ -1,0 +1,138 @@
+import { MockLink } from '@apollo/client/testing';
+
+import { renderRoute, waitFor } from '../testUtils';
+import {
+  Component as SignupModerationQueue,
+  loader,
+} from '../../../app/javascript/SignupModeration/SignupModerationQueue';
+import {
+  SignupModerationQueuePageQueryData,
+  SignupModerationQueuePageQueryDocument,
+  SignupModerationQueueQueryData,
+  SignupModerationQueueQueryDocument,
+  SignupModerationSignupRequestFieldsFragment,
+} from '../../../app/javascript/SignupModeration/queries.generated';
+import { SignupRequestState } from '../../../app/javascript/graphqlTypes.generated';
+
+describe('SignupModerationQueue', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  const buildPageLoaderData = (): SignupModerationQueuePageQueryData => ({
+    __typename: 'Query',
+    convention: { __typename: 'Convention', id: '1', signup_rounds: [] },
+  });
+
+  const buildSignupRequest = (requestedBucket: { id: string } | null): SignupModerationSignupRequestFieldsFragment => ({
+    __typename: 'SignupRequest',
+    id: '1',
+    state: SignupRequestState.Pending,
+    created_at: '2025-01-01T00:00:00Z',
+    requested_bucket: requestedBucket && { __typename: 'RegistrationPolicyBucket', id: requestedBucket.id },
+    user_con_profile: {
+      __typename: 'UserConProfile',
+      id: '1',
+      name: 'Test User',
+      name_inverted: 'User, Test',
+      name_without_nickname: 'Test User',
+      gravatar_enabled: false,
+      gravatar_url: '',
+    },
+    replace_signup: null,
+    result_signup: null,
+    signup_ranked_choice: null,
+    target_run: {
+      __typename: 'Run',
+      id: '1',
+      title_suffix: null,
+      starts_at: '2025-01-01T19:00:00Z',
+      event: {
+        __typename: 'Event',
+        id: '1',
+        title: 'Test Event',
+        length_seconds: 14400,
+        registration_policy: {
+          __typename: 'RegistrationPolicy',
+          prevent_no_preference_signups: false,
+          buckets: [
+            {
+              __typename: 'RegistrationPolicyBucket',
+              id: '1',
+              key: 'player',
+              name: 'Player',
+              total_slots: 10,
+              slots_limited: true,
+              anything: false,
+              not_counted: false,
+            },
+            {
+              __typename: 'RegistrationPolicyBucket',
+              id: '2',
+              key: 'gm',
+              name: 'GM',
+              total_slots: 2,
+              slots_limited: true,
+              anything: false,
+              not_counted: false,
+            },
+          ],
+        },
+      },
+      grouped_signup_counts: [],
+    },
+  });
+
+  const buildQueueQueryData = (
+    entries: SignupModerationSignupRequestFieldsFragment[],
+  ): SignupModerationQueueQueryData => ({
+    __typename: 'Query',
+    convention: {
+      __typename: 'Convention',
+      id: '1',
+      signup_requests_paginated: { __typename: 'SignupRequestsPagination', total_pages: 1, entries },
+    },
+  });
+
+  const renderQueue = async (requestedBucket: { id: string } | null) => {
+    const pageMock: MockLink.MockedResponse<SignupModerationQueuePageQueryData> = {
+      request: { query: SignupModerationQueuePageQueryDocument, variables: {} },
+      result: { data: buildPageLoaderData() },
+    };
+    const queueMock: MockLink.MockedResponse<SignupModerationQueueQueryData> = {
+      request: {
+        query: SignupModerationQueueQueryDocument,
+        variables: { page: 1, perPage: 20, filters: {}, sort: [] },
+      },
+      result: { data: buildQueueQueryData([buildSignupRequest(requestedBucket)]) },
+    };
+
+    const result = await renderRoute([{ path: '/signup_moderation/queue', loader, Component: SignupModerationQueue }], {
+      apolloMocks: [pageMock, queueMock],
+      initialEntries: ['/signup_moderation/queue'],
+    });
+
+    await waitFor(() => expect(result.getByText('User, Test')).toBeTruthy());
+    return result;
+  };
+
+  it("shows the requested bucket's name, matched by id, when one is present", async () => {
+    // key intentionally does not match any of this run's actual bucket keys, to confirm this is
+    // matched by id, not any key-based coincidence.
+    const { container } = await renderQueue({ id: '2' });
+
+    expect(container.textContent).toContain('GM');
+  });
+
+  it('shows no preference when there is no requested bucket', async () => {
+    const { getByText } = await renderQueue(null);
+
+    expect(getByText(/No preference/)).toBeTruthy();
+  });
+
+  it('shows no preference when the requested bucket id does not match any of the run’s buckets', async () => {
+    const { getByText } = await renderQueue({ id: 'removed-bucket' });
+
+    expect(getByText(/No preference/)).toBeTruthy();
+  });
+});

--- a/test/javascript/Tables/BucketChangeCell.test.tsx
+++ b/test/javascript/Tables/BucketChangeCell.test.tsx
@@ -1,0 +1,98 @@
+import { CellContext } from '@tanstack/react-table';
+
+import { render } from '../testUtils';
+import BucketChangeCell, { BucketChangeType } from '../../../app/javascript/Tables/BucketChangeCell';
+import { SignupChangeType } from '../../../app/javascript/EventsApp/SignupAdmin/RunSignupChangesTable';
+import { EventForFormatBucket } from '../../../app/javascript/EventsApp/SignupAdmin/SignupUtils';
+import { SignupChangeAction, SignupState } from '../../../app/javascript/graphqlTypes.generated';
+
+describe('BucketChangeCell', () => {
+  const event: EventForFormatBucket = {
+    event_category: { team_member_name: 'GM' },
+    registration_policy: {
+      buckets: [
+        { id: '1', name: 'Player' },
+        { id: '2', name: 'GM' },
+      ],
+    },
+    team_members: [],
+  };
+
+  const buildSignupChange = (overrides: Partial<SignupChangeType> = {}): SignupChangeType => ({
+    __typename: 'SignupChange',
+    id: '1',
+    state: SignupState.Confirmed,
+    counted: true,
+    action: SignupChangeAction.SelfServiceSignup,
+    created_at: '2025-01-01T00:00:00Z',
+    bucket: { __typename: 'RegistrationPolicyBucket', id: '1' },
+    previous_signup_change: null,
+    signup: { __typename: 'Signup', id: '1', requested_bucket: { __typename: 'RegistrationPolicyBucket', id: '1' } },
+    user_con_profile: {
+      __typename: 'UserConProfile',
+      id: '1',
+      name_inverted: 'User, Test',
+      gravatar_enabled: false,
+      gravatar_url: '',
+    },
+    ...overrides,
+  });
+
+  // BucketChangeCell only reads getValue() out of the full CellContext it's normally given by
+  // react-table -- this builds just enough of a fake context to exercise it directly.
+  const renderCell = async (value: BucketChangeType) => {
+    const cellContext = { getValue: () => value } as unknown as CellContext<unknown, BucketChangeType>;
+    return render(<BucketChangeCell {...cellContext} />);
+  };
+
+  it('shows just the new bucket name when there is no previous change', async () => {
+    const value: BucketChangeType = { signupChange: buildSignupChange(), event };
+    const { getByText, queryByText } = await renderCell(value);
+
+    expect(getByText('Player')).toBeTruthy();
+    expect(queryByText('GM')).toBeFalsy();
+  });
+
+  it('shows the old bucket struck through when the bucket changed, matching old and new by id', async () => {
+    const value: BucketChangeType = {
+      signupChange: buildSignupChange({
+        bucket: { __typename: 'RegistrationPolicyBucket', id: '2' },
+        signup: { __typename: 'Signup', id: '1', requested_bucket: null },
+        previous_signup_change: {
+          __typename: 'SignupChange',
+          id: '0',
+          state: SignupState.Confirmed,
+          counted: true,
+          bucket: { __typename: 'RegistrationPolicyBucket', id: '1' },
+        },
+      }),
+      event,
+    };
+    const { container, getByText } = await renderCell(value);
+
+    // The old bucket (id 1, "Player") is struck through; the new one (id 2, "GM") is shown plainly
+    // -- matched by id even though the two buckets share no key/name relationship in this fixture.
+    expect(getByText('Player (no preference)').closest('s')).toBeTruthy();
+    expect(container.textContent).toContain('GM (no preference)');
+  });
+
+  it('does not show a struck-through old bucket when the bucket did not actually change', async () => {
+    const value: BucketChangeType = {
+      signupChange: buildSignupChange({
+        bucket: { __typename: 'RegistrationPolicyBucket', id: '1' },
+        previous_signup_change: {
+          __typename: 'SignupChange',
+          id: '0',
+          state: SignupState.Confirmed,
+          counted: true,
+          bucket: { __typename: 'RegistrationPolicyBucket', id: '1' },
+        },
+      }),
+      event,
+    };
+    const { getByText, container } = await renderCell(value);
+
+    expect(getByText('Player')).toBeTruthy();
+    expect(container.querySelector('s')).toBeFalsy();
+  });
+});

--- a/test/javascript/testUtils.tsx
+++ b/test/javascript/testUtils.tsx
@@ -1,7 +1,9 @@
 import { Suspense, useMemo, useState } from 'react';
+import { ApolloClient, InMemoryCache } from '@apollo/client';
 import { MockedProvider, MockedProviderProps } from '@apollo/client/testing/react';
+import { MockLink } from '@apollo/client/testing';
 import { render, queries, Queries, RenderOptions, RenderResult, waitFor } from '@testing-library/react';
-import { createMemoryRouter, RouterProvider } from 'react-router';
+import { createMemoryRouter, createRoutesStub, RouterContextProvider, RouterProvider } from 'react-router';
 import { i18n } from 'i18next';
 import { I18nextProvider } from 'react-i18next';
 import type { Stripe } from '@stripe/stripe-js';
@@ -11,6 +13,7 @@ import type { ApolloCache } from '@apollo/client';
 import getI18n from '../../app/javascript/setupI18Next';
 import { LazyStripeContext } from '../../app/javascript/LazyStripe';
 import AppRootContext, { appRootContextDefaultValue, AppRootContextValue } from '../../app/javascript/AppRootContext';
+import { apolloClientContext } from '../../app/javascript/AppContexts';
 
 export type TestWrapperProps = {
   apolloMocks?: MockedProviderProps['mocks'];
@@ -125,6 +128,61 @@ async function customRender<Q extends Queries = Queries>(
   await waitFor(() => expect(result.queryAllByTestId('test-wrapper-suspense-fallback')).toHaveLength(0));
 
   return result;
+}
+
+export type RenderRouteOptions = {
+  apolloMocks?: MockLink.MockedResponse[];
+  initialEntries?: string[];
+  initialIndex?: number;
+  appRootContextValue?: Partial<AppRootContextValue>;
+};
+
+type RouteStubArray = Parameters<typeof createRoutesStub>[0];
+
+// Fills in a no-op HydrateFallback on every route that doesn't already have one, recursively --
+// otherwise react-router logs a "No HydrateFallback element provided" warning while a route's
+// loader is still resolving, which is expected and harmless in every one of these tests (they all
+// await the real content afterward).
+function withDefaultHydrateFallback(routes: RouteStubArray): RouteStubArray {
+  return routes.map((route) => ({
+    HydrateFallback: () => null,
+    ...route,
+    children: route.children ? withDefaultHydrateFallback(route.children) : route.children,
+  })) as RouteStubArray;
+}
+
+// For components that get their data via a React Router loader/action (context.get(apolloClientContext)
+// inside a LoaderFunction/ActionFunction) rather than an Apollo hook -- MockedProvider only intercepts
+// hooks that go through React's ApolloProvider context, so a loader-side client.query() call needs its
+// own real ApolloClient wired to a MockLink instead. Mirrors how the real app wires up its router
+// context (see packs/application.tsx's getContext), and matches its v8_middleware future flag so
+// context.get/set behaves the same way in tests as it does in production.
+export async function renderRoute(
+  routes: RouteStubArray,
+  options: RenderRouteOptions = {},
+): Promise<RenderResult<typeof queries & CustomQueries>> {
+  const { apolloMocks = [], initialEntries, initialIndex, appRootContextValue } = options;
+
+  const client = new ApolloClient({ link: new MockLink(apolloMocks), cache: new InMemoryCache() });
+  const context = new RouterContextProvider();
+  context.set(apolloClientContext, client);
+
+  const RoutesStub = createRoutesStub(withDefaultHydrateFallback(routes), context);
+  const i18nInstance = await getI18n();
+  const effectiveAppRootContextValue = { ...appRootContextDefaultValue, ...appRootContextValue };
+
+  const result = render(
+    <AppRootContext.Provider value={effectiveAppRootContextValue}>
+      <Confirm>
+        <I18nextProvider i18n={i18nInstance}>
+          <RoutesStub initialEntries={initialEntries} initialIndex={initialIndex} future={{ v8_middleware: true }} />
+        </I18nextProvider>
+      </Confirm>
+    </AppRootContext.Provider>,
+    { queries: { ...queries, ...customQueries } },
+  );
+
+  return result as RenderResult<typeof queries & CustomQueries>;
 }
 
 // re-export everything

--- a/test/javascript/testUtils.tsx
+++ b/test/javascript/testUtils.tsx
@@ -163,6 +163,11 @@ function withDefaultHydrateFallback(routes: RouteStubArray): RouteStubArray {
 // own real ApolloClient wired to a MockLink instead. Mirrors how the real app wires up its router
 // context (see packs/application.tsx's getContext), and matches its v8_middleware future flag so
 // context.get/set behaves the same way in tests as it does in production.
+//
+// Some routed components ALSO call Apollo hooks directly (e.g. a table driven by useQuery, on top
+// of a parent route's loader) -- those go through React's ApolloProvider context instead, so this
+// also wraps the tree in MockedProvider using the same apolloMocks. A query reachable only via a
+// loader is never touched by MockedProvider's link, and vice versa, so one list safely covers both.
 export async function renderRoute(
   routes: RouteStubArray,
   options: RenderRouteOptions = {},
@@ -177,15 +182,23 @@ export async function renderRoute(
   const i18nInstance = await getI18n();
   const effectiveAppRootContextValue = { ...appRootContextDefaultValue, ...appRootContextValue };
 
-  const result = render(
-    <AppRootContext.Provider value={effectiveAppRootContextValue}>
-      <Confirm>
-        <I18nextProvider i18n={i18nInstance}>
-          <RoutesStub initialEntries={initialEntries} initialIndex={initialIndex} future={{ v8_middleware: true }} />
-        </I18nextProvider>
-      </Confirm>
-    </AppRootContext.Provider>,
-    { queries: { ...queries, ...customQueries } },
+  const result = await act(() =>
+    render(
+      <AppRootContext.Provider value={effectiveAppRootContextValue}>
+        <MockedProvider mocks={apolloMocks}>
+          <Confirm>
+            <I18nextProvider i18n={i18nInstance}>
+              <RoutesStub
+                initialEntries={initialEntries}
+                initialIndex={initialIndex}
+                future={{ v8_middleware: true }}
+              />
+            </I18nextProvider>
+          </Confirm>
+        </MockedProvider>
+      </AppRootContext.Provider>,
+      { queries: { ...queries, ...customQueries } },
+    ),
   );
 
   return result as RenderResult<typeof queries & CustomQueries>;

--- a/test/javascript/testUtils.tsx
+++ b/test/javascript/testUtils.tsx
@@ -2,7 +2,7 @@ import { Suspense, useMemo, useState } from 'react';
 import { ApolloClient, InMemoryCache } from '@apollo/client';
 import { MockedProvider, MockedProviderProps } from '@apollo/client/testing/react';
 import { MockLink } from '@apollo/client/testing';
-import { render, queries, Queries, RenderOptions, RenderResult, waitFor } from '@testing-library/react';
+import { act, render, queries, Queries, RenderOptions, RenderResult, waitFor } from '@testing-library/react';
 import { createMemoryRouter, createRoutesStub, RouterContextProvider, RouterProvider } from 'react-router';
 import { i18n } from 'i18next';
 import { I18nextProvider } from 'react-i18next';
@@ -111,20 +111,26 @@ async function customRender<Q extends Queries = Queries>(
     ...providedQueries,
   } as typeof queries & Q & CustomQueries;
   const i18nInstance = await getI18n();
-  const result = render(ui, {
-    wrapper: (wrapperProps) => (
-      <TestWrapper
-        apolloMocks={apolloMocks}
-        apolloCache={apolloCache}
-        stripePublishableKey={stripePublishableKey}
-        i18nInstance={i18nInstance}
-        appRootContextValue={appRootContextValue}
-        {...wrapperProps}
-      />
-    ),
-    queries: combinedQueries,
-    ...otherOptions,
-  });
+  // useSuspenseQuery suspends immediately (unlike useQuery, which stays mounted in a loading
+  // state), so React needs the initial render wrapped in its own act() to actually process and
+  // resolve the suspended promise -- without this, a component using it never progresses past the
+  // Suspense fallback in tests, per Apollo's own testing docs.
+  const result = await act(() =>
+    render(ui, {
+      wrapper: (wrapperProps) => (
+        <TestWrapper
+          apolloMocks={apolloMocks}
+          apolloCache={apolloCache}
+          stripePublishableKey={stripePublishableKey}
+          i18nInstance={i18nInstance}
+          appRootContextValue={appRootContextValue}
+          {...wrapperProps}
+        />
+      ),
+      queries: combinedQueries,
+      ...otherOptions,
+    }),
+  );
   await waitFor(() => expect(result.queryAllByTestId('test-wrapper-suspense-fallback')).toHaveLength(0));
 
   return result;

--- a/test/services/event_change_registration_policy_service_test.rb
+++ b/test/services/event_change_registration_policy_service_test.rb
@@ -65,6 +65,41 @@ class EventChangeRegistrationPolicyServiceTest < ActiveSupport::TestCase
     end
   end
 
+  describe "when a bucket's key changes while it has an existing signup" do
+    let(:event) do
+      create(
+        :event,
+        convention: convention,
+        registration_policy:
+          RegistrationPolicy.build_from_hash(
+            buckets: [{ key: "dogs", name: "Dogs", slots_limited: true, total_slots: 1 }]
+          )
+      )
+    end
+    let(:dogs_bucket_id) { event.registration_policy.buckets.find_by!(key: "dogs").id }
+    let(:new_registration_policy) do
+      RegistrationPolicy.build_from_hash(
+        buckets: [{ id: dogs_bucket_id, key: "hounds", name: "Hounds", slots_limited: true, total_slots: 1 }]
+      )
+    end
+
+    before { create(:signup, run: the_run, bucket_id: dogs_bucket_id, state: "confirmed") }
+
+    it "keeps the existing signup in the renamed bucket, rather than treating it as removed" do
+      signup = the_run.signups.sole
+      result = subject.call
+      assert result.success?
+
+      event.reload
+      renamed_bucket = event.registration_policy.buckets.find_by!(key: "hounds")
+      assert_equal dogs_bucket_id, renamed_bucket.id
+
+      signup.reload
+      assert_equal renamed_bucket.id, signup.bucket_id
+      assert_equal "confirmed", signup.state
+    end
+  end
+
   it "does not email the team members if nobody moved" do
     perform_enqueued_jobs do
       subject.call!


### PR DESCRIPTION
## Context

While preparing to gain confidence in the #11892/#11895/#11896/#11897/#11899/#11904 registration-policy-bucket key→id migration before its production deploy, I audited the full `v7.8.6..main` diff (the whole undeployed epic) against existing test coverage and did targeted manual tracing of the riskiest code paths.

## What this found and fixes

1. **Correctness bug**: `EventChangeRegistrationPolicyService#removed_buckets` matched buckets by `key` while the rest of that class (and `RegistrationPolicy#sync_buckets_from_hash!` itself) matches by `id`. Renaming a bucket's key while it has existing signups was treated as remove-and-recreate: `clear_references_to_removed_buckets` nulled those signups' `bucket_id`/`requested_bucket_id`, and `apply_changes_for_signup`'s "already correct" check compared against a stale pre-clear in-memory value, so the correct value never got written back. The mutation reported success while silently orphaning the signup. Fixed to match by `id`.
2. **Broken view**: `app/views/reports/_per_event_single.html.erb` called three methods removed/renamed by this migration (`RegistrationPolicy#bucket_with_key`, `Signup#requested_bucket_key`, `Run#available_slots_by_bucket_key`). The last call is unconditional, so the Per-Event and Single-Attendee printable reports raised `NoMethodError` for any event, not just an edge case.
3. **Display bug**: `SignupModerationQueue`'s `describeRequestedBucket` rendered blank instead of falling back to "no preference" when a signup request's `requested_bucket` id no longer resolved to any of the run's current buckets.
4. **Testing-infra gap**: this codebase had never exercised `useSuspenseQuery` through the shared `render()` test helper. Unlike `useQuery`, it suspends immediately rather than staying mounted in a loading state, so without wrapping the initial render in `act()`, a component using it never progresses past the Suspense fallback in tests. Fixed in the shared helper (`test/javascript/testUtils.tsx`) so every current and future test benefits.

## Test coverage added

- End-to-end test for renaming a bucket's key while it has an existing signup (the scenario bug #1 lived in).
- Mutation-level test for `UpdateEvent`'s `bucket_key_mappings` (`from_bucket_id`/`to_key` resolution).
- New test file for `useBucketKeyRemapping`, previously uncovered despite being the only place that derives a removed bucket's real id and reconciles it against key-based removal detection.
- `RegistrationPolicyEditor` now asserts a freshly-added bucket has no fabricated id, and that an edited bucket's id survives intact.
- New `ReportsControllerTest` covering the two report actions that were crashing.
- Coverage for the id-based bucket-matching logic shared across signup admin/display: `SignupUtils.ts`, `AvailabilityUtils.tsx`, `BucketInput.tsx`, `BucketChangeCell.tsx`.
- A new `renderRoute` test helper (built on `createRoutesStub`, react-router's own recommended pattern for loader-based routes), extended to also support components that mix a router loader with a plain `useQuery` hook (via `MockedProvider`, reusing the same mocks).
- Full coverage for every remaining previously-untested component in the signup-admin/moderation cluster: `RunSignupSummary`, `RunEmailList`, `EditSignup`, `ChangeBucketModal`, `CreateSignupRunCard`, `UserSignupQueueItem`, `RunSignupsTable`, and `SignupModerationQueue` — the last two required composing `renderRoute` with `MockedProvider` for `useReactTableWithTheWorks`, which turned out to need no new primitives beyond what the rest of this PR had already built.

This closes every coverage gap identified in the original audit for this cluster of components (popover-driven filter interaction via `ChoiceSetFilter` is the one piece intentionally left for a later, separate pass — the default unsorted/unfiltered render is what's covered here).

## Test plan

- [x] `bin/rails test test/controllers/reports_controller_test.rb test/services/event_change_registration_policy_service_test.rb test/graphql/mutations/update_event_test.rb` — all pass
- [x] Broader regression sweep: `bin/rails test test/services/event_signup_service_test.rb test/services/event_vacancy_fill_service_test.rb test/services/event_withdraw_service_test.rb test/services/execute_ranked_choice_signup_service_test.rb test/services/accept_event_proposal_service_test.rb test/models/registration_policy_test.rb test/models/registration_policy_bucket_test.rb test/graphql/mutations/update_event_proposal_test.rb test/graphql/mutations/create_event_proposal_test.rb` — all pass, no regressions from the `removed_buckets` fix
- [x] `yarn vitest run` (full suite) — 244 passed, 1 pre-existing skip
- [x] `yarn run tsc --noEmit` — clean
- [x] `yarn eslint` on changed/new files — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
