### PR TITLE
Fix FK violation destroying a run with a signup referenced as replace_signup elsewhere

### DIFF
--- a/app/models/signup.rb
+++ b/app/models/signup.rb
@@ -45,6 +45,11 @@ class Signup < ApplicationRecord
   has_one :event, through: :run
   has_one :convention, through: :event
   has_one :signup_request, foreign_key: "result_signup_id", dependent: :destroy
+  has_many :signup_requests_replacing_this_signup,
+           class_name: "SignupRequest",
+           foreign_key: "replace_signup_id",
+           dependent: :nullify,
+           inverse_of: :replace_signup
   has_one :signup_ranked_choice, foreign_key: "result_signup_id", dependent: :destroy
   belongs_to :updated_by, class_name: "User", optional: true
   belongs_to :bucket, class_name: "RegistrationPolicyBucket", optional: true

--- a/app/models/signup_request.rb
+++ b/app/models/signup_request.rb
@@ -39,7 +39,7 @@
 class SignupRequest < ApplicationRecord
   belongs_to :user_con_profile
   belongs_to :target_run, class_name: "Run"
-  belongs_to :replace_signup, class_name: "Signup", optional: true
+  belongs_to :replace_signup, class_name: "Signup", optional: true, inverse_of: :signup_requests_replacing_this_signup
   belongs_to :result_signup, class_name: "Signup", optional: true
   belongs_to :updated_by, class_name: "User", optional: true
   belongs_to :requested_bucket, class_name: "RegistrationPolicyBucket", optional: true

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -50,4 +50,18 @@ class RunTest < ActiveSupport::TestCase
       assert_operator queries, :<=, 2, "expected a constant number of bucket queries regardless of signup count"
     end
   end
+
+  describe "#destroy" do
+    let(:other_run) { create(:run, event:) }
+    let(:user_con_profile) { create(:user_con_profile, convention:) }
+    let(:signup) { create(:signup, run: the_run, user_con_profile:, bucket_id: dogs_bucket_id) }
+
+    it "nullifies replace_signup_id on pending signup requests targeting other runs, instead of failing" do
+      signup_request = create(:signup_request, target_run: other_run, user_con_profile:, replace_signup: signup)
+
+      the_run.destroy!
+
+      assert_nil signup_request.reload.replace_signup_id
+    end
+  end
 end


### PR DESCRIPTION
### Purpose

We had a Sentry issue (INTERCODE-19B) where deleting a run would blow up with `PG::ForeignKeyViolation` on `fk_rails_008590ab32`. Turned out `Signup` cleans up `signup_requests.result_signup_id` on destroy (`dependent: :destroy`) but never had an equivalent for `replace_signup_id`. `replace_signup` points at an attendee's *existing* signup that a pending request targeting a *different* run wants to replace — so `Run#destroy!` cascading into its signups could hit a signup that's still referenced by a pending request elsewhere, and Postgres would (correctly) refuse the delete.

Went with nullifying `replace_signup_id` rather than destroying the whole `SignupRequest` — if the signup being replaced is gone, the request to move into the target run is still perfectly valid, it just no longer has anything to replace.

### Changes

💻 Engineer-facing
- `Signup` gets a `has_many :signup_requests_replacing_this_signup, foreign_key: "replace_signup_id", dependent: :nullify`
- Matching `inverse_of:` on `SignupRequest#replace_signup`

### Testing

Added a regression test in `run_test.rb` that reproduces the exact FK violation without the fix (confirmed it fails on the old code) and passes with it. Also verified against a production DB copy — found the exact signup/run/request from the Sentry event, plus 115 other signup_requests in prod with this cross-run `replace_signup` shape, and confirmed `run.destroy!` now succeeds and nullifies correctly (in a rolled-back transaction, so no data was actually touched).

Fixes INTERCODE-19B

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASWZqodYah22tg28gW37Hp
