### PR TITLE
Rename intercode_aws_resources' recaptcha variable to turnstile

### DIFF
--- a/terraform/modules/intercode_aws_resources/ssm.tf
+++ b/terraform/modules/intercode_aws_resources/ssm.tf
@@ -37,9 +37,9 @@ locals {
       STRIPE_PUBLISHABLE_KEY         = var.stripe.publishable_key
       STRIPE_CONNECT_ENDPOINT_SECRET = var.stripe.connect_endpoint_secret
     } : {},
-    var.recaptcha != null ? {
-      RECAPTCHA_SECRET_KEY = var.recaptcha.secret_key
-      RECAPTCHA_SITE_KEY   = var.recaptcha.site_key
+    var.turnstile != null ? {
+      TURNSTILE_SECRET_KEY = var.turnstile.secret_key
+      TURNSTILE_SITE_KEY   = var.turnstile.site_key
     } : {},
     var.twilio != null ? {
       TWILIO_ACCOUNT_SID = var.twilio.account_sid
@@ -76,9 +76,9 @@ locals {
       STRIPE_PUBLISHABLE_KEY         = "SecureString"
       STRIPE_CONNECT_ENDPOINT_SECRET = "SecureString"
     } : {},
-    var.recaptcha != null ? {
-      RECAPTCHA_SECRET_KEY = "SecureString"
-      RECAPTCHA_SITE_KEY   = "SecureString"
+    var.turnstile != null ? {
+      TURNSTILE_SECRET_KEY = "SecureString"
+      TURNSTILE_SITE_KEY   = "SecureString"
     } : {},
     var.twilio != null ? {
       TWILIO_ACCOUNT_SID = "SecureString"
@@ -183,14 +183,6 @@ moved {
 moved {
   from = aws_ssm_parameter.stripe_connect_endpoint_secret[0]
   to   = aws_ssm_parameter.params["STRIPE_CONNECT_ENDPOINT_SECRET"]
-}
-moved {
-  from = aws_ssm_parameter.recaptcha_secret_key[0]
-  to   = aws_ssm_parameter.params["RECAPTCHA_SECRET_KEY"]
-}
-moved {
-  from = aws_ssm_parameter.recaptcha_site_key[0]
-  to   = aws_ssm_parameter.params["RECAPTCHA_SITE_KEY"]
 }
 moved {
   from = aws_ssm_parameter.twilio_account_sid[0]

--- a/terraform/modules/intercode_aws_resources/variables.tf
+++ b/terraform/modules/intercode_aws_resources/variables.tf
@@ -66,8 +66,8 @@ variable "stripe" {
   default   = null
 }
 
-variable "recaptcha" {
-  description = "Google reCAPTCHA credentials. If null, no reCAPTCHA SSM parameters are written."
+variable "turnstile" {
+  description = "Cloudflare Turnstile credentials. If null, no Turnstile SSM parameters are written."
   type = object({
     secret_key = string
     site_key   = string


### PR DESCRIPTION
## Summary

Follow-up to #11953 (already merged), which migrated the app itself from reCAPTCHA to Cloudflare Turnstile but didn't touch this Terraform module. Renames `terraform/modules/intercode_aws_resources`' `recaptcha` variable to `turnstile`, so it writes `TURNSTILE_SITE_KEY`/`TURNSTILE_SECRET_KEY` to SSM instead of the now-unused `RECAPTCHA_*` names.

Part of #11952.

## Dependency

[neil-terraform#19](https://github.com/neinteractiveliterature/neil-terraform/pull/19) provisions the actual `cloudflare_turnstile_widget` and feeds its `sitekey`/`secret` into this new `turnstile` variable — that PR needs this one merged to `main` first, since it pulls this module via `ref=main`.

## Test plan

- [x] `tofu validate` on the module in isolation — passes
- [x] Diff reviewed — only renames `recaptcha` → `turnstile` in `variables.tf` and the two `_ssm_values`/`_ssm_types` blocks in `ssm.tf`, plus drops the now-irrelevant `moved` blocks for the old individual `recaptcha_secret_key[0]`/`recaptcha_site_key[0]` resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)
